### PR TITLE
feat: use a random tick value for the delta_t to start at a random se…

### DIFF
--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -119,10 +119,9 @@ class GameEngine(object):
             disable_signups=disable_signups,
         )
         self.log_action(log_entry)
-        last_midnight = self.start_date.replace(hour=0, minute=0, second=0, microsecond=0)
-        # time shift in ticks. Defines the number of ticks between
-        # the first simulated tick and the beginning of in-game year 0.
-        self.delta_t = round((self.start_date - last_midnight).total_seconds() // self.clock_time)
+        # Random time shift in number of ticks to start the game at a random season of the year
+        rng = random.Random(self.random_seed)
+        self.delta_t = rng.randint(0, 72 * 3600 * 24 // self.in_game_seconds_per_tick)
         # transform start_date to a seconds timestamp corresponding to the time of the first tick
         self.start_date = datetime.fromtimestamp(math.floor(self.start_date.timestamp() / clock_time) * clock_time)
 

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -10,6 +10,7 @@ import pickle
 import random
 import tarfile
 import uuid
+import numpy as np
 from datetime import datetime
 from pathlib import Path
 from threading import RLock
@@ -120,8 +121,8 @@ class GameEngine(object):
         )
         self.log_action(log_entry)
         # Random time shift in number of ticks to start the game at a random season of the year
-        rng = random.Random(self.random_seed)
-        self.delta_t = rng.randint(0, 72 * 3600 * 24 // self.in_game_seconds_per_tick)
+        rng = np.random.default_rng(self.random_seed)
+        self.delta_t = int(rng.integers(0, 72 * 3600 * 24 // self.in_game_seconds_per_tick))
         # transform start_date to a seconds timestamp corresponding to the time of the first tick
         self.start_date = datetime.fromtimestamp(math.floor(self.start_date.timestamp() / clock_time) * clock_time)
 


### PR DESCRIPTION
This adresses the feature request #435. delta_t is now asigned to a random value in order to start at a random moment in the in-game year. 