### PR TITLE
fix: storage facilities decommissioning phase

### DIFF
--- a/energetica/database/active_facility.py
+++ b/energetica/database/active_facility.py
@@ -20,7 +20,7 @@ class ActiveFacility(db.Model):
     facility = db.Column(db.String(50))
     pos_x = db.Column(db.Float)
     pos_y = db.Column(db.Float)
-    # time at witch the facility will be decommissioned
+    # tick at witch the facility will be decommissioned
     end_of_life = db.Column(db.Integer)
     # multiply the base values by the following values
     price_multiplier = db.Column(db.Float)
@@ -31,6 +31,11 @@ class ActiveFacility(db.Model):
     usage = db.Column(db.Float, default=0)
 
     player_id = db.Column(db.Integer, db.ForeignKey("player.id"))
+
+    @property
+    def decommissioning(self) -> bool:
+        """returns True if the facility is being decommissioned."""
+        return self.end_of_life <= current_app.config["engine"].data["total_t"]
 
     @property
     def const_config(self) -> dict:
@@ -115,10 +120,13 @@ class ActiveFacility(db.Model):
         return self.const_config["base_power_consumption"] * self.multiplier_1
 
     @property
-    def remaining_lifespan(self) -> int:
+    def remaining_lifespan(self) -> int | None:
         """Time left until the facility is decommissioned in ticks."""
         engine: GameEngine = current_app.config["engine"]
-        return self.end_of_life - engine.data["total_t"]
+        remaining_ticks = self.end_of_life - engine.data["total_t"]
+        if remaining_ticks < 0:
+            return None
+        return remaining_ticks
 
     @property
     def is_upgradable(self) -> bool:

--- a/energetica/database/engine_data.py
+++ b/energetica/database/engine_data.py
@@ -85,7 +85,8 @@ class CapacityData:
                     + (base_data["base_efficiency"] * facility.multiplier_3 * power_gen)
                 ) / (effective_values["power"] + power_gen)
                 effective_values["power"] += power_gen
-                effective_values["capacity"] += facility.storage_capacity
+                if facility.end_of_life > 0:
+                    effective_values["capacity"] += facility.storage_capacity
             elif facility.facility in engine.extraction_facilities:
                 effective_values["extraction_rate_per_day"] += (
                     base_data["base_extraction_rate_per_day"] * facility.multiplier_2

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -775,11 +775,15 @@ class Player(db.Model, UserMixin):
                     "hourly_op_cost": sum(f.hourly_op_cost for f in group) * ticks_per_hour,
                     "efficiency": sum(f.efficiency * f.storage_capacity for f in group)
                     / sum(f.storage_capacity for f in group),
-                    "remaining_lifespan": min(f.remaining_lifespan for f in group),
+                    "remaining_lifespan": None
+                    if all(f.decommissioning for f in group)
+                    else min(f.remaining_lifespan for f in group if not f.decommissioning),
                     "upgrade_cost": sum(f.upgrade_cost for f in group if f.is_upgradable)
                     if any(f.is_upgradable for f in group)
                     else None,
-                    "dismantle_cost": sum(f.dismantle_cost for f in group),
+                    "dismantle_cost": None
+                    if all(f.decommissioning for f in group)
+                    else sum(f.dismantle_cost for f in group if not f.decommissioning),
                 }
                 for group_name, group in storage_facility_groups.items()
             },
@@ -792,8 +796,8 @@ class Player(db.Model, UserMixin):
                     "hourly_op_cost": storage_facility.hourly_op_cost,
                     "efficiency": storage_facility.efficiency,
                     "remaining_lifespan": storage_facility.remaining_lifespan,
-                    "upgrade_cost": storage_facility.upgrade_cost,
-                    "dismantle_cost": storage_facility.dismantle_cost,
+                    "upgrade_cost": None if storage_facility.decommissioning else storage_facility.upgrade_cost,
+                    "dismantle_cost": None if storage_facility.decommissioning else storage_facility.dismantle_cost,
                 }
                 for storage_facility in storage_facilities
             },

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -113,8 +113,12 @@ def set_facilities_usage(engine, new_values, player):
             )
     for facility in engine.storage_facilities:
         if player.data.capacities.contains(facility):
+            if player.data.capacities[facility]["capacity"] == 0:
+                usage = 1.0
+            else:
+                usage = new_values["storage"][facility] / player.data.capacities[facility]["capacity"]
             ActiveFacility.query.filter_by(player_id=player.id, facility=facility).update(
-                {ActiveFacility.usage: new_values["storage"][facility] / player.data.capacities[facility]["capacity"]},
+                {ActiveFacility.usage: usage},
                 synchronize_session=False,
             )
     for facility in engine.extraction_facilities:

--- a/energetica/static/profile.js
+++ b/energetica/static/profile.js
@@ -47,6 +47,10 @@ function add_dismantle_button(cell_element, table_data, facility, id, dismantle_
         button_all.onclick = () => are_you_sure_dismantle_all_of_type(id, facility.display_name, dismantle_cost);
         cell_element.appendChild(button_all);
     } else {
+        if (dismantle_cost == null) {
+            cell_element.innerHTML = "Decommissioning...";
+            return;
+        }
         const button_single = document.createElement("button");
         button_single.classList.add("dismantle_button");
         button_single.innerHTML = format_money(dismantle_cost);

--- a/energetica/utils/assets.py
+++ b/energetica/utils/assets.py
@@ -211,6 +211,9 @@ def upgrade_facility(player: Player, facility: ActiveFacility) -> None:
     if player.money < upgrade_cost:
         msg = "Not enough money"
         raise GameError(msg)
+    if facility.decommissioning:
+        msg = "FacilityIsDecommissioning"
+        raise GameError(msg)
     player.money -= upgrade_cost
     engine: GameEngine = current_app.config["engine"]
     if facility.facility in engine.extraction_facilities:
@@ -250,6 +253,12 @@ def remove_asset(player: Player, facility: ActiveFacility, *, decommissioning: b
     if facility.facility in engine.technologies + engine.functional_facilities:
         msg = "Cannot remove technologies or functional facilities"
         raise GameError(msg)
+    if facility.facility in engine.storage_facilities and not decommissioning:
+        facility.end_of_life = 0
+        db.session.flush()
+        player.data.capacities.update(player, facility.facility)
+        db.session.commit()
+        return
     db.session.delete(facility)
     db.session.flush()
     # The cost of decommissioning is 20% of the building cost.

--- a/energetica/utils/tick_execution.py
+++ b/energetica/utils/tick_execution.py
@@ -86,6 +86,13 @@ def check_events_completion(engine):
     ).all()
     for facility in eolt_facilities:
         player = db.session.get(Player, facility.player_id)
+        if facility.facility in engine.storage_facilities:
+            if facility.end_of_life == engine.data["total_t"]:
+                player.data.capacities.update(player, facility.facility)
+            stored_energy = player.data.rolling_history.get_last_data("storage", facility.facility)
+            available_capacity = player.data.capacities[facility.facility]["capacity"]
+            if stored_energy > available_capacity:
+                continue
         remove_asset(player, facility)
 
     # check end of climate events


### PR DESCRIPTION
When a storage facility is dismantled by the player, destroyed by a natural event or decommissioned due to end of life, if the stored energy cannot be stored in the remaining storage plants of the same type, it enters a decommissioning phase. During the decommissioning phase, the stored energy can only decrease and when it reaches a low enough level to allow removal of the storage plant, it is removed. 