### PR TITLE
fix: get_chart_data when past_data file doesn't exist

### DIFF
--- a/energetica/api/http.py
+++ b/energetica/api/http.py
@@ -16,6 +16,7 @@ from energetica.database.player import Player
 from energetica.game_error import GameError, GameExceptionType
 from energetica.globals import engine
 from energetica.utils.auth import get_current_user
+from energetica.utils.misc import empty_network_data, empty_player_data
 
 # TODO: migrate all these routes to native FastAPI routes
 todo_router = APIRouter(prefix="", tags=["Flask Migration"])
@@ -81,15 +82,21 @@ def get_chart_data(user: Annotated[Player, Depends(get_current_user)]):  # noqa:
     total_t = engine.total_t
     rolling_history = user.rolling_history.get_data(t=total_t % 216 + 1)
     filename = f"instance/data/players/player_{user.id}.pck"
-    with open(filename, "rb") as file:
-        data = pickle.load(file)
+    if not Path(filename).is_file():
+        data = empty_player_data()
+    else:
+        with open(filename, "rb") as file:
+            data = pickle.load(file)
     concat_slices(data, rolling_history)
 
     network_data = None
     if user.network is not None:
         filename = f"instance/data/networks/{user.network.id}/time_series.pck"
-        with open(filename, "rb") as file:
-            network_data = pickle.load(file)
+        if not Path(filename).is_file():
+            network_data = empty_network_data()
+        else:
+            with open(filename, "rb") as file:
+                network_data = pickle.load(file)
         concat_slices(network_data, user.network.rolling_history.get_data(t=total_t % 216 + 1))
 
     current_climate_data = engine.current_climate_data.get_data(t=total_t % 216 + 1)

--- a/energetica/utils/misc.py
+++ b/energetica/utils/misc.py
@@ -76,9 +76,9 @@ def init_array() -> list[list[float]]:
     return [[0.0] * 360 for _ in range(5)]
 
 
-def init_player_data_file(player_id: int) -> None:
-    """Initialize the past production data file for a player."""
-    past_data = {
+def empty_player_data() -> None:
+    """return an empty data structure for a new player."""
+    return {
         "revenues": {
             "industry": init_array(),
             "exports": init_array(),
@@ -108,13 +108,11 @@ def init_player_data_file(player_id: int) -> None:
             "construction": init_array(),
         },
     }
-    with open(f"instance/data/players/player_{player_id}.pck", "wb") as file:
-        pickle.dump(past_data, file)
 
 
-def init_network_data_file(network_id: int) -> None:
-    """Initialize the past production data file for a network."""
-    past_data = {
+def empty_network_data() -> None:
+    """return an empty data structure for a new network."""
+    return {
         "network_data": {
             "price": init_array(),
             "quantity": init_array(),
@@ -124,9 +122,6 @@ def init_network_data_file(network_id: int) -> None:
         "generation": {},
         "consumption": {},
     }
-    Path(f"instance/data/networks/{network_id}").mkdir(parents=True, exist_ok=True)
-    with open(f"instance/data/networks/{network_id}/time_series.pck", "wb") as file:
-        pickle.dump(past_data, file)
 
 
 def save_past_data() -> None:
@@ -149,7 +144,8 @@ def save_past_data() -> None:
             continue
         past_data = {}
         if not os.path.exists(f"instance/data/players/player_{player.id}.pck"):
-            init_player_data_file(player.id)
+            with open(f"instance/data/players/player_{player.id}.pck", "wb") as file:
+                pickle.dump(empty_player_data(), file)
         with open(
             f"instance/data/players/player_{player.id}.pck",
             "rb",
@@ -179,7 +175,9 @@ def save_past_data() -> None:
                 os.remove(os.path.join(network_dir, filename))
 
         if not os.path.exists(f"instance/data/networks/{network.id}/time_series.pck"):
-            init_network_data_file(network.id)
+            Path(f"instance/data/networks/{network.id}").mkdir(parents=True, exist_ok=True)
+            with open(f"instance/data/networks/{network.id}/time_series.pck", "wb") as file:
+                pickle.dump(empty_network_data(), file)
         past_data = {}
         with open(
             f"instance/data/networks/{network.id}/time_series.pck",


### PR DESCRIPTION
There was a problem with the merge 048d801c605acf68da768d8b5681af4c22b59fb5, the get_chart_data didn't work when the past_data_file did not yet exist. To fix it I used the initialization function that I slightly adapted to return dictionaries