### PR TITLE
fix: only dumping energy at a price of -5 and preventing players to set -5 as a price

### DIFF
--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -508,8 +508,8 @@ def market_logic(new_values: dict, market: dict) -> None:
             sold_cap = row.capacity - row.cumul_capacities + market_quantity
             if sold_cap > 0.1:
                 sell(row, market_price, quantity=sold_cap)
-            # dumping electricity that is offered for negative price and not sold
-            if row.price < 0:
+            # dumping electricity that is offered at the minimal price and not sold
+            if row.price <= -5:
                 dump_cap = max(0.0, min(row.capacity, row.capacity - sold_cap))
                 player = Player.get(row.player_id)
                 assert player is not None

--- a/energetica/schemas/networks.py
+++ b/energetica/schemas/networks.py
@@ -57,12 +57,12 @@ class ChangeNetworkPrices(BaseModel):
 
 class Ask(BaseModel):
     type: AskType
-    price: float = Field(ge=-5)
+    price: float = Field(gt=-5)
 
 
 class Bid(BaseModel):
     type: BidType
-    price: float = Field(ge=-5)
+    price: float = Field(gt=-5)
 
 
 # TODO(mglst): The following class definitions shouldn't be placed here - this temporarily resolves a circular import


### PR DESCRIPTION
This should fix the issue #455 by dumping only energy with a price set to -5 and not <0
Additionally I prevented players to set a price of -5 since that could also lead to dumping.