### PR TITLE
build: update package scripts

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -165,7 +165,7 @@ bun dev              # Start dev server (http://localhost:5173)
 bun build            # Build for production
 bun lint       # Check ESLint errors
 bun typecheck        # TypeScript type checking
-bun pretty           # Format code with Prettier
+bun format           # Format code with Prettier
 bun generate-types   # Generate API types from OpenAPI schema
 ```
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,10 @@
         "build": "vite build",
         "generate-types": "bash ../scripts/generate-types.sh",
         "lint": "eslint . --max-warnings 0 --cache",
-        "pretty": "prettier --write \"./**/*.{ts,tsx}\"",
-        "typecheck": "tsc --noEmit"
+        "lint:fix": "eslint . --fix --cache",
+        "format": "prettier --write \"./**/*.{ts,tsx}\"",
+        "typecheck": "tsc --noEmit",
+        "typecheck:watch": "tsc --noEmit --watch"
     },
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,13 @@
         "dev:remote": "cd frontend && VITE_BACKEND_URL=https://energetica-game.org bun run dev",
         "build": "cd frontend && bun run build",
         "lint": "cd frontend && bun run lint",
+        "lint:fix": "cd frontend && bun run lint:fix",
         "typecheck": "cd frontend && bun run typecheck",
-        "pretty": "cd frontend && bun run pretty",
+        "typecheck:watch": "cd frontend && bun run typecheck:watch",
+        "format": "cd frontend && bun run format",
         "generate-types": "cd frontend && bun run generate-types",
+        "ruff:check": ".venv/bin/ruff check energetica/ --fix",
+        "ruff:format": ".venv/bin/ruff format energetica/",
         "backend-test": ".venv/bin/python main.py --rm_instance --run_init_test_players --env dev",
         "check-wiki": ".venv/bin/python scripts/check_wiki_links.py"
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Standardizes package scripts by renaming `pretty` to `format` and adding new convenience scripts for linting and type checking.

Key changes:
- Renamed `pretty` script to `format` across frontend and root package.json, updated documentation accordingly
- Added `lint:fix` and `typecheck:watch` scripts to frontend for improved DX
- Added `ruff:check` and `ruff:format` scripts to root package.json for Python linting/formatting

The script naming is now more consistent with common conventions (`format` vs `pretty`), and the new helper scripts will streamline the development workflow.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor verification needed for ruff script paths
- The changes are straightforward script renames and additions that improve developer experience. Documentation is properly updated. Only concern is the new ruff scripts reference `.venv/bin/ruff` which may not be available unless ruff is explicitly installed in the venv (it's currently only in pre-commit hooks). This should be verified before the scripts are used.
- Verify `package.json` ruff script paths work with your setup

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/getting-started/installation.md | Updated script name from `bun pretty` to `bun format` for consistency |
| frontend/package.json | Renamed `pretty` to `format`, added `lint:fix` and `typecheck:watch` scripts |
| package.json | Added convenience scripts for linting/formatting; ruff scripts may fail if ruff not in venv |

</details>



<sub>Last reviewed commit: f5eed00</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->