### PR TITLE
fix: text wrapping in in-game chat

### DIFF
--- a/frontend/src/components/chat/message-container.tsx
+++ b/frontend/src/components/chat/message-container.tsx
@@ -137,7 +137,7 @@ export function MessageContainer({
                                 <div
                                     key={message.id}
                                     className={cn(
-                                        "p-3 rounded-lg wrap-break-word max-w-[70%] whitespace-pre-line",
+                                        "p-3 rounded-lg break-words max-w-[70%] whitespace-pre-line",
                                         isOwnMessage
                                             ? "bg-primary text-primary-foreground rounded-br-none"
                                             : "bg-secondary text-secondary-foreground rounded-bl-none",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to fix text wrapping in the in-game chat by making two types of changes to `message-container.tsx`:

1. **`w-full` additions (correct fix):** Adds `w-full` to both the outer message-group `div` and the inner messages `div`. Without a fixed width on these `flex flex-col` containers, the `items-end`/`items-start` alignment doesn't push bubbles to the correct edge, and `max-w-[70%]` on each bubble is computed relative to a content-sized container, which can prevent proper wrapping.

2. **Class rename (`wrap-break-word` → `break-words`) — potential regression:** The project is on Tailwind CSS v4.1, where `wrap-break-word` is the canonical utility for `overflow-wrap: break-word` (introduced/formalised in v4.1). The v3 utility `break-words` was renamed to `wrap-break-word` in v4 and may not generate any CSS in the v4.1 JIT engine. Reverting to `wrap-break-word` is needed to keep text-wrapping functional.

<h3>Confidence Score: 3/5</h3>

The `w-full` alignment fix is safe, but the `wrap-break-word` → `break-words` rename likely undoes the text-wrapping fix in a Tailwind v4 project.

The core layout fix is correct, but the class name change on line 140 risks removing `overflow-wrap: break-word` from message bubbles entirely under Tailwind v4.1, which would mean long words/URLs remain unwrapped — directly contradicting the PR's stated goal. One targeted fix (revert that single class name) would bring this to a clean merge.

frontend/src/components/chat/message-container.tsx — specifically line 140 where `break-words` should be reverted to `wrap-break-word`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/components/chat/message-container.tsx | Adds `w-full` to flex containers to fix message alignment (correct fix), but also swaps the Tailwind v4-canonical `wrap-break-word` for the v3-era `break-words`, which may no longer generate any CSS in v4.1 and would break text wrapping in message bubbles. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MessageContainer renders message groups"] --> B["Outer group div\nw-full flex flex-col\nitems-end / items-start"]
    B --> C["Timestamp + player name header"]
    B --> D["Inner messages div\nw-full flex flex-col\nitems-end / items-start"]
    D --> E["Individual message bubble\np-3 rounded-lg\nmax-w-[70%]\nwhitespace-pre-line\n⚠️ break-words (v3) vs wrap-break-word (v4)"]
    E -->|own message| F["bg-primary, rounded-br-none"]
    E -->|other message| G["bg-secondary, rounded-bl-none"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `frontend/src/components/chat/message-container.tsx`, line 140 ([link](https://github.com/felixvonsamson/energetica/blob/82c0e747645a2ab3357164f9b233082580ee83f1/frontend/src/components/chat/message-container.tsx#L140)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Non-standard Tailwind class `wrap-break-word`**

   `wrap-break-word` is not a standard Tailwind CSS utility class and will have no effect. Since this PR is addressing text wrapping issues, the correct Tailwind class for word-break overflow is `break-words` (which maps to `overflow-wrap: break-word`). Without it, long unbroken strings (e.g. URLs, long words) could still overflow the `max-w-[70%]` bubble.

2. `frontend/src/components/chat/message-container.tsx`, line 140 ([link](https://github.com/felixvonsamson/energetica/blob/910ae8dae8b60a47f2a4c6a117cceaed9eba03a0/frontend/src/components/chat/message-container.tsx#L140)) 

   **Replacing v4 class with removed v3 alias**

   This project uses Tailwind CSS v4.1 (`tailwindcss: ^4.1.12`). In Tailwind v4.1, `overflow-wrap: break-word` was introduced as `wrap-break-word` — this is precisely the class the code had *before* this PR. The v3 utility `break-words` was renamed to `wrap-break-word` in v4.1.

   Changing `wrap-break-word` → `break-words` means the message bubble likely generates **no `overflow-wrap` CSS at all** in the v4 JIT engine, since `break-words` is no longer a recognised utility. This would leave long words/URLs unwrapped in the bubble, defeating the stated purpose of the PR.

   The `w-full` additions on the parent containers are the real alignment fix and look correct. This class name change appears to be an accidental regression. Revert it to `wrap-break-word`:

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: tailwind class"](https://github.com/felixvonsamson/energetica/commit/910ae8dae8b60a47f2a4c6a117cceaed9eba03a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26463336)</sub>

<!-- /greptile_comment -->