### PR TITLE
fix(socket): prevent socket disconnect after player settles

### DIFF
--- a/frontend/src/contexts/socket-context.tsx
+++ b/frontend/src/contexts/socket-context.tsx
@@ -78,10 +78,7 @@ export function SocketProvider({ children }: SocketProviderProps) {
             return;
         }
 
-        console.log(
-            "[Socket.IO] Attempting connection for player",
-            user.is_settled ? "(settled)" : "(unsettled)",
-        );
+        console.log("[Socket.IO] Attempting connection for player");
 
         // Create socket connection
         const newSocket = io();
@@ -138,7 +135,7 @@ export function SocketProvider({ children }: SocketProviderProps) {
                 }
             }, 100);
         };
-    }, [canConnect, isAuthenticated, user?.role, user?.is_settled]);
+    }, [canConnect, isAuthenticated, user?.role]);
 
     const value: SocketContextValue = {
         socket,


### PR DESCRIPTION
user?.is_settled in the effect deps caused a re-run on settle. The new run exited early (socket already connected), then the previous run's cleanup fired 100ms later and disconnected the socket permanently — breaking all tick-driven updates on the dashboard.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a socket disconnect regression triggered when a player settles. Including `user?.is_settled` in the `useEffect` dependency array caused the effect to re-run on settle; the re-run exited early (socket already connected), but the previous run's delayed cleanup (`setTimeout 100ms`) still fired and disconnected the socket permanently, breaking all tick-driven dashboard updates.

Key changes:
- Removes `user?.is_settled` from the `useEffect` dependency array — the socket connection lifecycle is correctly governed only by `canConnect`, `isAuthenticated`, and `user?.role`, none of which change on settle.
- Removes the log line that referenced `user.is_settled`, keeping the log output consistent with the simplified deps.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the fix is minimal, targeted, and correctly removes the spurious dependency that caused the disconnect.
- `user?.is_settled` had no role in the socket connection logic; it was only referenced in a debug log. Removing it from the deps array directly prevents the race between the early-returning re-run and its predecessor's delayed cleanup without touching any other logic.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/contexts/socket-context.tsx | Removes `user?.is_settled` from the `useEffect` dependency array and its associated log message; correctly prevents the socket from being torn down when settle status changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant React
    participant Effect as useEffect (socket)
    participant Socket as Socket.IO

    Note over React,Socket: Before fix — is_settled in deps
    React->>Effect: run (user.is_settled = false)
    Effect->>Socket: io().connect()
    Note right of Effect: cleanup registered
    React->>Effect: re-run (user.is_settled → true)
    Effect->>Effect: early return (already connected)
    Note right of Effect: new cleanup registered
    Effect-->>Socket: setTimeout 100ms fires (old cleanup)
    Socket--xSocket: disconnect() 💥

    Note over React,Socket: After fix — is_settled removed from deps
    React->>Effect: run (initial mount)
    Effect->>Socket: io().connect()
    Note right of Effect: cleanup registered
    React->>Effect: settle event (is_settled changes)
    Note right of Effect: no re-run — deps unchanged ✓
    Socket->>Socket: stays connected ✅
```

<sub>Reviews (1): Last reviewed commit: ["fix(socket): prevent socket disconnect a..."](https://github.com/felixvonsamson/energetica/commit/43070e29646bcfd994d8de4e9c944fc88568f508) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26354573)</sub>

<!-- /greptile_comment -->