### PR TITLE
fix: switch to two column layout on narrow viewports

### DIFF
--- a/frontend/src/components/dashboard/weather.tsx
+++ b/frontend/src/components/dashboard/weather.tsx
@@ -105,36 +105,40 @@ export function WeatherSection() {
     const riverLabel = getRiverLabel(weatherData.river_flow_speed);
 
     return (
-        <div className="grid grid-cols-2 lg:grid-cols-4 items-center gap-y-3 px-1">
-            {/* Month */}
-            <WeatherItem
-                icon={Calendar}
-                label="Month"
-                value={getShortMonthName(weatherData.month_number)}
-            />
+        <div className="flex flex-wrap justify-around items-center gap-y-4 px-1">
+            <div className="flex justify-around grow">
+                {/* Month */}
+                <WeatherItem
+                    icon={Calendar}
+                    label="Month"
+                    value={getShortMonthName(weatherData.month_number)}
+                />
 
-            {/* Solar irradiance + sky condition */}
-            <WeatherItem
-                icon={SkyIcon}
-                label="Irradiance"
-                value={`${Math.round(weatherData.solar_irradiance)} W/m²`}
-            />
+                {/* Solar irradiance + sky condition */}
+                <WeatherItem
+                    icon={SkyIcon}
+                    label="Irradiance"
+                    value={`${Math.round(weatherData.solar_irradiance)} W/m²`}
+                />
+            </div>
 
-            {/* Wind */}
-            <WeatherItem
-                icon={Wind}
-                label="Wind"
-                value={windLabel}
-                sub={`${Math.round(weatherData.wind_speed)} km/h`}
-            />
+            <div className="flex justify-around grow">
+                {/* Wind */}
+                <WeatherItem
+                    icon={Wind}
+                    label="Wind"
+                    value={windLabel}
+                    sub={`${Math.round(weatherData.wind_speed)} km/h`}
+                />
 
-            {/* River flow */}
-            <WeatherItem
-                icon={Droplets}
-                label="River flow"
-                value={riverLabel}
-                sub={`${weatherData.river_flow_speed.toFixed(1)} m/s`}
-            />
+                {/* River flow */}
+                <WeatherItem
+                    icon={Droplets}
+                    label="River flow"
+                    value={riverLabel}
+                    sub={`${weatherData.river_flow_speed.toFixed(1)} m/s`}
+                />
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the weather section layout on narrow viewports by switching from a `flex flex-wrap` container to a CSS grid (`grid-cols-2 lg:grid-cols-4`). With exactly 4 `WeatherItem` children, this produces a clean 2×2 grid below the `lg` breakpoint and a single 4-column row on larger screens — a straightforward and correct responsive layout fix.

- Changed `flex flex-wrap justify-around` to `grid grid-cols-2 lg:grid-cols-4` on the wrapper `div`
- Minor: the retained `justify-around` class (`justify-content: space-around`) is effectively a no-op in this grid context since the `1fr` columns already fill the container width — it's harmless but can be removed for clarity

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line CSS class change with correct responsive behaviour and no functional risk.

The change is a minimal, well-scoped layout fix. The grid approach is a better fit than flex-wrap for exactly 4 evenly-distributed items. The only leftover (`justify-around`) is harmless in a grid context. No logic, data, or interaction paths are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/dashboard/weather.tsx | Replaces `flex flex-wrap justify-around` with `grid grid-cols-2 lg:grid-cols-4` to display the 4 weather items in a 2-column grid on narrow viewports and a 4-column row on large screens. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[WeatherSection renders] --> B{Viewport width}
    B -- "< lg (1024px)" --> C["grid grid-cols-2\n2-column layout\n2×2 grid of items"]
    B -- ">= lg (1024px)" --> D["grid lg:grid-cols-4\n4-column layout\nAll 4 items in one row"]
    C --> E["Row 1: Month | Irradiance"]
    C --> F["Row 2: Wind  | River flow"]
    D --> G["Month | Irradiance | Wind | River flow"]
```

<sub>Reviews (1): Last reviewed commit: ["fix: switch to two column layout on narr..."](https://github.com/felixvonsamson/energetica/commit/aa2c457d9f84cea40183f8a257f7e08f9b666dcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26816051)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->