### PR TITLE
fix: unlock pages update without refresh

### DIFF
--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -3,17 +3,16 @@
  * cookies and fetches user data from the backend.
  */
 
+import { useQuery } from "@tanstack/react-query";
 import {
     createContext,
-    useState,
-    useEffect,
     useCallback,
     type ReactNode,
 } from "react";
 
 import { authApi } from "@/lib/api/auth";
 import { ApiClientError } from "@/lib/api-client";
-import { queryClient } from "@/lib/query-client";
+import { queryClient, queryKeys } from "@/lib/query-client";
 import type { ApiSchema } from "@/types/api-helpers";
 
 type User = ApiSchema<"UserOut">;
@@ -36,52 +35,44 @@ export interface AuthProviderProps {
 }
 
 export function AuthProvider({ children }: AuthProviderProps) {
-    const [user, setUser] = useState<User | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<Error | null>(null);
-
-    const fetchUser = useCallback(async () => {
-        try {
-            setIsLoading(true);
-            setError(null);
-            const userData = await authApi.me();
-            setUser(userData);
-        } catch (err) {
-            if (err instanceof ApiClientError && err.status === 401) {
-                // Not authenticated - this is expected for logged-out users
-                setUser(null);
-            } else {
-                // Actual error
-                setError(
-                    err instanceof Error
-                        ? err
-                        : new Error("Failed to fetch user"),
-                );
-                setUser(null);
+    const {
+        data: user,
+        isLoading,
+        error,
+        refetch,
+    } = useQuery({
+        queryKey: queryKeys.auth.me,
+        queryFn: async () => {
+            try {
+                return await authApi.me();
+            } catch (err) {
+                if (err instanceof ApiClientError && err.status === 401) {
+                    // Not authenticated - return null instead of throwing
+                    return null;
+                }
+                throw err;
             }
-        } finally {
-            setIsLoading(false);
-        }
-    }, []);
-
-    useEffect(() => {
-        fetchUser();
-    }, [fetchUser]);
+        },
+        // Don't auto-refetch on window focus for auth - only refetch on invalidation
+        refetchOnWindowFocus: false,
+        // Keep auth data fresh indefinitely until explicitly invalidated
+        staleTime: Infinity,
+    });
 
     const logout = useCallback(() => {
         // Just clear the frontend state. The API logout is handled by the logout route.
-        setUser(null);
-        setError(null);
         // Clear all cached queries
         queryClient.clear();
     }, []);
 
     const value: AuthContextValue = {
-        user,
-        isAuthenticated: user !== null,
+        user: user ?? null,
+        isAuthenticated: (user ?? null) !== null,
         isLoading,
-        error,
-        refetch: fetchUser,
+        error: error instanceof Error ? error : null,
+        refetch: async () => {
+            await refetch();
+        },
         logout,
     };
 


### PR DESCRIPTION
## Summary

- `AuthContext` stored user/capabilities in plain `useState` and only fetched on mount
- Backend emits `invalidate` for `["auth", "me"]` when capabilities change (facility built, achievement unlocked), but since `AuthContext` had no React Query observer, the `queryClient.invalidateQueries` call had no effect
- Migrated `AuthContext` to `useQuery` so it reacts to cache invalidation like every other data hook

Closes #567

## Test plan

- [ ] Build a laboratory/warehouse/storage facility → sidebar should unlock the corresponding page without a page refresh
- [ ] Unlock the network achievement → network page should appear in sidebar without refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the bug where sidebar pages failed to unlock without a full page refresh after building facilities or earning achievements. The root cause was that `AuthContext` used plain React state and a `useEffect`, so no TanStack Query observer was registered for the `["auth", "me"]` cache key. Backend invalidation events targeting that key had no effect.

The fix migrates `AuthContext` to `useQuery`, registering a live cache observer so backend-emitted invalidations immediately trigger a refetch and propagate updated capabilities to the rest of the app.

**Key changes:**
- Replaced manual `useState`/`useEffect` fetching with `useQuery` using `staleTime: Infinity` and `refetchOnWindowFocus: false` — the minimal change needed to wire up backend-driven invalidation.
- 401 responses are caught inside `queryFn` and returned as `null` rather than thrown, keeping unauthenticated state out of React Query's error/retry path.
- `logout` now calls `queryClient.clear()` instead of setting state directly — functionally equivalent, though it triggers a harmless extra fetch of the auth endpoint while `AuthProvider` is still mounted (noted in inline comments).
- Minor verbosity in the `isAuthenticated` check is noted inline.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix correctly wires up the React Query observer, all edge cases (401, logout, refetch) are handled gracefully, and remaining findings are style-only P2s.

The core change is a clean, minimal migration from useState to useQuery that directly addresses the described bug. No P0 or P1 issues found. The two flagged items (verbose isAuthenticated expression and a superfluous network request triggered by queryClient.clear() during logout) are minor style improvements that do not affect correctness or reliability.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/contexts/auth-context.tsx | Migrates auth state from useState+useEffect to useQuery so the React Query cache observer is active and reacts to backend-driven invalidations of ["auth", "me"]; minor redundancy in isAuthenticated expression. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Backend
    participant SocketIO
    participant QueryClient
    participant AuthProvider
    participant Sidebar

    Note over AuthProvider: Before this PR: useState/useEffect — no RQ observer
    Note over AuthProvider: After this PR: useQuery observer active on ["auth","me"]

    Backend->>SocketIO: emit("invalidate", {queries: [["auth","me"]]})
    SocketIO->>QueryClient: invalidateQueries(["auth","me"])
    QueryClient->>AuthProvider: observer notified → refetch triggered
    AuthProvider->>Backend: GET /api/auth/me
    Backend-->>AuthProvider: 200 OK (updated user + capabilities)
    AuthProvider->>Sidebar: user/capabilities updated → new pages unlocked
```

<sub>Reviews (1): Last reviewed commit: ["fix(auth): refetch capabilities on backe..."](https://github.com/felixvonsamson/energetica/commit/5c452110a1b31d1b46397d82d529fa187423f5c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26670367)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->