### PR TITLE
fix: fetch relevant data to prevent choosing a location clash (#486)

### DIFF
--- a/energetica/static/map_selection.js
+++ b/energetica/static/map_selection.js
@@ -568,6 +568,7 @@ function settleLocation(locationId) {
                 response.json().then((body) => {
                     if (catchGameErrors(response, body)) {
                         setTimeout(function () {
+                            retrieve_all()
                             location.reload();
                         }, 1000);
                         return;


### PR DESCRIPTION
fix #486