### PR TITLE
Fix/522/wiki-redirect

### DIFF
--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as AppLogoutRouteImport } from './routes/app/logout'
 import { Route as AppLoginRouteImport } from './routes/app/login'
 import { Route as AppDashboardRouteImport } from './routes/app/dashboard'
 import { Route as AppChangelogRouteImport } from './routes/app/changelog'
+import { Route as AppWikiIndexRouteImport } from './routes/app/wiki/index'
 import { Route as AppWikiSlugRouteImport } from './routes/app/wiki/$slug'
 import { Route as AppOverviewsStorageRouteImport } from './routes/app/overviews/storage'
 import { Route as AppOverviewsResourcesRouteImport } from './routes/app/overviews/resources'
@@ -101,6 +102,11 @@ const AppDashboardRoute = AppDashboardRouteImport.update({
 const AppChangelogRoute = AppChangelogRouteImport.update({
   id: '/app/changelog',
   path: '/app/changelog',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AppWikiIndexRoute = AppWikiIndexRouteImport.update({
+  id: '/app/wiki/',
+  path: '/app/wiki/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AppWikiSlugRoute = AppWikiSlugRouteImport.update({
@@ -247,6 +253,7 @@ export interface FileRoutesByFullPath {
   '/app/overviews/resources': typeof AppOverviewsResourcesRoute
   '/app/overviews/storage': typeof AppOverviewsStorageRoute
   '/app/wiki/$slug': typeof AppWikiSlugRoute
+  '/app/wiki': typeof AppWikiIndexRoute
 }
 export interface FileRoutesByTo {
   '/about': typeof AboutRoute
@@ -281,6 +288,7 @@ export interface FileRoutesByTo {
   '/app/overviews/resources': typeof AppOverviewsResourcesRoute
   '/app/overviews/storage': typeof AppOverviewsStorageRoute
   '/app/wiki/$slug': typeof AppWikiSlugRoute
+  '/app/wiki': typeof AppWikiIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -317,6 +325,7 @@ export interface FileRoutesById {
   '/app/overviews/resources': typeof AppOverviewsResourcesRoute
   '/app/overviews/storage': typeof AppOverviewsStorageRoute
   '/app/wiki/$slug': typeof AppWikiSlugRoute
+  '/app/wiki/': typeof AppWikiIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -353,6 +362,7 @@ export interface FileRouteTypes {
     | '/app/overviews/resources'
     | '/app/overviews/storage'
     | '/app/wiki/$slug'
+    | '/app/wiki'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/about'
@@ -387,6 +397,7 @@ export interface FileRouteTypes {
     | '/app/overviews/resources'
     | '/app/overviews/storage'
     | '/app/wiki/$slug'
+    | '/app/wiki'
   id:
     | '__root__'
     | '/'
@@ -422,6 +433,7 @@ export interface FileRouteTypes {
     | '/app/overviews/resources'
     | '/app/overviews/storage'
     | '/app/wiki/$slug'
+    | '/app/wiki/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -458,6 +470,7 @@ export interface RootRouteChildren {
   AppOverviewsResourcesRoute: typeof AppOverviewsResourcesRoute
   AppOverviewsStorageRoute: typeof AppOverviewsStorageRoute
   AppWikiSlugRoute: typeof AppWikiSlugRoute
+  AppWikiIndexRoute: typeof AppWikiIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -544,6 +557,13 @@ declare module '@tanstack/react-router' {
       path: '/app/changelog'
       fullPath: '/app/changelog'
       preLoaderRoute: typeof AppChangelogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/app/wiki/': {
+      id: '/app/wiki/'
+      path: '/app/wiki'
+      fullPath: '/app/wiki'
+      preLoaderRoute: typeof AppWikiIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/app/wiki/$slug': {
@@ -730,6 +750,7 @@ const rootRouteChildren: RootRouteChildren = {
   AppOverviewsResourcesRoute: AppOverviewsResourcesRoute,
   AppOverviewsStorageRoute: AppOverviewsStorageRoute,
   AppWikiSlugRoute: AppWikiSlugRoute,
+  AppWikiIndexRoute: AppWikiIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/app/wiki/index.tsx
+++ b/frontend/src/routes/app/wiki/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/app/wiki/")({
+    loader: () => {
+        throw redirect({ to: "/app/wiki/$slug", params: { slug: "introduction" } });
+    },
+    staticData: {
+        title: "Game Wiki",
+    },
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a wiki index route (`/app/wiki/`) that redirects users to the introduction page (`/app/wiki/introduction`), fixing the issue where navigating to `/app/wiki` without a slug would not resolve to any content.

- Added `frontend/src/routes/app/wiki/index.tsx` with a loader-based redirect, following the same pattern used by `app/index.tsx` → `app/dashboard`
- `frontend/src/routeTree.gen.ts` was auto-regenerated by TanStack Router to register the new route

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a straightforward index route redirect with no risk to existing functionality.
- The manually-authored change is a single 10-line file that follows an established pattern already used elsewhere in the codebase (`app/index.tsx`). The redirect target (`introduction.mdx`) exists. The remaining changes are auto-generated by TanStack Router. No logic, security, or style concerns.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/routes/app/wiki/index.tsx | New index route for `/app/wiki/` that redirects to `/app/wiki/$slug` with `slug: "introduction"`. Follows the same pattern used by `app/index.tsx`. The redirect target (`introduction.mdx`) exists in the wiki content. |
| frontend/src/routeTree.gen.ts | Auto-generated route tree file updated by TanStack Router to register the new `/app/wiki/` index route. Changes are consistent with the file's generation pattern. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A["User navigates to /app/wiki"] --> B["wiki/index.tsx loader"]
    B --> C["throw redirect()"]
    C --> D["/app/wiki/$slug\n(slug = 'introduction')"]
    D --> E["$slug.tsx component"]
    E --> F["Renders introduction.mdx\nin WikiLayout"]
```

<sub>Last reviewed commit: 2a11e8c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->