### PR TITLE
fix: displaying the correct upgrade values for technologies

### DIFF
--- a/energetica/technology_effects.py
+++ b/energetica/technology_effects.py
@@ -43,6 +43,21 @@ def special_multiplier(pf: float, lvl: int) -> float:
     return (0.5 + 0.5 * pf) ** lvl + np.log(pf / (0.5 + 0.5 * pf)) * lvl
 
 
+def special_multiplier_gain(pf: float, lvl: int) -> float:
+    """Returns the value multiplier for one additional level in percent."""
+    return (special_multiplier(pf, lvl + 1) / special_multiplier(pf, lvl)) * 100 - 100
+
+
+def special_linear_multiplier(pf: float, lvl: int) -> float:
+    """Return a linear multiplier"""
+    return 1 + pf * lvl
+
+
+def special_linear_multiplier_gain(pf: float, lvl: int) -> float:
+    """Returns the value multiplier for one additional level in percent."""
+    return (special_linear_multiplier(pf, lvl + 1) / special_linear_multiplier(pf, lvl)) * 100 - 100
+
+
 def research_prevalence(technology_name: ProjectType, level: int) -> int:
     """
     Return the number of players that have researched the technology at the given level.
@@ -185,17 +200,13 @@ def power_production_multiplier(player: Player, facility_type: PowerFacilityType
     return mlt
 
 
-def power_consumption_multiplier(player: Player, facility_type: ExtractionFacilityType) -> float:
+def power_consumption_multiplier(player: Player, extraction_facility_type: ExtractionFacilityType) -> float:
     """Return by how much an extraction facility's `base_power_consumption` should be multiplied."""
     const_config = engine.const_config["assets"]
-    mlt = 1
-    # Mineral extraction (in this case it is the energy consumption)
-    if facility_type in const_config["mineral_extraction"]["affected_facilities"]:
-        mlt += (
-            const_config["mineral_extraction"]["energy_factor"]
-            * player.technology_lvl[TechnologyType.MINERAL_EXTRACTION]
-        )
-    return mlt
+    return special_linear_multiplier(
+        const_config["mineral_extraction"]["energy_factor"],
+        player.technology_lvl[TechnologyType.MINERAL_EXTRACTION],
+    )
 
 
 def capacity_multiplier(player: Player, storage_facility_type: StorageFacilityType) -> float:
@@ -220,7 +231,10 @@ def extraction_rate_multiplier(player: Player, *, mineral_extraction_level: int 
     if mineral_extraction_level is None:
         mineral_extraction_level = player.technology_lvl[TechnologyType.MINERAL_EXTRACTION]
     const_config = engine.const_config["assets"]
-    return 1 + const_config["mineral_extraction"]["extract_factor"] * mineral_extraction_level
+    return special_linear_multiplier(
+        const_config["mineral_extraction"]["extract_factor"],
+        mineral_extraction_level,
+    )
 
 
 def hydro_price_multiplier(player: Player, hydro_facility_type: HydroFacilityType) -> float:
@@ -318,11 +332,12 @@ def efficiency_multiplier_for_storage_facilities(
 
 def extraction_emissions_multiplier(player: Player, extraction_facility_type: ExtractionFacilityType) -> float:
     """Return by how much the `facility`'s `base_pollution` should be multiplied."""
+    # TODO(Felix): The if is is redundant no, this function is always called for extraction facilities.
     const_config = engine.const_config["assets"]
     if extraction_facility_type in const_config["mineral_extraction"]["affected_facilities"]:
-        return 1 + (
-            const_config["mineral_extraction"]["pollution_factor"]
-            * player.technology_lvl[TechnologyType.MINERAL_EXTRACTION]
+        return special_linear_multiplier(
+            const_config["mineral_extraction"]["pollution_factor"],
+            player.technology_lvl[TechnologyType.MINERAL_EXTRACTION],
         )
     return 1
 
@@ -935,8 +950,14 @@ def package_available_technologies(player: Player) -> list[dict]:
         )
         | (
             {
-                "power_generation_bonus": const_config_assets[technology]["prod_factor"] * 100 - 100,
-                "price_penalty": (const_config_assets[technology]["price_factor"] * 100 - 100),
+                "power_generation_bonus": special_multiplier_gain(
+                    const_config_assets[technology]["prod_factor"],
+                    levels[technology],
+                ),
+                "price_penalty": special_multiplier_gain(
+                    const_config_assets[technology]["price_factor"],
+                    levels[technology],
+                ),
             }
             if technology == TechnologyType.MECHANICAL_ENGINEERING
             else {}
@@ -968,10 +989,16 @@ def package_available_technologies(player: Player) -> list[dict]:
         )
         | (
             {
-                "price_penalty": (const_config_assets[technology]["price_factor"] * 100 - 100),
-                "power_generation_bonus": const_config_assets[technology]["prod_factor"] * 100 - 100,
+                "price_penalty": special_multiplier_gain(
+                    const_config_assets[technology]["price_factor"],
+                    levels[technology],
+                ),
+                "power_generation_bonus": special_multiplier_gain(
+                    const_config_assets[technology]["prod_factor"],
+                    levels[technology],
+                ),
             }
-            if technology == "physics"
+            if technology == TechnologyType.PHYSICS
             else {}
         )
         | (
@@ -991,13 +1018,18 @@ def package_available_technologies(player: Player) -> list[dict]:
                 * extraction_rate_multiplier(player, mineral_extraction_level=levels[technology])
                 / extraction_rate_multiplier(player, mineral_extraction_level=levels[technology] - 1)
                 - 100,
-                "power_consumption_penalty": 100
-                * const_config_assets[technology]["energy_factor"]
-                / (1 + const_config_assets[technology]["energy_factor"] * (levels[technology] - 1)),
-                "co2_emissions_penalty": 100
-                * const_config_assets[technology]["pollution_factor"]
-                / (1 + const_config_assets[technology]["pollution_factor"] * (levels[technology] - 1)),
-                "price_penalty": (const_config_assets[technology]["price_factor"] * 100 - 100),
+                "power_consumption_penalty": special_linear_multiplier_gain(
+                    const_config_assets[technology]["energy_factor"],
+                    levels[technology],
+                ),
+                "co2_emissions_penalty": special_linear_multiplier_gain(
+                    const_config_assets[technology]["pollution_factor"],
+                    levels[technology],
+                ),
+                "price_penalty": special_linear_multiplier_gain(
+                    const_config_assets[technology]["price_factor"],
+                    levels[technology],
+                ),
             }
             if technology == TechnologyType.MINERAL_EXTRACTION
             else {}
@@ -1025,17 +1057,32 @@ def package_available_technologies(player: Player) -> list[dict]:
         )
         | (
             {
-                "storage_capacity_bonus": const_config_assets[technology]["capacity_factor"] * 100 - 100,
-                "power_generation_bonus": const_config_assets[technology]["prod_factor"] * 100 - 100,
-                "price_penalty": (const_config_assets[technology]["price_factor"] * 100 - 100),
+                "storage_capacity_bonus": special_multiplier_gain(
+                    const_config_assets[technology]["capacity_factor"],
+                    levels[technology],
+                ),
+                "power_generation_bonus": special_multiplier_gain(
+                    const_config_assets[technology]["prod_factor"],
+                    levels[technology],
+                ),
+                "price_penalty": special_multiplier_gain(
+                    const_config_assets[technology]["price_factor"],
+                    levels[technology],
+                ),
             }
             if technology == TechnologyType.CIVIL_ENGINEERING
             else {}
         )
         | (
             {
-                "power_generation_bonus": const_config_assets[technology]["prod_factor"] * 100 - 100,
-                "price_penalty": (const_config_assets[technology]["price_factor"] * 100 - 100),
+                "power_generation_bonus": special_multiplier_gain(
+                    const_config_assets[technology]["prod_factor"],
+                    levels[technology],
+                ),
+                "price_penalty": special_multiplier_gain(
+                    const_config_assets[technology]["price_factor"],
+                    levels[technology],
+                ),
             }
             if technology == TechnologyType.AERODYNAMICS
             else {}
@@ -1075,15 +1122,24 @@ def package_available_technologies(player: Player) -> list[dict]:
                     )
                 )
                 * 100,
-                "price_penalty": (const_config_assets[technology]["price_factor"] * 100 - 100),
+                "price_penalty": special_multiplier_gain(
+                    const_config_assets[technology]["price_factor"],
+                    levels[technology],
+                ),
             }
             if technology == TechnologyType.CHEMISTRY
             else {}
         )
         | (
             {
-                "power_generation_bonus": const_config_assets[technology]["prod_factor"] * 100 - 100,
-                "price_penalty": (const_config_assets[technology]["price_factor"] * 100 - 100),
+                "power_generation_bonus": special_multiplier_gain(
+                    const_config_assets[technology]["prod_factor"],
+                    levels[technology],
+                ),
+                "price_penalty": special_multiplier_gain(
+                    const_config_assets[technology]["price_factor"],
+                    levels[technology],
+                ),
             }
             if technology == TechnologyType.NUCLEAR_ENGINEERING
             else {}

--- a/energetica/templates/assets/technologies.jinja
+++ b/energetica/templates/assets/technologies.jinja
@@ -245,16 +245,12 @@
                   lvl {{ technology_data.level-1 }} -> lvl {{ technology_data.level }}
                 </th>
               </tr>
-              {% macro render_effect_row(label, data_key, sign="+", precision=0, suffix="%", hover_info="", round_value=True) %}
+              {% macro render_effect_row(label, data_key, sign="+", precision=1, suffix="%", hover_info="") %}
                 {% if data_key in technology_data %}
                   <tr>
                     <td>{{ label | safe }}</td>
                     <td id="{{data_key}}" class="txt_center{% if hover_info %} hover_info{% endif %}">
-                      {% if round_value %}
-                        {{ sign }}{{ technology_data[data_key] | round(precision) }}{{ suffix }}
-                      {% else %}
-                        {{ sign }}{{ technology_data[data_key] }}{{ suffix }}
-                      {% endif %}
+                      {{ sign }}{{ technology_data[data_key] | round(precision) }}{{ suffix }}
                       {% if hover_info %}
                         <span class="popup_info small">{{ hover_info }}</span>
                       {% endif %}
@@ -264,9 +260,9 @@
               {% endmacro %}
               {{ render_effect_row('Power generation', 'power_generation_bonus') }}
               {{ render_effect_row('Extraction speed', 'extraction_speed_bonus') }}
-              {{ render_effect_row("Fuel use", "fuel_use_reduction_bonus", sign="-", precision=1) }}
-              {{ render_effect_row("CO<sub>2</sub> emissions", "co2_emissions_reduction_bonus", sign="-", precision=1) }}
-              {{ render_effect_row("Effic. molten salt", "molten_salt_efficiency_bonus", suffix="pp", precision=1, hover_info="percentage point") }}
+              {{ render_effect_row("Fuel use", "fuel_use_reduction_bonus", sign="-") }}
+              {{ render_effect_row("CO<sub>2</sub> emissions", "co2_emissions_reduction_bonus", sign="-") }}
+              {{ render_effect_row("Effic. molten salt", "molten_salt_efficiency_bonus", suffix="pp", hover_info="percentage point") }}
               {{ render_effect_row("Construction time", "construction_time_reduction_bonus", sign="-") }}
               {% if "construction_workers" in technology_data %}
                 <tr id="construction_workers_tr" {% if technology_data.construction_workers is none %}style="display:none"{% endif %}>


### PR DESCRIPTION
this PR fixes the display of the upgrade data seen on the technology page. That has been forgotten after the implementation of the special_multiplier to make the progression less exponential.

Note: I am not happy with the way the upgrade system works but this should be changes in the context of a broader discussion about the games values.