### PR TITLE
fix: add game verison to actions history and check version when running the log files

### DIFF
--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -1,7 +1,7 @@
 """Initializes the app and the game engine."""
 
-__version__ = "0.11.1-b"
-__release_date__ = "03/02/2025"
+__version__ = "0.11.2-b"
+__release_date__ = "20/08/2025"
 
 import asyncio
 import glob
@@ -133,11 +133,12 @@ def create_app(
         if actions:
             kwargs: dict = actions[0].model_dump()
             kwargs.pop("action_type")
-            # datetime.fromisoformat
-            kwargs["start_date"] = kwargs["start_date"]
+            assert kwargs["game_version"] == __version__, (
+                "Game version mismatch. This actions history is not compatible with this version of the game."
+            )
             engine.init_instance(**kwargs)
         else:
-            engine.init_instance(clock_time, in_game_seconds_per_tick, random_seed, env, disable_signups)
+            engine.init_instance(clock_time, in_game_seconds_per_tick, random_seed, env, __version__, disable_signups)
 
     action_id_by_tick = {
         action.total_t: action_id for action_id, action in enumerate(actions) if action.action_type == "tick"

--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -131,11 +131,12 @@ def create_app(
             assert uuid.UUID(actions[0].instance_uuid) == engine.uuid
     else:
         if actions:
-            kwargs: dict = actions[0].model_dump()
-            kwargs.pop("action_type")
-            assert kwargs["game_version"] == __version__, (
+            assert actions[0].action_type == "init_engine"
+            assert actions[0].game_version == __version__, (
                 "Game version mismatch. This actions history is not compatible with this version of the game."
             )
+            kwargs: dict = actions[0].model_dump()
+            kwargs.pop("action_type")
             engine.init_instance(**kwargs)
         else:
             engine.init_instance(clock_time, in_game_seconds_per_tick, random_seed, env, __version__, disable_signups)

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -85,6 +85,7 @@ class GameEngine(object):
         in_game_seconds_per_tick: int,
         random_seed: int,
         env: Literal["dev"] | Literal["prod"],
+        game_version: str,
         disable_signups: bool = False,
         start_date: datetime | None = None,
         instance_uuid: str | None = None,
@@ -109,6 +110,7 @@ class GameEngine(object):
         log_entry = InitEngineAction(
             instance_uuid=self.uuid.hex,
             env=self.env,
+            game_version=game_version,
             clock_time=self.clock_time,
             in_game_seconds_per_tick=self.in_game_seconds_per_tick,
             action_type="init_engine",

--- a/energetica/schemas/simulate.py
+++ b/energetica/schemas/simulate.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 class InitEngineAction(BaseModel):
     instance_uuid: str
     env: Literal["dev", "prod"]
+    game_version: str
     clock_time: int
     in_game_seconds_per_tick: int
     action_type: Literal["init_engine"]

--- a/tests/policy_runner.py
+++ b/tests/policy_runner.py
@@ -1,5 +1,6 @@
 """Run a list of policies with one player per policy."""
 
+from energetica import __version__
 from energetica.database.map import HexTile
 from energetica.database.player import Player
 from energetica.enums import Renewable
@@ -11,7 +12,7 @@ from tests.policy import Policy
 
 def run_policies(policies: list[Policy], ticks_to_run: int) -> list[Player]:
     """Run a list of policies with one player per policy."""
-    engine.init_instance(30, 3600, 0, env="dev")
+    engine.init_instance(30, 3600, 0, env="dev", game_version=__version__)
     players = [Player(f"player_{i}", "password_hash") for i in range(len(policies))]
     for player in players:
         # tile = HexTile.getitem(player.id)

--- a/tests/unit/test_network_prices.py
+++ b/tests/unit/test_network_prices.py
@@ -31,7 +31,8 @@ def test_seed_determinism() -> None:
             import json
             from energetica import engine
             from energetica.database.player import Player
-            engine.init_instance(30, 3600, 0, env="dev")
+            from energetica import __version__
+            engine.init_instance(30, 3600, 0, env="dev", game_version=__version__)
             
             engine.random_seed = {seed}
             player = Player("player1", "pwhash")


### PR DESCRIPTION
I'm not sure I did this right, please check.

We probably want to have forward-compatible actions history. For now we can only run actions history of the same version (including beta and release candidates). What do you suggest ? 