### PR TITLE
fix(sidebar): remove relative class breaking fixed positioning

### DIFF
--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -53,7 +53,7 @@ export function AppSidebar({ scrollPosition = 0 }: AppSidebarProps) {
         <Sidebar
             side="left"
             collapsible="offcanvas"
-            className="relative overflow-hidden"
+            className="overflow-hidden"
         >
             {/* Large background logo */}
             <div


### PR DESCRIPTION
## Summary

- `className="relative overflow-hidden"` was passed to `<Sidebar>` in `AppSidebar`
- This prop is forwarded to the `fixed` container div via `cn(..., className)`
- `twMerge` treats `fixed` and `relative` as conflicting position utilities and drops `fixed` in favor of the later `relative`
- Result: the sidebar container was `position: relative` (in flow), so it still occupied 16rem even when visually off-screen — blocking `SidebarInset` from expanding

`fixed` elements already establish a containing block for `absolute` children, so `relative` was redundant. Removing it restores the correct `position: fixed` behavior.

Closes #525

## Test plan

- [ ] Toggle the sidebar — content area should expand to fill the full width
- [ ] Background logo in sidebar still renders and is clipped correctly
- [ ] Sidebar slides in/out smoothly on toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `relative` Tailwind class from the `className` prop passed to `<Sidebar>` in `AppSidebar`, fixing a layout regression where the sidebar was incorrectly positioned in document flow instead of being fixed to the viewport.

**Root cause**: `className` is forwarded to the `sidebar-container` div in `sidebar.tsx` (line 254) via `cn(..., className)`. Because `twMerge` treats `fixed` and `relative` as conflicting position utilities and the passed `className` is appended last, `relative` was winning over the built-in `fixed` class. This made the sidebar occupy 16rem of space even when visually off-screen, preventing `SidebarInset` from expanding to full width.

**Fix correctness**:
- `overflow-hidden` is kept — it's still needed to clip the large rotating background `Logo` element, which is `absolute`-positioned inside the `sidebar-container`.
- `fixed` elements already create a new stacking and containing context for `absolute` children, so `relative` was always redundant.
- On mobile the `className` flows into `SheetContent` (which doesn't rely on `fixed`), so removing `relative` is harmless there too.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-understood one-class removal that restores correct CSS positioning behaviour.
- The change is a single-word deletion with a clear, well-articulated rationale backed by how `twMerge` resolves conflicting Tailwind position utilities. The sidebar source code confirms that `className` is appended last in `cn()`, making the conflict real and the fix correct. No logic, data, or API surface is touched.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/components/layout/app-sidebar.tsx | Removes `relative` from the `Sidebar` className prop; `twMerge` was overriding `fixed` with `relative` on the sidebar container, collapsing it into normal document flow and blocking SidebarInset expansion. The remaining `overflow-hidden` correctly clips the absolute-positioned background logo. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["AppSidebar renders\n&lt;Sidebar className='overflow-hidden'&gt;"]
    B["Sidebar component receives className prop"]
    C{collapsible mode?}
    D["Mobile: SheetContent\nclassName not applied to fixed div"]
    E["Desktop: sidebar-container div\ncn('fixed inset-y-0 z-10 ...', className)"]
    F["twMerge resolves classes:\nfixed + overflow-hidden\n✅ position: fixed"]
    G["Sidebar stays fixed to viewport\nSidebarInset expands to full width ✅"]

    A --> B --> C
    C -- isMobile --> D
    C -- desktop --> E
    E --> F --> G

    style F fill:#d4edda,stroke:#28a745
    style G fill:#d4edda,stroke:#28a745
```

<sub>Last reviewed commit: e0a3bce</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->