### PR TITLE
fix: invalidate market queries

### DIFF
--- a/energetica/utils/network_helpers.py
+++ b/energetica/utils/network_helpers.py
@@ -21,6 +21,10 @@ def join_network(player: Player, network: Network | None) -> Network:
     network.members.append(player)
     network.capacities.update_network(network)
     engine.log(f"{player.username} joined the network {network.name}")
+
+    # Invalidate electricity markets list for all players (membership changed)
+    engine.invalidate_queries(["electricity-markets"])
+
     return network
 
 
@@ -39,6 +43,10 @@ def create_network(player: Player, name: str) -> Network:
     new_network = Network(name=name, members=[player], created_tick=engine.total_t)
     player.network = new_network
     engine.log(f"{player.username} created the network {name}")
+
+    # Invalidate electricity markets list for all players (new market created)
+    engine.invalidate_queries(["electricity-markets"])
+
     return new_network
 
 
@@ -50,9 +58,14 @@ def leave_network(player: Player) -> Network | None:
     player.network = None
     network.members.remove(player)
     engine.log(f"{player.username} left the network {network.name}")
+
+    # Invalidate electricity markets list for all players (membership changed)
+    engine.invalidate_queries(["electricity-markets"])
+
     # delete network if it is empty
     if not network.members:
         engine.log(f"The network {network.name} has been deleted because it was empty")
         network.delete()
         return None
+
     return network

--- a/frontend/src/hooks/useElectricityMarkets.ts
+++ b/frontend/src/hooks/useElectricityMarkets.ts
@@ -33,10 +33,6 @@ export function useJoinElectricityMarket() {
             queryClient.invalidateQueries({
                 queryKey: queryKeys.electricityMarkets.all,
             });
-            // Invalidate network data since player is now in a network
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.network.all,
-            });
         },
     });
 }
@@ -52,10 +48,6 @@ export function useLeaveElectricityMarket() {
             queryClient.invalidateQueries({
                 queryKey: queryKeys.electricityMarkets.all,
             });
-            // Invalidate network data since player is no longer in a network
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.network.all,
-            });
         },
     });
 }
@@ -70,10 +62,6 @@ export function useCreateElectricityMarket() {
             // Invalidate the list of electricity markets to show the new market
             queryClient.invalidateQueries({
                 queryKey: queryKeys.electricityMarkets.all,
-            });
-            // Invalidate network data since a new network was created
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.network.all,
             });
         },
     });

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -202,10 +202,6 @@ export const queryKeys = {
         marketOrderData: (marketId: number, tick: number) =>
             ["charts", "markets", marketId, "orders", tick] as const,
     },
-    network: {
-        all: ["networks"] as const,
-        capacities: ["networks", "capacities"] as const,
-    },
     powerPriorities: {
         all: ["power-priorities"] as const,
     },


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors cache invalidation for electricity markets by moving invalidation logic from the frontend to the backend.

**Key Changes:**
- Backend (`network_helpers.py`) now calls `engine.invalidate_queries(["electricity-markets"])` after network membership changes
- Frontend hooks removed redundant `queryKeys.network.all` invalidations that were no longer needed
- Removed unused `network` query keys from `query-client.ts` (cleanup)

**How It Works:**
The backend now broadcasts invalidation events via Socket.IO to all connected clients when network membership changes. This ensures all players see updated market lists, not just the player who made the change. The frontend's `GameTickProvider` listens for these events and invalidates the appropriate queries.

**Benefits:**
- Centralized invalidation logic on the backend
- All players receive real-time updates (not just the acting player)
- Removed dead code (`network` query keys were unused after renaming to `electricity-markets`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes follow established patterns in the codebase, properly implement backend-driven cache invalidation, and remove unused code. All invalidation calls match the query key structure defined in `query-client.ts`.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| energetica/utils/network_helpers.py | Added backend-driven query invalidation for `electricity-markets` in join, create, and leave network operations |
| frontend/src/hooks/useElectricityMarkets.ts | Removed redundant frontend invalidation for unused `network` queries in join, leave, and create mutations |
| frontend/src/lib/query-client.ts | Removed unused `network` query keys that are no longer referenced anywhere |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Player
    participant Backend
    participant SocketIO
    participant Frontend
    participant QueryClient

    Note over Player,QueryClient: Player Joins/Leaves/Creates Electricity Market

    Player->>Backend: Join/Leave/Create Network
    Backend->>Backend: Update network membership
    Backend->>Backend: engine.invalidate_queries(["electricity-markets"])
    Backend->>SocketIO: emit("invalidate", {queries: [["electricity-markets"]]})
    SocketIO->>Frontend: broadcast invalidate event
    Frontend->>QueryClient: invalidateQueries({queryKey: ["electricity-markets"]})
    QueryClient->>QueryClient: Mark query as stale
    
    Note over Frontend,QueryClient: If query is actively observed
    QueryClient->>Backend: Refetch electricity markets
    Backend->>QueryClient: Return updated market list
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->