### PR TITLE
fix: correct resource storage logic in store_import function and enhance related tests

### DIFF
--- a/energetica/utils/resource_market.py
+++ b/energetica/utils/resource_market.py
@@ -100,11 +100,10 @@ def store_import(player: Player, fuel: Fuel, quantity: float) -> None:
     assert player.tile is not None
     max_cap: float = player.config["warehouse_capacities"][fuel]
     if player.resources[fuel] + quantity > max_cap:
-        player.resources[fuel] = max_cap
         # excess resources are stored in the ground
         # TODO(mglst): what if instead it was a political fiasco that the player had to deal with?
-        # TODO(mglst): the logic here is broken. player.resources[fuel] is updated too early
         player.tile.fuel_reserves[fuel] += player.resources[fuel] + quantity - max_cap
+        player.resources[fuel] = max_cap
         player.notify(
             "OngoingShipments",
             f"A shipment of {format_mass(quantity)} {fuel} arrived, but "

--- a/tests/integration/test_resource_market.py
+++ b/tests/integration/test_resource_market.py
@@ -23,11 +23,20 @@ def test_store_import() -> None:
     add_asset(player1, FunctionalFacilityType.WAREHOUSE, 1)
     assert player1.resources[Fuel.COAL] == 0
 
+    # The warehouse has capacity for 500,000, so all the shipment can be stored
     store_import(player1, Fuel.COAL, 250_000)
     assert player1.resources[Fuel.COAL] == 250_000
 
+    # The warehouse cannot store more than its capacity, the rest is stored in the ground
+    stored_and_ground = player1.tile.fuel_reserves[Fuel.COAL] + player1.resources[Fuel.COAL]
     store_import(player1, Fuel.COAL, 1_000_000)
+
+    # Check that the warehouse is full
     assert player1.resources[Fuel.COAL] == 500_000
+
+    # Check that the ground storage has increased, and that conservation of mass holds
+    new_stored_and_ground = player1.tile.fuel_reserves[Fuel.COAL] + player1.resources[Fuel.COAL]
+    assert new_stored_and_ground - stored_and_ground == 1_000_000
 
 
 def test_purchase_resource() -> None:


### PR DESCRIPTION
* Add test for 'conservation of mass'
* Fix logic (test fails without fix, and passes after fix)

fixes #441