### PR TITLE
fix electricity price link and quick card styling

### DIFF
--- a/frontend/src/components/dashboard/daily-quiz.tsx
+++ b/frontend/src/components/dashboard/daily-quiz.tsx
@@ -17,7 +17,7 @@ export function DailyQuizButton() {
             <DialogTrigger asChild>
                 <button
                     className={cn(
-                        "bg-card hover:bg-tan-hover dark:hover:bg-muted",
+                        "bg-card hover:bg-muted",
                         "p-6 rounded-lg text-center transition-colors block w-full",
                         "border border-transparent hover:border-pine dark:hover:border-brand-green",
                     )}
@@ -80,7 +80,7 @@ function DailyQuizSection() {
 
         if (!hasAnswered) {
             // Before answering - normal clickable button
-            return `${baseClass} bg-card border-1 border-border hover:border-brand-green dark:hover:border-brand-green hover:shadow-md text-foreground disabled:opacity-50 disabled:cursor-not-allowed`;
+            return `${baseClass} bg-card border-1 border-border hover:bg-muted hover:border-brand hover:shadow-md text-foreground disabled:opacity-50 disabled:cursor-not-allowed`;
         }
 
         // After answering - show feedback
@@ -150,25 +150,21 @@ function DailyQuizSection() {
 
                     {/* Answer Buttons */}
                     <div className="space-y-3">
-                        {(
-                            [
-                                "answer1",
-                                "answer2",
-                                "answer3",
-                            ] as const
-                        ).map((key) => (
-                            <button
-                                key={key}
-                                onClick={() => handleAnswerClick(key)}
-                                disabled={hasAnswered || isPending}
-                                className={getButtonClass(key)}
-                            >
-                                <span className="block text-center px-28">
-                                    {quizData[key]}
-                                </span>
-                                {getAnswerIndicator(key)}
-                            </button>
-                        ))}
+                        {(["answer1", "answer2", "answer3"] as const).map(
+                            (key) => (
+                                <button
+                                    key={key}
+                                    onClick={() => handleAnswerClick(key)}
+                                    disabled={hasAnswered || isPending}
+                                    className={getButtonClass(key)}
+                                >
+                                    <span className="block text-center px-28">
+                                        {quizData[key]}
+                                    </span>
+                                    {getAnswerIndicator(key)}
+                                </button>
+                            ),
+                        )}
                     </div>
 
                     {/* Explanation and Learn More (only shown after answering) */}

--- a/frontend/src/components/dashboard/quick-link-card.tsx
+++ b/frontend/src/components/dashboard/quick-link-card.tsx
@@ -22,7 +22,7 @@ export function QuickLinkCard({
         <Link
             to={to}
             className={cn(
-                "bg-card hover:bg-tan-hover dark:hover:bg-muted",
+                "bg-card hover:bg-muted",
                 "p-6 rounded-lg text-center transition-colors block",
                 "border border-transparent hover:border-pine dark:hover:border-brand-green",
                 className,

--- a/frontend/src/routes/app/dashboard.tsx
+++ b/frontend/src/routes/app/dashboard.tsx
@@ -29,12 +29,7 @@ import { QuickLinkCard } from "@/components/dashboard/quick-link-card";
 import { WeatherSection } from "@/components/dashboard/weather";
 import { DevelopmentBanner } from "@/components/development-banner";
 import { GameLayout } from "@/components/layout/game-layout";
-import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardTitle,
-} from "@/components/ui";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { useAchievements } from "@/hooks/use-achievements";
 import { useCapabilities, useHasCapability } from "@/hooks/use-capabilities";
 import { useProjects } from "@/hooks/use-projects";
@@ -220,7 +215,7 @@ function DashboardContent() {
                     )}
                     {hasNetwork && (
                         <QuickLinkCard
-                            to="/app/community/electricity-markets"
+                            to="/app/overviews/electricity-markets"
                             icon={TrendingUp}
                             title="Market Prices"
                         />
@@ -255,71 +250,72 @@ function BeginnersGuide() {
             </CardHeader>
             <CardContent>
                 <div className="space-y-4 text-base">
-                <p>Welcome to Energetica!</p>
-                <p>
-                    You begin your journey with <b>1 steam engine</b> and a
-                    small <b>industry</b>, generating revenues. You can monitor
-                    their{" "}
-                    <Link
-                        to="/app/overviews/power"
-                        className="text-info underline hover:opacity-80"
-                    >
-                        power generation and consumption
-                    </Link>{" "}
-                    as well as your{" "}
-                    <Link
-                        to="/app/overviews/cash-flow"
-                        className="text-info underline hover:opacity-80"
-                    >
-                        revenues
-                    </Link>{" "}
-                    under the <i>Production Overview</i> tab in the top menu.
-                </p>
-                <p>
-                    The first thing you will probably want to do is to{" "}
-                    <b>expand your production</b> by investing in{" "}
-                    <Link
-                        to="/app/facilities/power"
-                        className="text-info underline hover:opacity-80"
-                    >
-                        Power Facilities
-                    </Link>{" "}
-                    and upgrading your industry on the{" "}
-                    <Link
-                        to="/app/facilities/functional"
-                        className="text-info underline hover:opacity-80"
-                    >
-                        Functional Facilities
-                    </Link>{" "}
-                    page. You also have access to{" "}
-                    <Link
-                        to="/app/facilities/storage"
-                        className="text-info underline hover:opacity-80"
-                    >
-                        Storage Facilities
-                    </Link>{" "}
-                    to store energy. You will unlock new technologies and more
-                    game mechanics as you progress.
-                </p>
-                <p>
-                    Engage with other players via the <i>Community</i> tab.
-                </p>
-                <p>
-                    If you are lost, click on the{" "}
-                    <HelpCircle className="inline w-4 h-4" /> icon on the right
-                    side of the title, you will find explanations about the
-                    content of the page. For detailed explanations on any game
-                    mechanics, consult the{" "}
-                    <a
-                        href="/wiki/introduction"
-                        className="text-info underline hover:opacity-80"
-                    >
-                        wiki
-                    </a>
-                    .
-                </p>
-                <p>Best of luck in your energy adventure!</p>
-            </div>
+                    <p>Welcome to Energetica!</p>
+                    <p>
+                        You begin your journey with <b>1 steam engine</b> and a
+                        small <b>industry</b>, generating revenues. You can
+                        monitor their{" "}
+                        <Link
+                            to="/app/overviews/power"
+                            className="text-info underline hover:opacity-80"
+                        >
+                            power generation and consumption
+                        </Link>{" "}
+                        as well as your{" "}
+                        <Link
+                            to="/app/overviews/cash-flow"
+                            className="text-info underline hover:opacity-80"
+                        >
+                            revenues
+                        </Link>{" "}
+                        under the <i>Production Overview</i> tab in the top
+                        menu.
+                    </p>
+                    <p>
+                        The first thing you will probably want to do is to{" "}
+                        <b>expand your production</b> by investing in{" "}
+                        <Link
+                            to="/app/facilities/power"
+                            className="text-info underline hover:opacity-80"
+                        >
+                            Power Facilities
+                        </Link>{" "}
+                        and upgrading your industry on the{" "}
+                        <Link
+                            to="/app/facilities/functional"
+                            className="text-info underline hover:opacity-80"
+                        >
+                            Functional Facilities
+                        </Link>{" "}
+                        page. You also have access to{" "}
+                        <Link
+                            to="/app/facilities/storage"
+                            className="text-info underline hover:opacity-80"
+                        >
+                            Storage Facilities
+                        </Link>{" "}
+                        to store energy. You will unlock new technologies and
+                        more game mechanics as you progress.
+                    </p>
+                    <p>
+                        Engage with other players via the <i>Community</i> tab.
+                    </p>
+                    <p>
+                        If you are lost, click on the{" "}
+                        <HelpCircle className="inline w-4 h-4" /> icon on the
+                        right side of the title, you will find explanations
+                        about the content of the page. For detailed explanations
+                        on any game mechanics, consult the{" "}
+                        <a
+                            href="/wiki/introduction"
+                            className="text-info underline hover:opacity-80"
+                        >
+                            wiki
+                        </a>
+                        .
+                    </p>
+                    <p>Best of luck in your energy adventure!</p>
+                </div>
             </CardContent>
         </Card>
     );


### PR DESCRIPTION
fixes #574

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #574 by correcting a broken "Market Prices" quick-link on the dashboard that was pointing to the market management page (`/app/community/electricity-markets`) instead of the intended price visualization page (`/app/overviews/electricity-markets`). It also cleans up hover styling across `QuickLinkCard` and `DailyQuizButton` by unifying light/dark-mode hover classes into a single `bg-muted` token, and fixes a pre-existing indentation issue in the `BeginnersGuide` component.

- **Route fix**: `/app/community/electricity-markets` → `/app/overviews/electricity-markets` for the "Market Prices" card
- **Styling**: Removed `hover:bg-tan-hover dark:hover:bg-muted` in favor of the simpler, theme-aware `hover:bg-muted` in both `QuickLinkCard` and `DailyQuizButton`
- **Styling**: Replaced `hover:border-brand-green dark:hover:border-brand-green` with `hover:border-brand` for quiz answer buttons
- **Formatting**: Cleaned up `BeginnersGuide` child indentation and the `Card` import style

<h3>Confidence Score: 5/5</h3>

Safe to merge — focused bug fix with no logic regressions.

All changes are narrow and correct: the route fix is verifiably right (the overviews route is the price-visualization page matching the 'Market Prices' label), the styling simplifications are consistent across the codebase, and the formatting changes are cosmetic. No new logic, no data mutations, and no P0/P1 issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/app/dashboard.tsx | Primary bug fix: corrected 'Market Prices' link from /app/community/electricity-markets (market management) to /app/overviews/electricity-markets (price visualization); also fixed BeginnersGuide indentation and import formatting. |
| frontend/src/components/dashboard/quick-link-card.tsx | Simplified hover background from hover:bg-tan-hover dark:hover:bg-muted to unified hover:bg-muted, removing the now-unnecessary light/dark mode distinction. |
| frontend/src/components/dashboard/daily-quiz.tsx | Applied the same hover background simplification as quick-link-card; updated quiz answer button hover border from hover:border-brand-green dark:hover:border-brand-green to the single hover:border-brand token; minor code reformatting. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dashboard Quick Links] --> B{hasNetwork?}
    B -- Yes --> C["Market Prices Card\n(QuickLinkCard)"]
    B -- No --> D[Other Quick Links]
    C -- "Before fix" --> E["/app/community/electricity-markets\n(Market management: join/create/leave)"]
    C -- "After fix ✅" --> F["/app/overviews/electricity-markets\n(Price & clearing volume visualization)"]
    style E fill:#f88,stroke:#c00
    style F fill:#8f8,stroke:#0a0
```

<sub>Reviews (1): Last reviewed commit: ["fix electricity price link and quick car..."](https://github.com/felixvonsamson/energetica/commit/e0c39838b6eb4781140f6b195455ba7039ac7cc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26701101)</sub>

<!-- /greptile_comment -->