### PR TITLE
refactor: better name for market chart endpoint

### DIFF
--- a/energetica/routers/charts.py
+++ b/energetica/routers/charts.py
@@ -507,8 +507,8 @@ def get_resources(
     return ResourcesResponse(resolution=resolution, **data)
 
 
-@router.get("/markets/{market_id}/network_data/{resolution}")
-def get_network_data(
+@router.get("/markets/{market_id}/clearing/{resolution}")
+def get_network_clearing(
     market_id: int,
     resolution: Resolution,
     start_tick: int,

--- a/frontend/src/components/charts/market-clearing-volume-chart.tsx
+++ b/frontend/src/components/charts/market-clearing-volume-chart.tsx
@@ -34,7 +34,7 @@ function useMarketClearingData(
     // Determine which chart type to use for breakdown
     const chartType: ChartType = useMemo(() => {
         if (!breakdownEnabled) {
-            return "market-clearing-data"; // Use market-clearing-data for clearing volume
+            return "market-clearing"; // Use market-clearing for clearing volume
         } else if (breakdownType === "supply") {
             return breakdownMode === "player"
                 ? "market-exports"
@@ -93,7 +93,7 @@ export function MarketClearingVolumeChart({
     const chartConfig: TimeSeriesChartConfig = useMemo(
         () => ({
             chartType,
-            chartVariant: "bar",
+            chartVariant: "area",
             stacked: breakdownEnabled,
             showBrush: true,
             getColor: !breakdownEnabled

--- a/frontend/src/components/charts/market-price-chart.tsx
+++ b/frontend/src/components/charts/market-price-chart.tsx
@@ -21,7 +21,7 @@ export function MarketPriceChart({
 
     // Fetch chart data for network-data
     const { chartData, isLoading, isError } = useCurrentChartData({
-        chartType: "market-clearing-data",
+        chartType: "market-clearing",
         currentTick,
         resolution: selectedResolution.resolution,
         maxDatapoints: selectedResolution.datapoints,
@@ -38,7 +38,7 @@ export function MarketPriceChart({
 
     const chartConfig: TimeSeriesChartConfig = useMemo(
         () => ({
-            chartType: "market-clearing-data",
+            chartType: "market-clearing",
             chartVariant: "line",
             stacked: false,
             showBrush: true,

--- a/frontend/src/hooks/useCharts.ts
+++ b/frontend/src/hooks/useCharts.ts
@@ -403,7 +403,7 @@ const QUERY_KEY_FN_BY_CHART_TYPE = {
     climate: queryKeys.charts.climate,
     temperature: queryKeys.charts.temperature,
     resources: queryKeys.charts.resources,
-    "market-clearing-data": queryKeys.charts.marketClearingData,
+    "market-clearing": queryKeys.charts.marketClearingData,
     "market-exports": queryKeys.charts.marketExports,
     "market-imports": queryKeys.charts.marketImports,
     "market-generation": queryKeys.charts.marketGeneration,
@@ -411,7 +411,7 @@ const QUERY_KEY_FN_BY_CHART_TYPE = {
 } as const;
 
 const MARKET_CHART_TYPES: ChartType[] = [
-    "market-clearing-data",
+    "market-clearing",
     "market-exports",
     "market-imports",
     "market-generation",
@@ -421,7 +421,7 @@ const MARKET_CHART_TYPES: ChartType[] = [
 /** Extract the sub-type from a market chart type for query key construction */
 function getMarketChartSubType(chartType: ChartType): string {
     const mapping = {
-        "market-clearing-data": "clearing-data",
+        "market-clearing": "clearing-data",
         "market-exports": "exports",
         "market-imports": "imports",
         "market-generation": "generation",
@@ -464,7 +464,7 @@ function useFetchChartGaps({
                         chartsApi.getMarketChartData({
                             marketId,
                             chartType: chartType as
-                                | "market-clearing-data"
+                                | "market-clearing"
                                 | "market-exports"
                                 | "market-imports"
                                 | "market-generation"

--- a/frontend/src/lib/api/charts.ts
+++ b/frontend/src/lib/api/charts.ts
@@ -13,7 +13,7 @@ interface ChartParams {
 interface MarketChartParams {
     marketId: number;
     chartType:
-        | "market-clearing-data"
+        | "market-clearing"
         | "market-exports"
         | "market-imports"
         | "market-generation"
@@ -42,7 +42,7 @@ export const chartsApi = {
     }: MarketChartParams) => {
         // Map frontend chart type to backend endpoint
         const endpointMap = {
-            "market-clearing-data": "network_data",
+            "market-clearing": "clearing",
             "market-exports": "exports",
             "market-imports": "imports",
             "market-generation": "generation",
@@ -51,7 +51,7 @@ export const chartsApi = {
         const endpoint = endpointMap[chartType];
         const response = await apiClient.get<
             ApiResponse<
-                | "/api/v1/charts/markets/{market_id}/network_data/{resolution}"
+                | "/api/v1/charts/markets/{market_id}/clearing/{resolution}"
                 | "/api/v1/charts/markets/{market_id}/exports/{resolution}"
                 | "/api/v1/charts/markets/{market_id}/imports/{resolution}"
                 | "/api/v1/charts/markets/{market_id}/generation/{resolution}"

--- a/frontend/src/lib/charts/chart-key-order.ts
+++ b/frontend/src/lib/charts/chart-key-order.ts
@@ -167,7 +167,7 @@ export type ChartDataKeys = {
     climate: (typeof CLIMATE_KEYS)[number];
     temperature: (typeof TEMPERATURE_KEYS)[number];
     resources: (typeof RESOURCES_KEYS)[number];
-    "market-clearing-data": (typeof MARKET_CLEARING_DATA_KEYS)[number];
+    "market-clearing": (typeof MARKET_CLEARING_DATA_KEYS)[number];
     "market-exports": string; // Dynamic player IDs
     "market-imports": string; // Dynamic player IDs
     "market-generation": (typeof MARKET_GENERATION_KEYS)[number];
@@ -179,8 +179,8 @@ export type ChartDataKeys = {
  * tick number and values for each of its specific keys.
  *
  * @example
- *     // For market-clearing-data chart type:
- *     ChartDataPoint<"market-clearing-data"> = { tick: number; price: number; quantity: number }
+ *     // For market-clearing chart type:
+ *     ChartDataPoint<"market-clearing"> = { tick: number; price: number; quantity: number }
  */
 export type ChartDataPoint<T extends ChartType> = {
     tick: number;
@@ -197,7 +197,7 @@ export const KEY_ORDER_BY_CHART_TYPE: Record<ChartType, readonly string[]> = {
     climate: CLIMATE_KEYS,
     temperature: TEMPERATURE_KEYS,
     resources: RESOURCES_KEYS,
-    "market-clearing-data": MARKET_CLEARING_DATA_KEYS,
+    "market-clearing": MARKET_CLEARING_DATA_KEYS,
     "market-exports": MARKET_EXPORTS_KEYS,
     "market-imports": MARKET_IMPORTS_KEYS,
     "market-generation": MARKET_GENERATION_KEYS,

--- a/frontend/src/routes/app/community/electricity-markets.tsx
+++ b/frontend/src/routes/app/community/electricity-markets.tsx
@@ -127,7 +127,7 @@ function ElectricityMarketsContent() {
 
     // Fetch market data for selected market
     const { data: selectedMarketData } = useLatestChartData({
-        chartType: "market-clearing-data",
+        chartType: "market-clearing",
         marketId: selectedMarket?.id ?? 0,
     });
 

--- a/frontend/src/routes/app/overviews/electricity-markets.tsx
+++ b/frontend/src/routes/app/overviews/electricity-markets.tsx
@@ -146,7 +146,7 @@ function MarketsOverviewContent() {
     // Fetch latest data for real-time display
     const { data: latestData, isLoading: isLatestLoading } = useLatestChartData(
         {
-            chartType: "market-clearing-data",
+            chartType: "market-clearing",
             marketId: selectedMarketId,
         },
     );

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -431,7 +431,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/charts/markets/{market_id}/network_data/{resolution}": {
+    "/api/v1/charts/markets/{market_id}/clearing/{resolution}": {
         parameters: {
             query?: never;
             header?: never;
@@ -439,7 +439,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Network Data
+         * Get Network Clearing
          *
          * Get network price and quantity time series at the specified
          * resolution.
@@ -452,7 +452,7 @@ export interface paths {
          *         start_tick: First tick to include (must be aligned to resolution)
          *         count: Number of datapoints to retrieve
          */
-        get: operations["get_network_data_api_v1_charts_markets__market_id__network_data__resolution__get"];
+        get: operations["get_network_clearing_api_v1_charts_markets__market_id__clearing__resolution__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5287,7 +5287,7 @@ export interface operations {
             };
         };
     };
-    get_network_data_api_v1_charts_markets__market_id__network_data__resolution__get: {
+    get_network_clearing_api_v1_charts_markets__market_id__clearing__resolution__get: {
         parameters: {
             query: {
                 start_tick: number;

--- a/frontend/src/types/charts.ts
+++ b/frontend/src/types/charts.ts
@@ -10,7 +10,7 @@ export type ChartType =
     | "climate"
     | "temperature"
     | "resources"
-    | "market-clearing-data"
+    | "market-clearing"
     | "market-exports"
     | "market-imports"
     | "market-generation"


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors the market chart endpoint naming to be more concise and descriptive. The backend endpoint was renamed from `/markets/{market_id}/network_data/{resolution}` to `/markets/{market_id}/clearing/{resolution}`, and the frontend chart type was changed from `market-clearing-data` to `market-clearing`.

**Key Changes:**
- Backend: Renamed endpoint and handler function `get_network_data` → `get_network_clearing`
- Frontend: Updated chart type `market-clearing-data` → `market-clearing` across all components, hooks, and type definitions
- API mapping: Updated endpoint mapping from `network_data` to `clearing`
- Generated types updated to reflect the new API endpoint

**Minor Note:**
- The chart variant was changed from `"bar"` to `"area"` in `market-clearing-volume-chart.tsx`, which appears unrelated to the endpoint refactoring

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring is straightforward and systematic, with consistent renaming across the entire codebase. All references to the old endpoint name have been properly updated, and the changes maintain backward compatibility at the API level (same data structure). The only minor concern is the unrelated chartVariant change, which is a UI-only modification with no functional impact.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| energetica/routers/charts.py | Renamed endpoint from `/markets/{market_id}/network_data/{resolution}` to `/markets/{market_id}/clearing/{resolution}` and function from `get_network_data` to `get_network_clearing` |
| frontend/src/components/charts/market-clearing-volume-chart.tsx | Updated chart type from `market-clearing-data` to `market-clearing` and changed chart variant from `bar` to `area` |
| frontend/src/hooks/useCharts.ts | Updated chart type from `market-clearing-data` to `market-clearing` in query keys, type arrays, and API calls |
| frontend/src/lib/api/charts.ts | Updated endpoint mapping from `network_data` to `clearing` and chart type from `market-clearing-data` to `market-clearing` |
| frontend/src/types/charts.ts | Updated ChartType union to use `market-clearing` instead of `market-clearing-data` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Component as Chart Component
    participant Hook as useCurrentChartData
    participant API as chartsApi
    participant Backend as FastAPI Router
    participant DB as Database

    Component->>Hook: Request market-clearing data
    Note over Component,Hook: chartType: "market-clearing"
    Hook->>API: getMarketChartData()
    Note over Hook,API: Maps "market-clearing" to endpoint
    API->>API: Map chartType to endpoint
    Note over API: "market-clearing" → "clearing"
    API->>Backend: GET /api/v1/charts/markets/{market_id}/clearing/{resolution}
    Note over API,Backend: params: start_tick, count
    Backend->>Backend: get_network_clearing()
    Backend->>DB: Query market clearing data
    DB-->>Backend: Return price & quantity data
    Backend-->>API: MarketClearingDataResponse
    API-->>Hook: Chart data with tick, price, quantity
    Hook-->>Component: Formatted chartData
    Component->>Component: Render chart
    Note over Component: Display as area/line chart
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->