### PR TITLE
fix: theme switcher icons shows current theme

### DIFF
--- a/frontend/src/components/ui/theme-toggle.tsx
+++ b/frontend/src/components/ui/theme-toggle.tsx
@@ -21,9 +21,9 @@ export const ThemeToggle = forwardRef<HTMLButtonElement, ThemeToggleProps>(
 
         const icon =
             theme === "light" ? (
-                <Moon size={20} />
-            ) : theme === "dark" ? (
                 <Sun size={20} />
+            ) : theme === "dark" ? (
+                <Moon size={20} />
             ) : (
                 <SunMoon size={20} />
             );


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the `ThemeToggle` component where the displayed icon represented the *next* theme (what you'd switch to) rather than the *current* theme. The fix simply swaps `<Moon>` and `<Sun>` for the `"light"` and `"dark"` conditions, so the icon now correctly mirrors the active theme.

- **Before**: Light mode showed `Moon`, dark mode showed `Sun` (next-state icons).
- **After**: Light mode shows `Sun`, dark mode shows `Moon` (current-state icons), which matches the PR intent of \"shows current theme.\"
- The `aria-label` (`Switch to ${nextTheme} mode`) remains accurate and unchanged — it correctly describes the action that clicking will perform.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with no side effects.

The change is a two-line swap with a clear intent and no logic regressions. The accessibility label independently encodes the next-state action, so swapping the icons does not break any other part of the component.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/ui/theme-toggle.tsx | Swaps Moon/Sun icon assignments so the icon reflects the current active theme rather than the next theme. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ThemeToggle rendered] --> B{current theme?}
    B -- light --> C["☀️ Sun icon\naria-label: Switch to dark mode"]
    B -- dark --> D["🌙 Moon icon\naria-label: Switch to auto mode"]
    B -- auto/system --> E["🌓 SunMoon icon\naria-label: Switch to light mode"]
    C --> F[User clicks → toggleTheme]
    D --> F
    E --> F
    F --> G["theme cycles: light → dark → auto → light"]
```

<sub>Reviews (1): Last reviewed commit: ["fix: theme switcher icons shows current ..."](https://github.com/felixvonsamson/energetica/commit/40f9f31bbd4f3bdaf5066afffb53dc58611a73f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26816609)</sub>

<!-- /greptile_comment -->