### PR TITLE
refactor: reword chat disclaimer

### DIFF
--- a/frontend/src/components/chat/chat-disclaimer-dialog.tsx
+++ b/frontend/src/components/chat/chat-disclaimer-dialog.tsx
@@ -3,6 +3,7 @@ import {
     Dialog,
     DialogClose,
     DialogContent,
+    DialogDescription,
     DialogFooter,
     DialogHeader,
     DialogTitle,
@@ -22,6 +23,9 @@ export function ChatDisclaimerDialog({
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>Chat Disclaimer</DialogTitle>
+                    <DialogDescription className="sr-only">
+                        Important information about in-game chat usage.
+                    </DialogDescription>
                 </DialogHeader>
                 <ul className="list-disc pl-5 space-y-1 text-sm">
                     <li>The in-game chat is not censored</li>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the chat disclaimer dialog to improve clarity: the body text is converted from a prose paragraph into a concise bullet list, a redundant `DialogDescription` subtitle is removed, and the confirmation button label is changed from "OK" to "I understand".

Key changes:
- Replaces the single-paragraph disclaimer with a two-item `<ul>` list for better scannability
- Removes the `DialogDescription` component and its import (minor accessibility note — see inline comment)
- Updates the dismiss button text to "I understand" for stronger acknowledgement semantics

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely cosmetic/text changes with no logic affected.

All changes are UI text rewording with no functional, data, or logic impact. The only finding is a P2 accessibility suggestion regarding the removed DialogDescription.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/chat/chat-disclaimer-dialog.tsx | Rewrites the chat disclaimer from a paragraph to a bullet list, removes DialogDescription, and changes button text from "OK" to "I understand" |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: reword chat disclaimer"](https://github.com/felixvonsamson/energetica/commit/722d34a58389e6271e953c4c636f3a1ccea84f80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26575553)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->