### PR TITLE
fix: edge case in project priority swapping logic and add two related tests

### DIFF
--- a/energetica/utils/assets.py
+++ b/energetica/utils/assets.py
@@ -509,8 +509,12 @@ def decrease_project_priority(player: Player, project: OngoingProject) -> None:
 
     if project_1.status == ProjectStatus.ONGOING and project_2.status == ProjectStatus.WAITING:
         # Case 2
-        # This case can only happen when project 1 is using the last available worker. (Indeed, the other case is
-        # when project 1 is a prerequisite of project 2, but in this case, the swap is not possible)
+        # Project 1 is using the last available worker. If project 2 can resume, swap them, else raise error.
+        project_2.recompute_prerequisites_and_level()
+        # Here we need to recompute prerequisites. Indeed, if project_2 had a prerequisite but which has not been
+        # completed, it will not be removed from the project_2.prerequisites list - not unless we recompute.
+        if project_2.prerequisites:
+            raise GameError(GameExceptionType.REQUIREMENTS_PREVENT_REORDER)
         project_1.set_waiting()
         project_2.set_ongoing()
 

--- a/tests/integration/test_projects.py
+++ b/tests/integration/test_projects.py
@@ -10,11 +10,14 @@ from energetica.database.ongoing_project import OngoingProject
 from energetica.database.player import Player
 from energetica.database.user import User
 from energetica.enums import ControllableFacilityType, FunctionalFacilityType, ProjectStatus, TechnologyType, WorkerType
+from energetica.game_error import GameError
 from energetica.globals import engine
 from energetica.utils.assets import (
     cancel_project,
     decrease_project_priority,
     finish_project,
+    increase_project_priority,
+    pause_project,
     queue_project,
     toggle_pause_project,
 )
@@ -132,7 +135,7 @@ def validate_rule_7(player: Player) -> None:
                 )
 
 
-def test_swap_paused_and_unpaused_constructions() -> None:
+def test_swap_waiting_and_ongoing_constructions() -> None:
     """
     Setup:
     Player has one construction worker, constructions A and B are launched, A is ongoing, B is waiting.
@@ -308,3 +311,73 @@ def test_math_and_building_tech() -> None:
     technology_c = queue_project(player=player, project_type=TechnologyType.MECHANICAL_ENGINEERING, force=True)
     validate_rules(player)
     assert technology_c.status == ProjectStatus.WAITING
+
+
+def test_swapping_waiting_and_paused_researches() -> None:
+    """
+    Setup: player attempts to increase the priority of a project that is paused, swapping it with an unpaused project -
+    this is not allowed.
+
+    Research priority: at point (*)
+    * TECH A (ONGOING): Mathematics. All prerequisites satisfied
+    * TECH B (WAITING): Building tech. All prerequisites satisfied
+    * TECH C (PAUSED):  Mech. Engineering. Depends on TECH A - Mathematics
+    """
+    create_app(rm_instance=True, skip_adding_handlers=True, env="dev")
+
+    user = User(username="username", pwhash=generate_password_hash("password"), role="player")
+    hex_tile = HexTile.getitem(1)
+    player = confirm_location(user, hex_tile)
+    player.money = 1_000_000_000
+    finish_project(queue_project(player=player, project_type=FunctionalFacilityType.LABORATORY, force=True))
+
+    validate_rules(player)
+    technology_a = queue_project(player=player, project_type=TechnologyType.MATHEMATICS, force=True)
+    validate_rules(player)
+    technology_b = queue_project(player=player, project_type=TechnologyType.BUILDING_TECHNOLOGY, force=True)
+    validate_rules(player)
+    technology_c = queue_project(player=player, project_type=TechnologyType.MECHANICAL_ENGINEERING, force=True)
+    validate_rules(player)
+    pause_project(player, technology_c)
+    validate_rules(player)
+    with pytest.raises(GameError):
+        # (*)
+        increase_project_priority(player, technology_c)
+    validate_rules(player)
+
+
+def test_increasing_priority_of_paused_and_blocked_research() -> None:
+    """
+    Setup: player attempts to increase the priority of a project that is paused, and that has unfinished prerequisites.
+
+    This is a scenario that came up in testing v0.11.2-b. This is a minimal recreation of this situation. In practice,
+    the setup was much trickier, and came about on tick >> 15,000 with a large number of research workers.
+
+    Setup before the issue occurs with increase priority, at point (*):
+    * TECH A (ONGOING): Mathematics. All prerequisites satisfied
+    * TECH B (ONGOING): Building tech. All prerequisites satisfied
+    * TECH C (WAITING):  Mech. Engineering. **DEPENDS on TECH A - Mathematics**
+
+    We're trying to increase the priority of C, but it cannot go from waiting to ongoing since it has unfinished
+    prerequisites. This should therefore not be allowed.
+    """
+    create_app(rm_instance=True, skip_adding_handlers=True, env="dev")
+
+    user = User(username="username", pwhash=generate_password_hash("password"), role="player")
+    hex_tile = HexTile.getitem(1)
+    player = confirm_location(user, hex_tile)
+    player.money = 1_000_000_000
+    finish_project(queue_project(player=player, project_type=FunctionalFacilityType.LABORATORY, force=True))
+    player.workers[WorkerType.RESEARCH] = 2
+
+    validate_rules(player)
+    technology_a = queue_project(player=player, project_type=TechnologyType.MATHEMATICS, force=True)
+    validate_rules(player)
+    technology_b = queue_project(player=player, project_type=TechnologyType.BUILDING_TECHNOLOGY, force=True)
+    validate_rules(player)
+    technology_c = queue_project(player=player, project_type=TechnologyType.MECHANICAL_ENGINEERING, force=True)
+    validate_rules(player)
+    with pytest.raises(GameError):
+        # (*)
+        increase_project_priority(player, technology_c)
+    validate_rules(player)


### PR DESCRIPTION
Fixed edge case: we try to priority swap two projects, the first of which is using the last available worker, but the second project cannot be resumed (well, started) because it has prerequisites.

Add tests:
* test_swapping_waiting_and_paused_researches (unrelated to issue #389, good to have)
* test_increasing_priority_of_paused_and_blocked_research: recreates issue #389