### PR TITLE
StrEnum

### DIFF
--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -43,6 +43,7 @@ from energetica.auth import auth
 from energetica.database.map import HexTile
 from energetica.database.messages import Chat
 from energetica.database.player import Player
+from energetica.enums import Fuel, Renewable
 from energetica.init_test_players import init_test_players
 from energetica.simulate import simulate
 from energetica.utils.climate_helpers import data_init_climate
@@ -254,10 +255,10 @@ def create_app(
             csv_reader = csv.DictReader(file)
             for row in csv_reader:
                 tile = HexTile(coordinates=(int(row["q"]), int(row["r"])), climate_risk=int(row["climate_risk"]))
-                for renewable in ["solar", "wind", "hydro"]:
-                    tile.renewable_potential[renewable] = float(row[renewable])
-                for resource in ["coal", "gas", "uranium"]:
-                    tile.fuel_reserves[resource] = float(row[resource])
+                for renewable in Renewable:
+                    tile.potentials[renewable] = float(row[renewable])
+                for fuel in Fuel:
+                    tile.reserves[fuel] = float(row[fuel])
 
     # creating general chat
     if Chat.count() == 0:

--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -258,7 +258,7 @@ def create_app(
                 for renewable in Renewable:
                     tile.potentials[renewable] = float(row[renewable])
                 for fuel in Fuel:
-                    tile.reserves[fuel] = float(row[fuel])
+                    tile.fuel_reserves[fuel] = float(row[fuel])
 
     # creating general chat
     if Chat.count() == 0:

--- a/energetica/api/http.py
+++ b/energetica/api/http.py
@@ -25,6 +25,7 @@ from energetica.database.network import Network
 from energetica.database.ongoing_project import OngoingProject
 from energetica.database.player import Player
 from energetica.database.resource_on_sale import ResourceOnSale
+from energetica.enums import Fuel, Renewable
 from energetica.game_engine import Confirm
 from energetica.game_error import GameError
 from energetica.globals import engine
@@ -125,12 +126,12 @@ def get_map() -> Response:
             "id": tile.id,
             "q": tile.coordinates[0],
             "r": tile.coordinates[1],
-            "solar": tile.renewable_potential["solar"],
-            "wind": tile.renewable_potential["wind"],
-            "hydro": tile.renewable_potential["hydro"],
-            "coal": tile.fuel_reserves["coal"],
-            "gas": tile.fuel_reserves["gas"],
-            "uranium": tile.fuel_reserves["uranium"],
+            "solar": tile.potentials[Renewable.SOLAR],
+            "wind": tile.potentials[Renewable.WIND],
+            "hydro": tile.potentials[Renewable.HYDRO],
+            "coal": tile.reserves[Fuel.COAL],
+            "gas": tile.reserves[Fuel.GAS],
+            "uranium": tile.reserves[Fuel.URANIUM],
             "climate_risk": tile.climate_risk,
             "player_id": tile.player.id if tile.player else None,
         }
@@ -283,6 +284,7 @@ def get_player_data() -> Response | tuple:
 @http.route("/get_resource_reserves", methods=["GET"])
 def get_resource_reserves() -> Response:
     """Get the natural resources reserves for this player."""
+    # TODO(mglst): there is no `get_reserves` method in the `Player` class
     reserves = current_user.get_reserves()
     return jsonify(reserves)
 

--- a/energetica/api/http.py
+++ b/energetica/api/http.py
@@ -129,9 +129,9 @@ def get_map() -> Response:
             "solar": tile.potentials[Renewable.SOLAR],
             "wind": tile.potentials[Renewable.WIND],
             "hydro": tile.potentials[Renewable.HYDRO],
-            "coal": tile.reserves[Fuel.COAL],
-            "gas": tile.reserves[Fuel.GAS],
-            "uranium": tile.reserves[Fuel.URANIUM],
+            "coal": tile.fuel_reserves[Fuel.COAL],
+            "gas": tile.fuel_reserves[Fuel.GAS],
+            "uranium": tile.fuel_reserves[Fuel.URANIUM],
             "climate_risk": tile.climate_risk,
             "player_id": tile.player.id if tile.player else None,
         }

--- a/energetica/config/assets.py
+++ b/energetica/config/assets.py
@@ -5,18 +5,12 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from enum import StrEnum
 from typing import TYPE_CHECKING
+
+from energetica.enums import Fuel
 
 if TYPE_CHECKING:
     from energetica.database.player import Player
-
-
-class WorkerType(StrEnum):
-    """Enum for the worker type."""
-
-    CONSTRUCTION = "Construction"
-    RESEARCH = "Research"
 
 
 const_config: dict = {

--- a/energetica/database/active_facility.py
+++ b/energetica/database/active_facility.py
@@ -79,7 +79,7 @@ class ActiveFacility(DBModel):
         return (
             self.const_config["base_extraction_rate_per_day"]
             * self.multipliers["multiplier_2"]
-            * self.player.tile.reserves[fuels_by_extraction_facility[self.name]]
+            * self.player.tile.fuel_reserves[fuels_by_extraction_facility[self.name]]
             / 24
         )
 

--- a/energetica/database/active_facility.py
+++ b/energetica/database/active_facility.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from energetica import technology_effects
 from energetica.config.assets import const_config
 from energetica.database import DBModel
+from energetica.enums import fuels_by_extraction_facility
 from energetica.globals import engine
 
 if TYPE_CHECKING:
@@ -74,15 +75,11 @@ class ActiveFacility(DBModel):
     @property
     def extraction_rate(self) -> float:
         """Rate at which the facility extracts resources from the ground. Defined only for extraction facilities."""
-        extraction_to_resource = {
-            "coal_mine": "coal",
-            "gas_drilling_site": "gas",
-            "uranium_mine": "uranium",
-        }
+        assert self.player.tile is not None
         return (
             self.const_config["base_extraction_rate_per_day"]
             * self.multipliers["multiplier_2"]
-            * self.player.tile.fuel_reserves[extraction_to_resource[self.name]]
+            * self.player.tile.reserves[fuels_by_extraction_facility[self.name]]
             / 24
         )
 

--- a/energetica/database/map.py
+++ b/energetica/database/map.py
@@ -21,7 +21,7 @@ class HexTile(DBModel):
 
     climate_risk: int
 
-    reserves: dict[Fuel, float] = field(default_factory=lambda: {fuel: 0 for fuel in Fuel})
+    fuel_reserves: dict[Fuel, float] = field(default_factory=lambda: {fuel: 0 for fuel in Fuel})
     potentials: dict[Renewable, float] = field(default_factory=lambda: {renewable: 0 for renewable in Renewable})
 
     player: Player | None = None

--- a/energetica/database/map.py
+++ b/energetica/database/map.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from energetica.database import DBModel
+from energetica.enums import Fuel, Renewable
 
 if TYPE_CHECKING:
     from energetica.database.player import Player
@@ -20,8 +21,8 @@ class HexTile(DBModel):
 
     climate_risk: int
 
-    fuel_reserves: dict[str, float] = field(default_factory=lambda: {"coal": 0, "gas": 0, "uranium": 0})
-    renewable_potential: dict[str, float] = field(default_factory=lambda: {"solar": 0, "wind": 0, "hydro": 0})
+    reserves: dict[Fuel, float] = field(default_factory=lambda: {fuel: 0 for fuel in Fuel})
+    potentials: dict[Renewable, float] = field(default_factory=lambda: {renewable: 0 for renewable in Renewable})
 
     player: Player | None = None
 
@@ -42,7 +43,7 @@ class HexTile(DBModel):
             )
             return results
 
-        neighbors = []
+        neighbors: list[HexTile] = []
         tiles_at_distance = get_hex_at_distance(*self.coordinates, n)
         for q, r in tiles_at_distance:
             neighbor = next(HexTile.filter_by(coordinates=(q, r)), None)
@@ -52,7 +53,7 @@ class HexTile(DBModel):
 
     def get_downstream_tiles(self, n: int) -> list[HexTile]:
         """Return up to `n` many tiles that are downstream (related to hydro) from the current tile."""
-        downstream_tiles = []
+        downstream_tiles: list[HexTile] = []
 
         def find_downstream(tile: HexTile, n: int) -> None:
             if n == 0:
@@ -60,7 +61,7 @@ class HexTile(DBModel):
             for neighbor in tile.get_neighbors():
                 if (
                     neighbor not in downstream_tiles
-                    and neighbor.renewable_potential["hydro"] > tile.renewable_potential["hydro"]
+                    and neighbor.potentials[Renewable.HYDRO] > tile.potentials[Renewable.HYDRO]
                 ):
                     downstream_tiles.append(neighbor)
                     find_downstream(neighbor, n - 1)

--- a/energetica/database/ongoing_project.py
+++ b/energetica/database/ongoing_project.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from energetica.config.assets import WorkerType
 from energetica.database import DBModel
+from energetica.enums import WorkerType
 from energetica.globals import engine
 
 if TYPE_CHECKING:

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -144,7 +144,7 @@ class Player(DBModel, UserMixin):
 
     # resources :
     money: float = 25000
-    reserves: dict[Fuel, float] = field(default_factory=lambda: {fuel: 0 for fuel in Fuel})
+    resources: dict[Fuel, float] = field(default_factory=lambda: {fuel: 0 for fuel in Fuel})
     resources_on_sale: dict[str, float] = field(
         default_factory=lambda: {
             "coal": 0,

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -14,12 +14,12 @@ from flask_login import UserMixin
 from pywebpush import WebPushException, webpush
 
 from energetica.config.achievements import achievements
-from energetica.config.assets import WorkerType
 from energetica.database import DBModel
 from energetica.database.engine_data import CapacityData, CircularBufferPlayer, CumulativeEmissionsData, PlayerPrices
 from energetica.database.messages import Chat, Notification
 from energetica.database.ongoing_project import OngoingProject, ProjectStatus
 from energetica.database.shipment import OngoingShipment
+from energetica.enums import Fuel, WorkerType
 from energetica.game_error import GameError
 from energetica.globals import engine
 from energetica.technology_effects import (
@@ -144,13 +144,7 @@ class Player(DBModel, UserMixin):
 
     # resources :
     money: float = 25000
-    resources: dict[str, float] = field(
-        default_factory=lambda: {
-            "coal": 0,
-            "gas": 0,
-            "uranium": 0,
-        },
-    )
+    reserves: dict[Fuel, float] = field(default_factory=lambda: {fuel: 0 for fuel in Fuel})
     resources_on_sale: dict[str, float] = field(
         default_factory=lambda: {
             "coal": 0,

--- a/energetica/database/resource_on_sale.py
+++ b/energetica/database/resource_on_sale.py
@@ -1,19 +1,22 @@
 """Module that contains the ResourceOnSale class."""
 
-from dataclasses import dataclass
+from __future__ import annotations
 
-# from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
 from energetica.database import DBModel
 
-# if TYPE_CHECKING:
-from energetica.database.player import Player
+if TYPE_CHECKING:
+    from energetica.database.player import Player
+    from energetica.enums import Fuel
 
 
 @dataclass
 class ResourceOnSale(DBModel):
     """Class that stores resources currently on sale."""
 
-    resource: str
+    resource: Fuel
     quantity: float
     price: float
     player: Player

--- a/energetica/enums.py
+++ b/energetica/enums.py
@@ -1,0 +1,47 @@
+"""
+Enums for the game.
+
+Includes enums for worker types, fuel types, and renewable energy sources.
+Planned future enums include facility names
+"""
+
+from enum import StrEnum
+
+
+class WorkerType(StrEnum):
+    """Enum for the worker type."""
+
+    CONSTRUCTION = "Construction"
+    RESEARCH = "Research"
+
+
+class Fuel(StrEnum):
+    """Enum for fuel names."""
+
+    COAL = "coal"
+    GAS = "gas"
+    URANIUM = "uranium"
+
+    def associated_mine(self) -> str:
+        """Return the name of the mine associated with the fuel."""
+        return {
+            Fuel.COAL: "coal_mine",
+            Fuel.GAS: "gas_drilling_site",
+            Fuel.URANIUM: "uranium_mine",
+        }[self]
+
+
+class Renewable(StrEnum):
+    """Enum for renewable energy sources."""
+
+    SOLAR = "solar"
+    WIND = "wind"
+    HYDRO = "hydro"
+
+
+# TODO(mglst): make this a method of the (upcoming) ExtractionFacility class
+fuels_by_extraction_facility = {
+    "coal_mine": Fuel.COAL,
+    "gas_drilling_site": Fuel.GAS,
+    "uranium_mine": Fuel.URANIUM,
+}

--- a/energetica/init_test_players.py
+++ b/energetica/init_test_players.py
@@ -69,7 +69,7 @@ def init_test_players():
                 HexTile.get(i).player = player
 
                 player.money = 1_000_000_000
-                player.reserves = {Fuel.COAL: 300_000, Fuel.GAS: 100_000, Fuel.URANIUM: 500}
+                player.resources = {Fuel.COAL: 300_000, Fuel.GAS: 100_000, Fuel.URANIUM: 500}
                 player.priorities_of_controllables = ""
 
                 add_asset(player, "industry", 18)
@@ -111,7 +111,7 @@ def init_test_players():
 
     # Player 1
     player1.money = 1_000_000_000
-    player1.reserves[Fuel.COAL] = 300_000
+    player1.resources[Fuel.COAL] = 300_000
 
     add_asset(player1, "molten_salt", 1)
     add_asset(player1, "hydrogen_storage", 1)
@@ -164,7 +164,7 @@ def init_test_players():
 
     # Player 2
     player2.money = 1_000_000_000
-    player2.reserves = {Fuel.COAL: 300_000, Fuel.GAS: 100_000, Fuel.URANIUM: 500}
+    player2.resources = {Fuel.COAL: 300_000, Fuel.GAS: 100_000, Fuel.URANIUM: 500}
 
     add_asset(player2, "warehouse", 20)
     add_asset(player2, "steam_engine", 20)

--- a/energetica/init_test_players.py
+++ b/energetica/init_test_players.py
@@ -5,6 +5,7 @@ from werkzeug.security import generate_password_hash
 from energetica.database.map import HexTile
 from energetica.database.network import Network
 from energetica.database.player import Player
+from energetica.enums import Fuel
 from energetica.game_error import GameError
 from energetica.globals import engine
 from energetica.utils.assets import finish_project, queue_project
@@ -68,7 +69,7 @@ def init_test_players():
                 HexTile.get(i).player = player
 
                 player.money = 1_000_000_000
-                player.resources = {"coal": 300_000, "gas": 100_000, "uranium": 500}
+                player.reserves = {Fuel.COAL: 300_000, Fuel.GAS: 100_000, Fuel.URANIUM: 500}
                 player.priorities_of_controllables = ""
 
                 add_asset(player, "industry", 18)
@@ -110,7 +111,7 @@ def init_test_players():
 
     # Player 1
     player1.money = 1_000_000_000
-    player1.resources["coal"] = 300_000
+    player1.reserves[Fuel.COAL] = 300_000
 
     add_asset(player1, "molten_salt", 1)
     add_asset(player1, "hydrogen_storage", 1)
@@ -163,7 +164,7 @@ def init_test_players():
 
     # Player 2
     player2.money = 1_000_000_000
-    player2.resources = {"coal": 300_000, "gas": 100_000, "uranium": 500}
+    player2.reserves = {Fuel.COAL: 300_000, Fuel.GAS: 100_000, Fuel.URANIUM: 500}
 
     add_asset(player2, "warehouse", 20)
     add_asset(player2, "steam_engine", 20)

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -215,7 +215,7 @@ def extraction_facility_demand(new_values, player: Player, demand) -> None:
             max_warehouse = warehouse_caps[fuel] - player_resources[fuel]
             max_prod = (
                 player.capacities[extraction_facility]["extraction_rate_per_day"]
-                * player.tile.reserves[fuel]
+                * player.tile.fuel_reserves[fuel]
                 * engine.in_game_seconds_per_tick
                 / 86400  # 86400 seconds in a day
             )
@@ -673,7 +673,7 @@ def calculate_prod(
     if "fuel_use" in player.capacities[facility]:
         for fuel, amount in player.capacities[facility]["fuel_use"].items():
             fuel = Fuel(fuel)
-            available_resource = player.reserves[fuel] - player.resources_on_sale[fuel] - resource_reservations[fuel]
+            available_resource = player.resources[fuel] - player.resources_on_sale[fuel] - resource_reservations[fuel]
             p_max_resources = available_resource / amount * player.capacities[facility]["power"]
             max_resources = min(p_max_resources, max_resources)
     else:
@@ -768,7 +768,7 @@ def resources_and_pollution(new_values, player: Player) -> None:
             for fuel, amount in player.capacities[facility]["fuel_use"].items():
                 fuel = Fuel(fuel)
                 quantity = amount * generation[facility] / player.capacities[facility]["power"]
-                player.reserves[fuel] -= quantity
+                player.resources[fuel] -= quantity
             facility_emissions = (
                 engine.const_config["assets"][facility]["base_pollution"]
                 * generation[facility]
@@ -787,12 +787,12 @@ def resources_and_pollution(new_values, player: Player) -> None:
                 extracted_quantity = (
                     production_factor
                     * player.capacities[extraction_facility]["extraction_rate_per_day"]
-                    * player.tile.reserves[fuel]
+                    * player.tile.fuel_reserves[fuel]
                     * engine.in_game_seconds_per_tick
                     / 86400  # 86400 seconds in a day
                 )
-                player.tile.reserves[fuel] -= extracted_quantity
-                player.reserves[fuel] += extracted_quantity
+                player.tile.fuel_reserves[fuel] -= extracted_quantity
+                player.resources[fuel] += extracted_quantity
                 player.progression_metrics["extracted_resources"] += extracted_quantity
                 emissions = extracted_quantity * player.capacities[extraction_facility]["pollution"]
                 add_emissions(
@@ -801,7 +801,7 @@ def resources_and_pollution(new_values, player: Player) -> None:
                     extraction_facility,
                     emissions,
                 )
-            new_values["resources"][fuel] = player.reserves[fuel]
+            new_values["resources"][fuel] = player.resources[fuel]
 
     # Carbon capture CO2 absorption
     if player.functional_facility_lvl["carbon_capture"] > 0:

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -15,14 +15,9 @@ from energetica.database.network import Network
 from energetica.database.ongoing_project import OngoingProject
 from energetica.database.player import Player
 from energetica.database.shipment import OngoingShipment
+from energetica.enums import Fuel, fuels_by_extraction_facility
 from energetica.globals import engine
 from energetica.utils.misc import calculate_river_discharge, calculate_solar_irradiance, calculate_wind_speed
-
-resource_to_extraction = {
-    "coal": "coal_mine",
-    "gas": "gas_drilling_site",
-    "uranium": "uranium_mine",
-}
 
 extraction_to_resource = {
     "coal_mine": "coal",
@@ -211,19 +206,21 @@ def calculate_net_import(new_values) -> None:
 
 def extraction_facility_demand(new_values, player: Player, demand) -> None:
     """Calculate power consumption of extraction facilities."""
+    assert player.tile is not None
     player_resources = new_values["resources"]
     warehouse_caps = player.config["warehouse_capacities"]
-    for resource, facility in resource_to_extraction.items():
-        if player.capacities[facility] is not None:
-            max_warehouse = warehouse_caps[resource] - player_resources[resource]
+    for fuel in Fuel:
+        extraction_facility = fuel.associated_mine()
+        if player.capacities[extraction_facility] is not None:
+            max_warehouse = warehouse_caps[fuel] - player_resources[fuel]
             max_prod = (
-                player.capacities[facility]["extraction_rate_per_day"]
-                * player.tile.fuel_reserves[resource]
+                player.capacities[extraction_facility]["extraction_rate_per_day"]
+                * player.tile.reserves[fuel]
                 * engine.in_game_seconds_per_tick
                 / 86400  # 86400 seconds in a day
             )
             power_factor = min(1.0, max_warehouse / max(1.0, max_prod))
-            demand[facility] = player.capacities[facility]["power_use"] * power_factor
+            demand[extraction_facility] = player.capacities[extraction_facility]["power_use"] * power_factor
 
 
 def industry_demand_and_revenues(player: Player, demand, revenues) -> None:
@@ -674,10 +671,9 @@ def calculate_prod(
         * engine.in_game_seconds_per_tick
     )
     if "fuel_use" in player.capacities[facility]:
-        for resource, amount in player.capacities[facility]["fuel_use"].items():
-            available_resource = (
-                player.resources[resource] - player.resources_on_sale[resource] - resource_reservations[resource]
-            )
+        for fuel, amount in player.capacities[facility]["fuel_use"].items():
+            fuel = Fuel(fuel)
+            available_resource = player.reserves[fuel] - player.resources_on_sale[fuel] - resource_reservations[fuel]
             p_max_resources = available_resource / amount * player.capacities[facility]["power"]
             max_resources = min(p_max_resources, max_resources)
     else:
@@ -762,15 +758,17 @@ def bid(market, player_id, demand, price, facility):
 
 def resources_and_pollution(new_values, player: Player) -> None:
     """Calculate resource use and production, O&M costs and emissions."""
+    assert player.tile is not None
     generation = new_values["generation"]
     op_costs = new_values["op_costs"]
     demand = new_values["demand"]
     # Calculate resource consumption and pollution of generation facilities
     for facility in engine.controllable_facilities:
         if player.capacities[facility] is not None:
-            for resource, amount in player.capacities[facility]["fuel_use"].items():
+            for fuel, amount in player.capacities[facility]["fuel_use"].items():
+                fuel = Fuel(fuel)
                 quantity = amount * generation[facility] / player.capacities[facility]["power"]
-                player.resources[resource] -= quantity
+                player.reserves[fuel] -= quantity
             facility_emissions = (
                 engine.const_config["assets"][facility]["base_pollution"]
                 * generation[facility]
@@ -782,19 +780,19 @@ def resources_and_pollution(new_values, player: Player) -> None:
 
     if player.functional_facility_lvl["warehouse"] > 0:
         for extraction_facility in engine.extraction_facilities:
-            resource = extraction_to_resource[extraction_facility]
+            fuel = fuels_by_extraction_facility[extraction_facility]
             if player.capacities[extraction_facility] is not None:
                 max_demand = player.capacities[extraction_facility]["power_use"]
                 production_factor = demand[extraction_facility] / max_demand
                 extracted_quantity = (
                     production_factor
                     * player.capacities[extraction_facility]["extraction_rate_per_day"]
-                    * player.tile.fuel_reserves[resource]
+                    * player.tile.reserves[fuel]
                     * engine.in_game_seconds_per_tick
                     / 86400  # 86400 seconds in a day
                 )
-                player.tile.fuel_reserves[resource] -= (extracted_quantity,)
-                player.resources[resource] += extracted_quantity
+                player.tile.reserves[fuel] -= extracted_quantity
+                player.reserves[fuel] += extracted_quantity
                 player.progression_metrics["extracted_resources"] += extracted_quantity
                 emissions = extracted_quantity * player.capacities[extraction_facility]["pollution"]
                 add_emissions(
@@ -803,7 +801,7 @@ def resources_and_pollution(new_values, player: Player) -> None:
                     extraction_facility,
                     emissions,
                 )
-            new_values["resources"][resource] = player.resources[resource]
+            new_values["resources"][fuel] = player.reserves[fuel]
 
     # Carbon capture CO2 absorption
     if player.functional_facility_lvl["carbon_capture"] > 0:

--- a/energetica/technology_effects.py
+++ b/energetica/technology_effects.py
@@ -14,6 +14,7 @@ from energetica.config.assets import (
 )
 from energetica.database.active_facility import ActiveFacility
 from energetica.database.ongoing_project import OngoingProject
+from energetica.enums import Fuel, Renewable, fuels_by_extraction_facility
 from energetica.game_error import GameError
 from energetica.globals import engine
 
@@ -207,7 +208,7 @@ def hydro_price_multiplier(player: Player, facility: str) -> float:
     if not player.tile:
         raise GameError("TileNotFound")  # TODO(mglst): handle this case
     if facility in ["watermill", "small_water_dam", "large_water_dam"]:
-        mlt *= hydro_price_function(next_available_location(player, facility), player.tile.renewable_potential["hydro"])
+        mlt *= hydro_price_function(next_available_location(player, facility), player.tile.potentials[Renewable.HYDRO])
     return mlt
 
 
@@ -223,7 +224,7 @@ def wind_speed_multiplier(player: Player, facility: str) -> float:
     if not player.tile:
         raise GameError("TileNotFound")  # TODO(mglst): handle this case
     if facility in ["windmill", "onshore_wind_turbine", "offshore_wind_turbine"]:
-        mlt *= wind_speed_function(next_available_location(player, facility), player.tile.renewable_potential["wind"])
+        mlt *= wind_speed_function(next_available_location(player, facility), player.tile.potentials[Renewable.WIND])
     return mlt
 
 
@@ -678,33 +679,15 @@ def package_storage_facilities(player: Player) -> list[dict]:
 def package_extraction_facilities(player: Player) -> list[dict]:
     """Package data relevant for the extraction_facilities frontend."""
     const_config_assets = engine.const_config["assets"]
-    facility_to_resource = {
-        "coal_mine": "coal",
-        "gas_drilling_site": "gas",
-        "uranium_mine": "uranium",
-    }
 
-    # TODO(mglst): remove this, let the frontend compute it (since tile resource can change often)
-    def tile_resource_amount(tile: HexTile, resource: str) -> float:
-        if resource == "coal":
-            return tile.coal_reserves
-        if resource == "gas":
-            return tile.gas_reserves
-        if resource == "uranium":
-            return tile.uranium_reserves
-        msg = f"unknown resource {resource}"
-        raise ValueError(msg)
-
-    def production_will_be_poor(tile: HexTile, resource: str) -> bool:
+    def production_will_be_poor(tile: HexTile, fuel: Fuel) -> bool:
         """Return whether extracting the resource will be poor."""
-        if resource == "coal":
-            return tile.coal_reserves < 500_000_000
-        if resource == "gas":
-            return tile.gas_reserves < 180_000_000
-        if resource == "uranium":
-            return tile.uranium_reserves < 2_400_000
-        msg = f"unknown resource {resource}"
-        raise ValueError(msg)
+        limits = {
+            Fuel.COAL: 500_000_000,
+            Fuel.GAS: 180_000_000,
+            Fuel.URANIUM: 2_400_000,
+        }
+        return tile.reserves[fuel] < limits[fuel]
 
     if not player.tile:
         raise GameError("TileNotFound")
@@ -718,14 +701,18 @@ def package_extraction_facilities(player: Player) -> list[dict]:
             "pollution": const_config_assets[extraction_facility]["base_pollution"]
             * 1000
             * extraction_emissions_multiplier(player, extraction_facility),
+            # TODO(mglst): remove this, let the frontend compute it (since tile resource can change often)
             "resource_production": {
-                "name": facility_to_resource[extraction_facility],
+                "name": fuels_by_extraction_facility[extraction_facility],
                 "rate": const_config_assets[extraction_facility]["base_extraction_rate_per_day"]
                 * extraction_rate_multiplier(player)
-                * tile_resource_amount(player.tile, facility_to_resource[extraction_facility])
+                * player.tile.reserves[fuels_by_extraction_facility[extraction_facility]]
+                # * tile_resource_amount(player.tile, facility_to_resource[extraction_facility])
                 / 24,
             },
-            "poor_resource_production": production_will_be_poor(player.tile, facility_to_resource[extraction_facility]),
+            "poor_resource_production": production_will_be_poor(
+                player.tile, fuels_by_extraction_facility[extraction_facility]
+            ),
         }
         for extraction_facility in engine.extraction_facilities
     ]

--- a/energetica/technology_effects.py
+++ b/energetica/technology_effects.py
@@ -687,7 +687,7 @@ def package_extraction_facilities(player: Player) -> list[dict]:
             Fuel.GAS: 180_000_000,
             Fuel.URANIUM: 2_400_000,
         }
-        return tile.reserves[fuel] < limits[fuel]
+        return tile.fuel_reserves[fuel] < limits[fuel]
 
     if not player.tile:
         raise GameError("TileNotFound")
@@ -706,7 +706,7 @@ def package_extraction_facilities(player: Player) -> list[dict]:
                 "name": fuels_by_extraction_facility[extraction_facility],
                 "rate": const_config_assets[extraction_facility]["base_extraction_rate_per_day"]
                 * extraction_rate_multiplier(player)
-                * player.tile.reserves[fuels_by_extraction_facility[extraction_facility]]
+                * player.tile.fuel_reserves[fuels_by_extraction_facility[extraction_facility]]
                 # * tile_resource_amount(player.tile, facility_to_resource[extraction_facility])
                 / 24,
             },

--- a/energetica/templates/assets/extraction_facilities.jinja
+++ b/energetica/templates/assets/extraction_facilities.jinja
@@ -70,7 +70,7 @@
                 <em class="txt-blue">
                   <i class="fa fa-info-circle"></i> Underground reserves of {{ resource }} :
                   <strong></strong>
-                  <script>document.currentScript.previousElementSibling.innerHTML = format_mass({{ user.tile.reserves[resource] }});</script>
+                  <script>document.currentScript.previousElementSibling.innerHTML = format_mass({{ user.tile.fuel_reserves[resource] }});</script>
                 </em>
               </div>
               {# Requirements #}

--- a/energetica/templates/assets/extraction_facilities.jinja
+++ b/energetica/templates/assets/extraction_facilities.jinja
@@ -70,7 +70,7 @@
                 <em class="txt-blue">
                   <i class="fa fa-info-circle"></i> Underground reserves of {{ resource }} :
                   <strong></strong>
-                  <script>document.currentScript.previousElementSibling.innerHTML = format_mass({{ user.tile[resource] }});</script>
+                  <script>document.currentScript.previousElementSibling.innerHTML = format_mass({{ user.tile.reserves[resource] }});</script>
                 </em>
               </div>
               {# Requirements #}

--- a/energetica/utils/assets.py
+++ b/energetica/utils/assets.py
@@ -6,10 +6,10 @@ import random
 from typing import TYPE_CHECKING
 
 from energetica import technology_effects
-from energetica.config.assets import WorkerType
 from energetica.database.active_facility import ActiveFacility
 from energetica.database.ongoing_project import OngoingProject, ProjectStatus
 from energetica.database.player import Player
+from energetica.enums import WorkerType
 from energetica.game_engine import Confirm
 from energetica.game_error import GameError
 from energetica.globals import engine

--- a/energetica/utils/climate_helpers.py
+++ b/energetica/utils/climate_helpers.py
@@ -10,6 +10,7 @@ from energetica.config.climate_events import climate_events
 from energetica.database.climate_event_recovery import ClimateEventRecovery
 from energetica.database.engine_data import calculate_reference_gta, calculate_temperature_deviation
 from energetica.database.map import HexTile
+from energetica.enums import Renewable
 from energetica.globals import engine
 from energetica.utils.assets import facility_destroyed
 from energetica.utils.formatting import display_money
@@ -100,7 +101,7 @@ def check_climate_events():
     flood_probability = climate_events["flood"]["base_probability"] / ticks_per_day * climate_change**2
     if random.random() < flood_probability:
         # the hydro value for a flood needs to be above 20%
-        hydro_tiles = HexTile.filter(lambda tile: tile.renewable_potential["hydro"] > 0.2)
+        hydro_tiles = HexTile.filter(lambda tile: tile.potentials[Renewable.HYDRO] > 0.2)
         tile = random.choice(hydro_tiles)
         climate_event_impact(tile, "flood")
 

--- a/energetica/utils/resource_market.py
+++ b/energetica/utils/resource_market.py
@@ -2,20 +2,22 @@
 
 import math
 
+from energetica.database.player import Player
 from energetica.database.resource_on_sale import ResourceOnSale
 from energetica.database.shipment import OngoingShipment
+from energetica.enums import Fuel
 from energetica.game_error import GameError
 from energetica.globals import engine
 from energetica.utils.formatting import display_money, format_mass
 
 
-def put_resource_on_market(player, resource, quantity, price):
+def put_resource_on_market(player: Player, fuel: Fuel, quantity: float, price: float) -> None:
     """Put an offer on the resource market."""
-    if player.resources[resource] - player.resources_on_sale[resource] < quantity:
+    if player.reserves[fuel] - player.resources_on_sale[fuel] < quantity:
         raise GameError("notEnoughResource")
-    player.resources_on_sale[resource] += quantity
+    player.resources_on_sale[fuel] += quantity
     new_sale = ResourceOnSale(
-        resource=resource,
+        resource=fuel,
         quantity=quantity,
         price=price,
         player=player,
@@ -23,9 +25,10 @@ def put_resource_on_market(player, resource, quantity, price):
     player.resource_market_offers.append(new_sale)
 
 
-def buy_resource_from_market(player, quantity, sale):
+def buy_resource_from_market(player: Player, quantity: float, sale: ResourceOnSale) -> None:
     """Buy an offer from the resource market."""
-
+    assert player.tile is not None
+    assert sale.player.tile is not None
     if quantity is None or quantity <= 0 or quantity > sale.quantity:
         raise GameError("invalidQuantity")
     total_price = sale.price * quantity
@@ -42,10 +45,10 @@ def buy_resource_from_market(player, quantity, sale):
         sale.quantity -= quantity
         player.money -= total_price
         sale.player.money += total_price
-        player.resources[sale.resource] -= quantity
+        player.reserves[sale.resource] -= quantity
         player.resources_on_sale[sale.resource] -= quantity
-        sale.player.progression_metrics.sold_resources += quantity
-        player.progression_metrics.bought_resources += quantity
+        sale.player.progression_metrics["sold_resources"] += quantity
+        player.progression_metrics["bought_resources"] += quantity
         player.check_trading_achievement()
         dq = player.tile.coordinates[0] - sale.player.tile.coordinates[0]
         dr = player.tile.coordinates[1] - sale.player.tile.coordinates[1]
@@ -67,40 +70,42 @@ def buy_resource_from_market(player, quantity, sale):
         engine.log(
             f"{player.username} bought {format_mass(quantity)} of "
             f"{sale.resource} from {sale.player.username} for a total cost of "
-            f"{display_money(total_price)}."
+            f"{display_money(total_price)}.",
         )
         if sale.quantity == 0:
             # Player is purchasing all available quantity
             sale.delete()
 
 
-def store_import(player, resource, quantity):
+def store_import(player: Player, fuel: Fuel, quantity: float) -> None:
     """
     Add a resource shipment to the player's warehouse.
 
     This function is executed when a resource shipment arrives.
     """
-    max_cap = player.config["warehouse_capacities"][resource]
-    if player.resources[resource] + quantity > max_cap:
-        player.resources[resource] = max_cap
+    assert player.tile is not None
+    max_cap: float = player.config["warehouse_capacities"][fuel]
+    if player.reserves[fuel] + quantity > max_cap:
+        player.reserves[fuel] = max_cap
         # excess resources are stored in the ground
-        player.tile.fuel_reserves[resource] += player.resources[resource] + quantity - max_cap
+        # TODO(mglst): what if instead it was a political fiasco that the player had to deal with?
+        player.tile.reserves[fuel] += player.reserves[fuel] + quantity - max_cap
         player.notify(
             "OngoingShipments",
-            f"A shipment of {format_mass(quantity)} {resource} arrived, but "
-            f"only {format_mass(max_cap - player.resources[resource])} could be "
+            f"A shipment of {format_mass(quantity)} {fuel} arrived, but "
+            f"only {format_mass(max_cap - player.reserves[fuel])} could be "
             "stored in your warehouse.",
         )
         engine.log(
             f"{player.username} received a shipment of {format_mass(quantity)} "
-            f"{resource}, but could only store "
-            f"{format_mass(max_cap - player.resources[resource])} "
-            "in their warehouse."
+            f"{fuel}, but could only store "
+            f"{format_mass(max_cap - player.reserves[fuel])} "
+            "in their warehouse.",
         )
     else:
-        player.resources[resource] += quantity
+        player.reserves[fuel] += quantity
         player.notify(
             "OngoingShipments",
-            f"A shipment of {format_mass(quantity)} {resource} arrived.",
+            f"A shipment of {format_mass(quantity)} {fuel} arrived.",
         )
-        engine.log(f"{player.username} received a shipment of {format_mass(quantity)} {resource}.")
+        engine.log(f"{player.username} received a shipment of {format_mass(quantity)} {fuel}.")

--- a/energetica/utils/resource_market.py
+++ b/energetica/utils/resource_market.py
@@ -13,7 +13,7 @@ from energetica.utils.formatting import display_money, format_mass
 
 def put_resource_on_market(player: Player, fuel: Fuel, quantity: float, price: float) -> None:
     """Put an offer on the resource market."""
-    if player.reserves[fuel] - player.resources_on_sale[fuel] < quantity:
+    if player.resources[fuel] - player.resources_on_sale[fuel] < quantity:
         raise GameError("notEnoughResource")
     player.resources_on_sale[fuel] += quantity
     new_sale = ResourceOnSale(
@@ -45,7 +45,7 @@ def buy_resource_from_market(player: Player, quantity: float, sale: ResourceOnSa
         sale.quantity -= quantity
         player.money -= total_price
         sale.player.money += total_price
-        player.reserves[sale.resource] -= quantity
+        player.resources[sale.resource] -= quantity
         player.resources_on_sale[sale.resource] -= quantity
         sale.player.progression_metrics["sold_resources"] += quantity
         player.progression_metrics["bought_resources"] += quantity
@@ -85,25 +85,25 @@ def store_import(player: Player, fuel: Fuel, quantity: float) -> None:
     """
     assert player.tile is not None
     max_cap: float = player.config["warehouse_capacities"][fuel]
-    if player.reserves[fuel] + quantity > max_cap:
-        player.reserves[fuel] = max_cap
+    if player.resources[fuel] + quantity > max_cap:
+        player.resources[fuel] = max_cap
         # excess resources are stored in the ground
         # TODO(mglst): what if instead it was a political fiasco that the player had to deal with?
-        player.tile.reserves[fuel] += player.reserves[fuel] + quantity - max_cap
+        player.tile.fuel_reserves[fuel] += player.resources[fuel] + quantity - max_cap
         player.notify(
             "OngoingShipments",
             f"A shipment of {format_mass(quantity)} {fuel} arrived, but "
-            f"only {format_mass(max_cap - player.reserves[fuel])} could be "
+            f"only {format_mass(max_cap - player.resources[fuel])} could be "
             "stored in your warehouse.",
         )
         engine.log(
             f"{player.username} received a shipment of {format_mass(quantity)} "
             f"{fuel}, but could only store "
-            f"{format_mass(max_cap - player.reserves[fuel])} "
+            f"{format_mass(max_cap - player.resources[fuel])} "
             "in their warehouse.",
         )
     else:
-        player.reserves[fuel] += quantity
+        player.resources[fuel] += quantity
         player.notify(
             "OngoingShipments",
             f"A shipment of {format_mass(quantity)} {fuel} arrived.",


### PR DESCRIPTION
Add `Fuel` and  `Renewable` enums. These are python classes, and their instances are str, with additional functionally, though they can be used anywhere that a str is expected. The values can easily be iterated over. Converting str to a strenum is also easy, the class construction can take a str.
```
fuel = Fuel("coal")  # Fuel.COAL
print(fuel.associated_mine())  # coal_mine
for fuel in Fuel:
    print(fuel)  # coal, gas, uranium
fuel = Fuel("nonexistent")  # ValueError: 'nonexistent' is not a valid Fuel
```