### PR TITLE
Fix/357-project-pause-logic-frontend

### DIFF
--- a/energetica/static/progress_bar.js
+++ b/energetica/static/progress_bar.js
@@ -398,7 +398,7 @@ function html_for_progressBar(projectIndex, projectsQueue, project) {
     throw Error("html_for_progressBar: project is null");
   }
   let playPauseLogo = "fa-pause";
-  const togglePauseButtonFunctionName = project.status === 2 ? "pause_construction" : "resume_construction";
+  const togglePauseButtonFunctionName = project.status !== 0 ? "pause_construction" : "resume_construction";
   if (project.status == 0) {
     playPauseLogo = "fa-play";
   }


### PR DESCRIPTION
The error was that projects which were "waiting" were trying to be resume - but they're not paused, they're waiting. The valid action that the button should do is pause
Fixes #357