### PR TITLE
feat: new `save_game_engine_instance` action to resume from

### DIFF
--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -141,8 +141,14 @@ def create_app(
     action_id_by_tick = {
         action.total_t: action_id for action_id, action in enumerate(actions) if action.action_type == "tick"
     }
+    save_action_ids = [
+        action_id for action_id, action in enumerate(actions) if action.action_type == "save_game_engine_instance"
+    ]
     loaded_tick = engine.total_t
-    start_action_id = action_id_by_tick[loaded_tick] + 1 if loaded_tick else 1
+    if simulate_file:
+        start_action_id = action_id_by_tick[loaded_tick] + 1 if loaded_tick else 1
+    else:
+        start_action_id = save_action_ids[-1] + 1 if save_action_ids else 1
     last_action_id = action_id_by_tick[simulate_till] if simulate_till else len(actions) - 1
     actions_to_simulate = actions[start_action_id : last_action_id + 1]
 

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -19,7 +19,7 @@ import socketio
 
 from energetica.config.assets import config, const_config
 from energetica.enums import Fuel, Renewable
-from energetica.schemas.simulate import Action, InitEngineAction
+from energetica.schemas.simulate import Action, InitEngineAction, SaveInstanceAction
 
 if TYPE_CHECKING:
     from energetica.database.messages import Chat
@@ -230,6 +230,7 @@ class GameEngine(object):
         data = {member: getattr(self, member) for member in members_to_save}
         with open("instance/engine_data.pck", "wb") as file:
             pickle.dump(data, file)
+        self.log_action(SaveInstanceAction(timestamp=datetime.now(), action_type="save_game_engine_instance"))
 
     def load(self) -> None:
         """Load the game engine data from a file."""

--- a/energetica/schemas/simulate.py
+++ b/energetica/schemas/simulate.py
@@ -58,7 +58,12 @@ class ApiActionResponse(BaseModel):
     payload: str
 
 
+class SaveInstanceAction(BaseModel):
+    timestamp: datetime
+    action_type: Literal["save_game_engine_instance"]
+
+
 Method = Literal["POST", "PUT", "DELETE", "PATCH"]
 
-ActionUnionType = InitEngineAction | CreateUserAction | TickAction | ApiAction
+ActionUnionType = InitEngineAction | CreateUserAction | TickAction | ApiAction | SaveInstanceAction
 Action = Annotated[ActionUnionType, Field(discriminator="action_type")]


### PR DESCRIPTION
This PR is my suggested solution to #302 

This adds a new action type, namely `save_game_engine_instance`, which is logged whenever the game engine's instance is saved. This can then be used in the logic to decide what actions, if any, need to be re simulated when resuming the server.

The logic for `actions_to_simulate` is not one I'm very familiar with. @yassir-akram could you give me your thoughts and feedback on my suggested addition and changes ?