### PR TITLE
feat(chat): optimistic message updates

### DIFF
--- a/frontend/src/components/chat/message-container.tsx
+++ b/frontend/src/components/chat/message-container.tsx
@@ -137,10 +137,11 @@ export function MessageContainer({
                                 <div
                                     key={message.id}
                                     className={cn(
-                                        "p-3 rounded-lg break-words max-w-[70%] whitespace-pre-line",
+                                        "p-3 rounded-lg break-words max-w-[70%] whitespace-pre-line transition-opacity",
                                         isOwnMessage
                                             ? "bg-primary text-primary-foreground rounded-br-none"
                                             : "bg-secondary text-secondary-foreground rounded-bl-none",
+                                        message.id < 0 && "opacity-60",
                                     )}
                                 >
                                     {message.text}

--- a/frontend/src/components/chat/message-input.tsx
+++ b/frontend/src/components/chat/message-input.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 
 import { Button } from "@/components/ui";
+import { useAuth } from "@/hooks/use-auth";
 import { useSendMessage } from "@/hooks/use-chats";
 
 interface MessageInputProps {
@@ -16,7 +17,8 @@ export function MessageInput({
 }: MessageInputProps) {
     const [message, setMessage] = useState("");
     const inputRef = useRef<HTMLTextAreaElement>(null);
-    const { mutate: sendMessage, isPending } = useSendMessage();
+    const { mutate: sendMessage } = useSendMessage();
+    const { user } = useAuth();
 
     // Auto-resize textarea as content changes
     const adjustHeight = useCallback(() => {
@@ -28,22 +30,26 @@ export function MessageInput({
     }, []);
 
     const handleSend = () => {
-        if (!message.trim()) return;
+        if (!message.trim() || !user?.player_id) return;
+        const messageText = message;
+
+        // Clear input immediately (optimistic)
+        setMessage("");
+        if (inputRef.current) {
+            inputRef.current.style.height = "auto";
+            inputRef.current.focus();
+        }
 
         sendMessage(
             {
                 chatId,
-                data: { new_message: message },
+                data: { new_message: messageText },
+                playerId: user!.player_id!,
             },
             {
-                onSuccess: () => {
-                    setMessage("");
-                    // Input is no longer disabled, so we can focus immediately
-                    inputRef.current?.focus();
-                    // Reset height after clearing message
-                    if (inputRef.current) {
-                        inputRef.current.style.height = "auto";
-                    }
+                onError: () => {
+                    // Restore message text if the request fails
+                    setMessage(messageText);
                 },
             },
         );
@@ -52,10 +58,7 @@ export function MessageInput({
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
-            // Only send if not already pending
-            if (!isPending) {
-                handleSend();
-            }
+            handleSend();
         }
         // Shift+Enter will naturally insert a new line in textarea
     };
@@ -87,7 +90,7 @@ export function MessageInput({
             />
             <Button
                 onClick={handleSend}
-                disabled={isDisabled || isPending || !message.trim()}
+                disabled={isDisabled || !message.trim()}
                 aria-label="Send message"
                 className="max-h-12"
             >

--- a/frontend/src/hooks/use-chats.ts
+++ b/frontend/src/hooks/use-chats.ts
@@ -17,8 +17,10 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { chatsApi } from "@/lib/api/chats";
 import { queryKeys, queryClient } from "@/lib/query-client";
 import type {
+    ChatMessagesResponse,
     CreateChatRequest,
     CreateChatResponse,
+    Message,
     SendMessageRequest,
     OpenChatResponse,
 } from "@/types/chats";
@@ -100,14 +102,53 @@ export function useSendMessage() {
         }: {
             chatId: number;
             data: SendMessageRequest;
+            playerId: number;
         }): ReturnType<typeof chatsApi.sendMessage> =>
             chatsApi.sendMessage(chatId, data),
-        onSuccess: (_response, variables) => {
-            // Invalidate the messages for this chat to refresh
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.chats.messages(variables.chatId),
+        onMutate: async ({ chatId, data, playerId }) => {
+            // Cancel in-flight refetches so they don't overwrite the optimistic update
+            await queryClient.cancelQueries({
+                queryKey: queryKeys.chats.messages(chatId),
             });
-            // Also invalidate the chat list since unread counts may have changed
+
+            const previousMessages =
+                queryClient.getQueryData<ChatMessagesResponse>(
+                    queryKeys.chats.messages(chatId),
+                );
+
+            // Optimistic message — negative ID flags it as pending
+            const optimisticMessage: Message = {
+                id: -Date.now(),
+                player_id: playerId,
+                text: data.new_message,
+                timestamp: new Date().toISOString(),
+            };
+
+            queryClient.setQueryData<ChatMessagesResponse>(
+                queryKeys.chats.messages(chatId),
+                (old) =>
+                    old
+                        ? {
+                              ...old,
+                              messages: [...old.messages, optimisticMessage],
+                          }
+                        : old,
+            );
+
+            return { previousMessages };
+        },
+        onError: (_err, { chatId }, context) => {
+            if (context?.previousMessages !== undefined) {
+                queryClient.setQueryData(
+                    queryKeys.chats.messages(chatId),
+                    context.previousMessages,
+                );
+            }
+        },
+        onSettled: (_response, _err, { chatId }) => {
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.chats.messages(chatId),
+            });
             queryClient.invalidateQueries({
                 queryKey: queryKeys.chats.list,
             });


### PR DESCRIPTION
## Summary

- Input clears immediately on send instead of waiting for server confirmation
- Sent message appears in the chat UI right away at 60% opacity (pending state)
- On server confirmation, the real message replaces the optimistic one (full opacity)
- On error, the optimistic message is rolled back and the input text is restored
- Rapid successive sends now work smoothly — no `isPending` gate blocking the input

## Implementation

- `useSendMessage`: added `onMutate` (cancel in-flight queries, inject optimistic `Message` with negative temp ID into cache), `onError` (rollback), switched to `onSettled` (always invalidate)
- `MessageInput`: clears input immediately, passes `playerId` for the optimistic entry, restores text on error
- `MessageContainer`: `message.id < 0` → `opacity-60 transition-opacity`

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up optimistic message updates for the chat feature using TanStack Query's `onMutate` / `onError` / `onSettled` lifecycle. The input clears and a temporary message (negative ID, 60% opacity) appears instantly; on server confirmation the real message replaces it, and on failure the cache is rolled back and the input text is restored.

- **`use-chats.ts`** — `onMutate` cancels in-flight queries, snapshots the cache, and injects an optimistic `Message` with `id: -Date.now()`. `onError` restores the snapshot. `onSettled` (replacing the old `onSuccess`) always invalidates both the message list and the chat list.
- **`message-input.tsx`** — Input is cleared eagerly before the mutation fires. `playerId` is now passed into the mutation for the optimistic entry. The `isPending` gate is removed, enabling rapid successive sends. Per-call `onError` restores the input text.
- **`message-container.tsx`** — A single `message.id < 0 && "opacity-60"` conditional provides the pending visual state with a CSS transition.

Two P2 findings: a UX edge case where error recovery can overwrite in-progress typing, and a stale JSDoc example.

<h3>Confidence Score: 5/5</h3>

Safe to merge — implementation is correct and follows TanStack Query best practices; only P2 findings remain

All findings are P2. No data loss, cache corruption, or broken mutation flow was found. The rollback and invalidation logic is sound, and the optimistic ID scheme (negative timestamp) is reliable within a single session.

frontend/src/components/chat/message-input.tsx — minor error-recovery UX edge case worth addressing

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/hooks/use-chats.ts | Core optimistic update logic — onMutate snapshots cache and injects optimistic message, onError rolls back, onSettled always invalidates; stale JSDoc example flagged as P2 |
| frontend/src/components/chat/message-input.tsx | Clears input and resets height immediately before the send; restores text on error — P2: restore may overwrite in-progress typing when a previous send fails concurrently |
| frontend/src/components/chat/message-container.tsx | Minimal change: adds opacity-60 and transition-opacity to messages whose id < 0 (pending optimistic messages); correct and straightforward |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/hooks/use-chats.ts`, line 86-93 ([link](https://github.com/felixvonsamson/energetica/blob/aa78beb767aa658d001d899f93f4c50e54ae2170/frontend/src/hooks/use-chats.ts#L86-L93)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **JSDoc example is stale after the signature change**

   The `@example` block still shows the old two-field call and destructures `isPending`, which is no longer used. It also omits the now-required `playerId` field, so a developer copying this snippet would get a TypeScript error.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(chat): optimistic message updates f..."](https://github.com/felixvonsamson/energetica/commit/aa78beb767aa658d001d899f93f4c50e54ae2170) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26669979)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->