### PR TITLE
fix(achievements): two-row layout for narrow viewports

### DIFF
--- a/frontend/src/components/dashboard/achievement-card.tsx
+++ b/frontend/src/components/dashboard/achievement-card.tsx
@@ -42,14 +42,19 @@ export function AchievementCard(achievement: AchievementCardProps) {
     }
 
     return (
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
             {/* Achievement name */}
-            <div className="font-medium text-sm text-foreground min-w-35">
+            <div className="font-medium text-sm text-foreground min-w-35 grow sm:grow-0">
                 {name}
             </div>
 
+            {/* XP reward — shown inline with name on small screens */}
+            <div className="font-medium text-sm text-foreground text-center min-w-15 sm:hidden">
+                +{reward} XP
+            </div>
+
             {/* Progress bar */}
-            <div className="flex-1 relative h-7 bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden">
+            <div className="w-full sm:w-auto sm:flex-1 relative h-5 sm:h-7 bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden">
                 <div
                     className="absolute inset-0 bg-brand-secondary dark:bg-brand-secondary transition-all duration-300 ease-out"
                     style={{ width: `${progressPercent}%` }}
@@ -59,8 +64,8 @@ export function AchievementCard(achievement: AchievementCardProps) {
                 </div>
             </div>
 
-            {/* XP reward */}
-            <div className="font-medium text-sm text-foreground text-center min-w-15">
+            {/* XP reward — hidden on small screens (shown above progress bar) */}
+            <div className="hidden sm:block font-medium text-sm text-foreground text-center min-w-15">
                 +{reward} XP
             </div>
         </div>


### PR DESCRIPTION
Fixes #592

## Summary
- On small screens (`< 640px`): achievement name and XP share row 1 (name grows, XP right-aligned), progress bar drops to a full-width row 2 at reduced height (`h-5`)
- On larger screens: original single-row layout preserved (`h-7`), no visual change

## Test plan
- [ ] Resize browser below 640px — achievements should show 2-row layout with XP next to the name
- [ ] Resize above 640px — single-row layout, progress bar same height as before

---

> 🐢 *Quorum says: "Congratulations, it took a mobile screenshot from a bug report to realize your progress bars were basically unreadable. The achievements were an achievement in illegibility."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a readability issue on narrow viewports by introducing a two-row layout for achievement cards below the `sm` (640 px) breakpoint. The implementation uses Tailwind's `flex-wrap` + `sm:` responsive variants to show the achievement name and XP reward side-by-side on row 1, while the progress bar drops to a full-width row 2 at a slightly reduced height (`h-5` vs `h-7`). The original single-row layout on wider screens is completely preserved.

Key changes:
- Outer container gains `flex-wrap`, `gap-x-3`, and `gap-y-1` to enable row-wrapping with controlled spacing.
- Name div gains `grow` on small screens (`sm:grow-0` on larger) so it expands to fill row 1 next to the XP badge.
- A new XP div (`sm:hidden`) appears on small screens alongside the name; the original XP div becomes `hidden sm:block`.
- Progress bar switches to `w-full` on small screens and drops to `h-5`; `sm:flex-1` and `sm:h-7` restore the original large-screen appearance.

The approach is idiomatic Tailwind responsive CSS and carries no runtime risk.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure CSS/layout change with no logic, no data handling, and no regressions on wide viewports.

Single-file, presentation-only change using well-established Tailwind responsive patterns. The duplicate XP DOM node is a normal show/hide technique; CSS display:none correctly removes it from the accessibility tree, so screen readers will not double-read it. No P0 or P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/dashboard/achievement-card.tsx | Adds responsive two-row layout for narrow viewports: name + XP share row 1 on small screens (< 640 px), progress bar wraps to full-width row 2 at reduced height; original single-row layout preserved on sm+ breakpoints. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["AchievementCard rendered"] --> B{"Viewport width"}
    B -- "< 640px (small)" --> C["Row 1: Name (grow) + XP badge (sm:hidden)"]
    C --> D["Row 2: Progress bar (w-full, h-5)"]
    D --> E["Original XP div: hidden (hidden sm:block)"]
    B -- ">= 640px (sm+)" --> F["Single row: Name (grow-0) + Progress bar (flex-1, h-7) + XP (sm:block)"]
    F --> G["Small-screen XP div: hidden (sm:hidden)"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(achievements): two-row layout for na..."](https://github.com/felixvonsamson/energetica/commit/a6a5b63c1037ca18d5d71df538782877c8b5148b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27024251)</sub>

<!-- /greptile_comment -->