### PR TITLE
feat: rework facility and research cards

### DIFF
--- a/frontend/src/components/facilities/construction-info.tsx
+++ b/frontend/src/components/facilities/construction-info.tsx
@@ -1,9 +1,9 @@
 /**
- * Shared component for displaying construction information. Shows duration,
- * power consumption, and emissions.
+ * Shared component for displaying construction/research information. Shows
+ * duration, power consumption, and emissions as icon + value pairs.
  */
 
-import { Zap, Cloud } from "lucide-react";
+import { Clock, Zap, Cloud } from "lucide-react";
 
 import { TogglingDuration } from "@/components/ui";
 import { formatPower, formatMass } from "@/lib/format-utils";
@@ -20,24 +20,24 @@ export function ConstructionInfo({
     constructionPollution,
 }: ConstructionInfoProps) {
     return (
-        <div className="flex flex-wrap gap-4 w-full justify-around">
-            <div className="flex items-center gap-2">
-                <span className="text-foreground">Duration:</span>
+        <div className="flex flex-wrap gap-4 items-center">
+            <div className="flex items-center gap-1.5">
+                <Clock className="w-4 h-4 text-muted-foreground shrink-0" />
                 <strong>
                     <TogglingDuration ticks={constructionTime} />
                 </strong>
             </div>
-            <div className="flex items-center gap-2">
-                <span className="text-foreground">Power:</span>
+            <div className="flex items-center gap-1.5">
+                <Zap className="w-4 h-4 text-muted-foreground shrink-0" />
                 <strong>{formatPower(constructionPower)}</strong>
-                <Zap className="w-4 h-4" />
             </div>
             {constructionPollution !== undefined &&
                 constructionPollution !== null && (
-                    <div className="flex items-center gap-2">
-                        <span className="text-foreground">Emissions:</span>
-                        <strong>{formatMass(constructionPollution)} CO₂</strong>
-                        <Cloud className="w-4 h-4" />
+                    <div className="flex items-center gap-1.5">
+                        <Cloud className="w-4 h-4 text-muted-foreground shrink-0" />
+                        <strong>
+                            {formatMass(constructionPollution)} CO₂
+                        </strong>
                     </div>
                 )}
         </div>

--- a/frontend/src/components/facilities/construction-info.tsx
+++ b/frontend/src/components/facilities/construction-info.tsx
@@ -7,37 +7,38 @@ import { Clock, Zap, Cloud } from "lucide-react";
 
 import { TogglingDuration } from "@/components/ui";
 import { formatPower, formatMass } from "@/lib/format-utils";
+import { cn } from "@/lib/utils";
 
 interface ConstructionInfoProps {
     constructionTime: number;
     constructionPower: number;
     constructionPollution?: number | null;
+    className?: string;
 }
 
 export function ConstructionInfo({
     constructionTime,
     constructionPower,
     constructionPollution,
+    className,
 }: ConstructionInfoProps) {
     return (
-        <div className="flex flex-wrap gap-4 items-center">
+        <div className={cn("flex flex-wrap gap-4 items-center", className)}>
             <div className="flex items-center gap-1.5">
-                <Clock className="w-4 h-4 text-muted-foreground shrink-0" />
+                <Clock className="w-4 h-4 shrink-0" />
                 <strong>
                     <TogglingDuration ticks={constructionTime} />
                 </strong>
             </div>
             <div className="flex items-center gap-1.5">
-                <Zap className="w-4 h-4 text-muted-foreground shrink-0" />
+                <Zap className="w-4 h-4 shrink-0" />
                 <strong>{formatPower(constructionPower)}</strong>
             </div>
             {constructionPollution !== undefined &&
                 constructionPollution !== null && (
                     <div className="flex items-center gap-1.5">
-                        <Cloud className="w-4 h-4 text-muted-foreground shrink-0" />
-                        <strong>
-                            {formatMass(constructionPollution)} CO₂
-                        </strong>
+                        <Cloud className="w-4 h-4 shrink-0" />
+                        <strong>{formatMass(constructionPollution)} CO₂</strong>
                     </div>
                 )}
         </div>

--- a/frontend/src/components/facilities/facility-detail-dialog.tsx
+++ b/frontend/src/components/facilities/facility-detail-dialog.tsx
@@ -68,7 +68,7 @@ export function FacilityDetailDialog<T>({
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-            <DialogContent>
+            <DialogContent className="flex flex-col p-0 gap-0 overflow-hidden">
                 {facility !== null &&
                     FacilityContent(
                         facility,
@@ -106,6 +106,7 @@ function FacilityContent<T>(
 ) {
     const imageExtension = imageExtensionMap[facility.name] ?? "jpg";
     const imageUrl = `/static/images/${facilityType}_facilities/${facility.name}.${imageExtension}`;
+    const isLocked = facility.requirements_status === "unsatisfied";
 
     return (
         <>
@@ -118,7 +119,9 @@ function FacilityContent<T>(
                     information.
                 </DialogDescription>
             </DialogHeader>
-            <div className="space-y-6">
+
+            {/* Scrollable body */}
+            <div className="flex-1 min-h-0 overflow-y-auto p-6 space-y-6">
                 {/* Image */}
                 <div className="w-full overflow-hidden">
                     <img
@@ -129,53 +132,58 @@ function FacilityContent<T>(
                 </div>
 
                 {/* Header */}
-                <div className="flex flex-wrap items-center justify-center gap-3">
-                    <div className="flex items-center gap-2 mr-auto">
-                        <TypographyH2 className="flex items-center gap-2">
-                            <FacilityIcon facility={facility.name} size={28} />
-                            <FacilityName
-                                facility={facility.name}
-                                mode="long"
-                            />
-                        </TypographyH2>
-                        {extraHeaderContent && extraHeaderContent(facility)}
-                    </div>
-                    <div className="flex items-center gap-3 shrink-0">
-                        <div className="text-xl font-semibold">
-                            <Money amount={facility.price} long />
-                        </div>
-                    </div>
+                <div className="flex flex-wrap items-center gap-3">
+                    <TypographyH2 className="flex items-center gap-2 mr-auto">
+                        <FacilityIcon facility={facility.name} size={28} />
+                        <FacilityName facility={facility.name} mode="long" />
+                    </TypographyH2>
+                    {extraHeaderContent && extraHeaderContent(facility)}
                 </div>
 
-                {/* Action Buttons */}
-                <div className="flex justify-center gap-3">
-                    {onCompare && (
-                        <Button
-                            size="lg"
-                            variant="secondary"
-                            onClick={() => onCompare(facility)}
-                            className="px-6 text-lg font-semibold"
-                        >
-                            <GitCompareArrows className="w-5 h-5 mr-2" />
-                            Compare
-                        </Button>
+                {/* Description + Learn More */}
+                <CardContent>
+                    {renderDescription ? (
+                        <div className="space-y-1.5">
+                            {renderDescription(facility)}
+                            {facilityType !== "functional" && (
+                                <a
+                                    href={facility.wikipedia_link}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground w-fit"
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    <ExternalLink className="w-3 h-3" />
+                                    Learn more
+                                </a>
+                            )}
+                        </div>
+                    ) : (
+                        <div className="[&_p:last-of-type]:inline">
+                            <div
+                                className="contents"
+                                dangerouslySetInnerHTML={{
+                                    __html: facility.description,
+                                }}
+                            />
+                            {facilityType !== "functional" && (
+                                <>
+                                    {" "}
+                                    <a
+                                        href={facility.wikipedia_link}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground"
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        <ExternalLink className="w-3 h-3" />
+                                        Learn more
+                                    </a>
+                                </>
+                            )}
+                        </div>
                     )}
-                    <Button
-                        size="lg"
-                        onClick={handleConstruction}
-                        disabled={facility.requirements_status === "unsatisfied"}
-                        variant={
-                            facility.requirements_status === "unsatisfied"
-                                ? "destructive"
-                                : "default"
-                        }
-                        className="px-8 text-lg font-bold"
-                    >
-                        {facility.requirements_status === "unsatisfied"
-                            ? "Locked"
-                            : "Start Construction"}
-                    </Button>
-                </div>
+                </CardContent>
 
                 {/* Requirements */}
                 {facility.requirements.some(
@@ -188,52 +196,56 @@ function FacilityContent<T>(
                     </CardContent>
                 )}
 
-                {/* Construction Info */}
-                <CardContent className="flex justify-around">
-                    <ConstructionInfo
-                        constructionTime={facility.construction_time}
-                        constructionPower={facility.construction_power}
-                        constructionPollution={
-                            facility.construction_pollution ?? undefined
-                        }
-                    />
-                </CardContent>
-
-                <hr className="border-border" />
-
-                {/* Description */}
+                {/* Stats Table + Compare */}
                 <CardContent>
-                    {renderDescription ? (
-                        renderDescription(facility)
-                    ) : (
-                        <div
-                            dangerouslySetInnerHTML={{
-                                __html: facility.description,
-                            }}
-                        />
-                    )}
-                </CardContent>
-
-                {/* Stats Table */}
-                <CardContent className="flex justify-around">
-                    {renderStatsTable(facility)}
-                </CardContent>
-
-                {/* Learn More */}
-                {facilityType !== "functional" && (
                     <div className="flex justify-center">
-                        <a
-                            href={facility.wikipedia_link}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground"
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            <ExternalLink className="w-4 h-4" />
-                            Learn more
-                        </a>
+                        <div className="flex flex-col gap-3">
+                            {renderStatsTable(facility)}
+                            {onCompare && (
+                                <div className="flex justify-end">
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() => onCompare(facility)}
+                                    >
+                                        <GitCompareArrows className="w-4 h-4" />
+                                        Compare
+                                    </Button>
+                                </div>
+                            )}
+                        </div>
                     </div>
-                )}
+                </CardContent>
+            </div>
+
+            {/* Footer — always visible */}
+            <div className="shrink-0 border-t border-border bg-background px-6 py-4 flex flex-wrap items-center justify-between gap-4">
+                <ConstructionInfo
+                    constructionTime={facility.construction_time}
+                    constructionPower={facility.construction_power}
+                    constructionPollution={
+                        facility.construction_pollution ?? undefined
+                    }
+                />
+                <Button
+                    size="lg"
+                    onClick={handleConstruction}
+                    disabled={isLocked}
+                    variant={isLocked ? "destructive" : "default"}
+                    className="px-8 text-base font-bold"
+                >
+                    {isLocked ? (
+                        "Locked"
+                    ) : (
+                        <span className="flex items-center gap-2">
+                            Start Construction
+                            <span className="opacity-70 font-normal">·</span>
+                            <span className="font-normal">
+                                <Money amount={facility.price} long />
+                            </span>
+                        </span>
+                    )}
+                </Button>
             </div>
         </>
     );

--- a/frontend/src/components/facilities/facility-detail-dialog.tsx
+++ b/frontend/src/components/facilities/facility-detail-dialog.tsx
@@ -38,7 +38,7 @@ interface FacilityDetailDialogProps<T> {
           })
         | null;
     facilityType: "power" | "storage" | "extraction" | "functional";
-    renderDescription?: (facility: T) => ReactNode;
+    renderDescription?: (facility: T, learnMore?: ReactNode) => ReactNode;
     renderStatsTable: (facility: T) => ReactNode;
     extraHeaderContent?: (facility: T) => ReactNode;
     onCompare?: (facility: T) => void;
@@ -99,7 +99,9 @@ function FacilityContent<T>(
     },
     facilityType: string,
     extraHeaderContent: ((facility: T) => ReactNode) | undefined,
-    renderDescription: ((facility: T) => ReactNode) | undefined,
+    renderDescription:
+        | ((facility: T, learnMore?: ReactNode) => ReactNode)
+        | undefined,
     renderStatsTable: (facility: T) => ReactNode,
     onCompare: ((facility: T) => void) | undefined,
     handleConstruction: () => void,
@@ -107,6 +109,23 @@ function FacilityContent<T>(
     const imageExtension = imageExtensionMap[facility.name] ?? "jpg";
     const imageUrl = `/static/images/${facilityType}_facilities/${facility.name}.${imageExtension}`;
     const isLocked = facility.requirements_status === "unsatisfied";
+    const hasUnsatisfiedRequirements = facility.requirements.some(
+        (r) => r.status !== "satisfied",
+    );
+
+    const learnMoreLink =
+        facilityType !== "functional" ? (
+            <a
+                href={facility.wikipedia_link}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground w-fit"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <ExternalLink className="w-3 h-3" />
+                Learn more
+            </a>
+        ) : undefined;
 
     return (
         <>
@@ -140,24 +159,10 @@ function FacilityContent<T>(
                     {extraHeaderContent && extraHeaderContent(facility)}
                 </div>
 
-                {/* Description + Learn More */}
+                {/* Description */}
                 <CardContent>
                     {renderDescription ? (
-                        <div className="space-y-1.5">
-                            {renderDescription(facility)}
-                            {facilityType !== "functional" && (
-                                <a
-                                    href={facility.wikipedia_link}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground w-fit"
-                                    onClick={(e) => e.stopPropagation()}
-                                >
-                                    <ExternalLink className="w-3 h-3" />
-                                    Learn more
-                                </a>
-                            )}
-                        </div>
+                        renderDescription(facility, learnMoreLink)
                     ) : (
                         <div className="[&_p:last-of-type]:inline">
                             <div
@@ -185,24 +190,13 @@ function FacilityContent<T>(
                     )}
                 </CardContent>
 
-                {/* Requirements */}
-                {facility.requirements.some(
-                    (r) => r.status !== "satisfied",
-                ) && (
-                    <CardContent>
-                        <RequirementsDisplay
-                            requirements={facility.requirements}
-                        />
-                    </CardContent>
-                )}
-
                 {/* Stats Table + Compare */}
                 <CardContent>
                     <div className="flex justify-center">
                         <div className="flex flex-col gap-3">
                             {renderStatsTable(facility)}
                             {onCompare && (
-                                <div className="flex justify-end">
+                                <div className="flex justify-center">
                                     <Button
                                         size="sm"
                                         variant="outline"
@@ -219,33 +213,39 @@ function FacilityContent<T>(
             </div>
 
             {/* Footer — always visible */}
-            <div className="shrink-0 border-t border-border bg-background px-6 py-4 flex flex-wrap items-center justify-between gap-4">
+            <div className="shrink-0 border-t border-border bg-background px-6 py-4 flex flex-col gap-3">
+                {/* Construction info */}
                 <ConstructionInfo
                     constructionTime={facility.construction_time}
                     constructionPower={facility.construction_power}
                     constructionPollution={
                         facility.construction_pollution ?? undefined
                     }
+                    className="w-full justify-evenly"
                 />
-                <Button
-                    size="lg"
-                    onClick={handleConstruction}
-                    disabled={isLocked}
-                    variant={isLocked ? "destructive" : "default"}
-                    className="px-8 text-base font-bold"
-                >
-                    {isLocked ? (
-                        "Locked"
-                    ) : (
-                        <span className="flex items-center gap-2">
-                            Start Construction
-                            <span className="opacity-70 font-normal">·</span>
-                            <span className="font-normal">
-                                <Money amount={facility.price} long />
-                            </span>
-                        </span>
-                    )}
-                </Button>
+
+                {/* Unlock requirements */}
+                {hasUnsatisfiedRequirements && (
+                    <RequirementsDisplay requirements={facility.requirements} />
+                )}
+
+                {/* Price + Action button */}
+                <div className="flex items-center justify-around">
+                    <Money
+                        amount={facility.price}
+                        long
+                        className="text-lg font-semibold"
+                    />
+                    <Button
+                        size="lg"
+                        onClick={handleConstruction}
+                        disabled={isLocked}
+                        variant={isLocked ? "destructive" : "default"}
+                        className="px-8 text-base font-bold"
+                    >
+                        {isLocked ? "Locked" : "Start Construction"}
+                    </Button>
+                </div>
             </div>
         </>
     );

--- a/frontend/src/components/facilities/requirements-display.tsx
+++ b/frontend/src/components/facilities/requirements-display.tsx
@@ -5,12 +5,13 @@
 
 import { Link } from "@tanstack/react-router";
 
-import { AssetName } from "@/components/ui/asset-name";
+import { TechnologyName } from "@/components/ui/asset-name";
 import {
     getTechnologyRoute,
     getFacilityRoute,
     isTechnology,
 } from "@/lib/facility-routes";
+import { cn } from "@/lib/utils";
 
 interface Requirement {
     name: string;
@@ -34,6 +35,16 @@ export function RequirementsDisplay({
                     const route = isTech
                         ? getTechnologyRoute(req.name)
                         : getFacilityRoute(req.name);
+                    const requirementComponent = (
+                        <TechnologyName
+                            technology={req.name}
+                            level={req.level}
+                            mode="long"
+                            className={cn(
+                                route && "underline hover:opacity-80",
+                            )}
+                        />
+                    );
 
                     return (
                         <li
@@ -48,18 +59,9 @@ export function RequirementsDisplay({
                         >
                             -{" "}
                             {route ? (
-                                <Link
-                                    to={route}
-                                    className="underline hover:opacity-80"
-                                >
-                                    <AssetName assetId={req.name} mode="long" className="underline" />{" "}
-                                    lvl {req.level}
-                                </Link>
+                                <Link to={route}>{requirementComponent}</Link>
                             ) : (
-                                <>
-                                    <AssetName assetId={req.name} mode="long" />{" "}
-                                    lvl {req.level}
-                                </>
+                                requirementComponent
                             )}
                         </li>
                     );

--- a/frontend/src/components/facilities/requirements-display.tsx
+++ b/frontend/src/components/facilities/requirements-display.tsx
@@ -52,7 +52,7 @@ export function RequirementsDisplay({
                                     to={route}
                                     className="underline hover:opacity-80"
                                 >
-                                    <AssetName assetId={req.name} mode="long" />{" "}
+                                    <AssetName assetId={req.name} mode="long" className="underline" />{" "}
                                     lvl {req.level}
                                 </Link>
                             ) : (

--- a/frontend/src/components/facilities/resource-stock-indicators.tsx
+++ b/frontend/src/components/facilities/resource-stock-indicators.tsx
@@ -49,7 +49,7 @@ export function ResourceStockIndicators({
     const isHydroFacility = hydroFacilities.includes(facilityName);
 
     return (
-        <>
+        <div className="mt-2">
             {/* Wind Potential */}
             {isWindFacility &&
                 windPotential !== undefined &&
@@ -135,6 +135,6 @@ export function ResourceStockIndicators({
                         return null;
                     },
                 )}
-        </>
+        </div>
     );
 }

--- a/frontend/src/components/layout/game-layout.tsx
+++ b/frontend/src/components/layout/game-layout.tsx
@@ -40,10 +40,12 @@ export function GameLayout({ children }: GameLayoutProps) {
                     <AppSidebar bgLogoRef={bgLogoRef} />
                     <SidebarInset>
                         <main
-                            className="flex-1 overflow-auto 2xl:px-50"
+                            className="flex-1 overflow-auto min-w-0"
                             onScroll={handleScroll}
                         >
-                            {children}
+                            <div className="max-w-[1400px] mx-auto">
+                                {children}
+                            </div>
                         </main>
                         <Toaster position="top-center" richColors />
                     </SidebarInset>

--- a/frontend/src/components/technologies/technology-detail-dialog.tsx
+++ b/frontend/src/components/technologies/technology-detail-dialog.tsx
@@ -3,12 +3,7 @@ import { ExternalLink } from "lucide-react";
 import { ReactNode } from "react";
 
 import { RequirementsDisplay, ConstructionInfo } from "@/components/facilities";
-import {
-    TechnologyIcon,
-    Money,
-    CardContent,
-    AssetName,
-} from "@/components/ui";
+import { TechnologyIcon, Money, CardContent, AssetName } from "@/components/ui";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -105,8 +100,8 @@ export function TechnologyDetailDialog<T>({
                             </div>
 
                             {/* Header */}
-                            <div className="space-y-1">
-                                <TypographyH2 className="flex items-center gap-2">
+                            <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                                <TypographyH2 className="flex items-center gap-2 mr-auto">
                                     <TechnologyIcon
                                         technology={technology.name}
                                         size={28}
@@ -130,18 +125,17 @@ export function TechnologyDetailDialog<T>({
                                             __html: technology.description,
                                         }}
                                     />
-                                    {" "}
-                                    <a
-                                        href={technology.wikipedia_link}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        className="inline-flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground"
-                                        onClick={(e) => e.stopPropagation()}
-                                    >
-                                        <ExternalLink className="w-3 h-3" />
-                                        Learn more
-                                    </a>
                                 </div>
+                                <a
+                                    href={technology.wikipedia_link}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground w-fit"
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    <ExternalLink className="w-3 h-3" />
+                                    Learn more
+                                </a>
                                 {/* Affected Facilities */}
                                 {technology.affected_facilities.length > 0 && (
                                     <div>
@@ -192,17 +186,6 @@ export function TechnologyDetailDialog<T>({
                                 )}
                             </CardContent>
 
-                            {/* Requirements */}
-                            {technology.requirements.some(
-                                (r) => r.status !== "satisfied",
-                            ) && (
-                                <CardContent>
-                                    <RequirementsDisplay
-                                        requirements={technology.requirements}
-                                    />
-                                </CardContent>
-                            )}
-
                             {/* Effects Table */}
                             <CardContent className="flex justify-around">
                                 {renderEffectsTable(technology)}
@@ -210,33 +193,65 @@ export function TechnologyDetailDialog<T>({
                         </div>
 
                         {/* Footer — always visible */}
-                        <div className="shrink-0 border-t border-border bg-background px-6 py-4 flex flex-wrap items-center justify-between gap-4">
+                        <div className="shrink-0 border-t border-border bg-background px-6 py-4 flex flex-col gap-3">
+                            {/* Construction info */}
                             <ConstructionInfo
                                 constructionTime={technology.construction_time}
-                                constructionPower={technology.construction_power}
+                                constructionPower={
+                                    technology.construction_power
+                                }
+                                className="w-full justify-evenly"
                             />
-                            <div className="flex items-center gap-3">
-                                {/* Knowledge spillover badge */}
-                                {technology.discount && (
-                                    <Tooltip>
-                                        <TooltipTrigger asChild>
-                                            <span className="inline-flex items-center rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 px-2.5 py-1 text-sm font-semibold cursor-help select-none">
-                                                −
-                                                {Math.round(
-                                                    (1 - technology.discount) *
-                                                        100,
-                                                )}
-                                                %
-                                            </span>
-                                        </TooltipTrigger>
-                                        <TooltipContent className="max-w-56 text-center leading-snug">
-                                            Knowledge spillover
-                                            {technology.prevalence
-                                                ? ` — ${technology.prevalence} other player${technology.prevalence > 1 ? "s have" : " has"} already researched this, reducing your cost.`
-                                                : " reduces your research cost."}
-                                        </TooltipContent>
-                                    </Tooltip>
-                                )}
+
+                            {/* Unlock requirements */}
+                            {technology.requirements.some(
+                                (r) => r.status !== "satisfied",
+                            ) && (
+                                <RequirementsDisplay
+                                    requirements={technology.requirements}
+                                />
+                            )}
+
+                            {/* Price + Action button */}
+                            <div className="flex items-center justify-around">
+                                <div className="flex items-center gap-2">
+                                    <Money
+                                        amount={Math.round(
+                                            technology.price *
+                                                (technology.discount ?? 1),
+                                        )}
+                                        long
+                                        className="text-lg font-semibold"
+                                    />
+                                    {/* Knowledge spillover badge */}
+                                    {technology.discount && (
+                                        <Tooltip>
+                                            <TooltipTrigger asChild>
+                                                <span className="inline-flex items-center rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 px-2.5 py-1 text-sm font-semibold cursor-help select-none">
+                                                    −
+                                                    {Math.round(
+                                                        (1 -
+                                                            technology.discount) *
+                                                            100,
+                                                    )}
+                                                    %
+                                                </span>
+                                            </TooltipTrigger>
+                                            <TooltipContent className="max-w-56 text-center leading-snug">
+                                                <Link
+                                                    to="/app/wiki/$slug"
+                                                    params={{
+                                                        slug: "technologies",
+                                                    }}
+                                                    hash="knowledge-spillover"
+                                                    className="underline hover:opacity-80"
+                                                >
+                                                    Knowledge spillover
+                                                </Link>
+                                            </TooltipContent>
+                                        </Tooltip>
+                                    )}
+                                </div>
                                 <Button
                                     size="lg"
                                     onClick={handleResearch}
@@ -253,29 +268,12 @@ export function TechnologyDetailDialog<T>({
                                     className="px-8 text-base font-bold"
                                 >
                                     {technology.requirements_status ===
-                                    "unsatisfied" ? (
-                                        "Locked"
-                                    ) : (
-                                        <span className="flex items-center gap-2">
-                                            {technology.requirements_status ===
+                                    "unsatisfied"
+                                        ? "Locked"
+                                        : technology.requirements_status ===
                                             "queued"
-                                                ? "Queue Research"
-                                                : "Start Research"}
-                                            <span className="opacity-70 font-normal">
-                                                ·
-                                            </span>
-                                            <span className="font-normal">
-                                                <Money
-                                                    amount={Math.round(
-                                                        technology.price *
-                                                            (technology.discount ??
-                                                                1),
-                                                    )}
-                                                    long
-                                                />
-                                            </span>
-                                        </span>
-                                    )}
+                                          ? "Queue Research"
+                                          : "Start Research"}
                                 </Button>
                             </div>
                         </div>

--- a/frontend/src/components/technologies/technology-detail-dialog.tsx
+++ b/frontend/src/components/technologies/technology-detail-dialog.tsx
@@ -17,6 +17,11 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { TypographyH2 } from "@/components/ui/typography";
 import { useQueueProject } from "@/hooks/use-projects";
 import { getFacilityRoute } from "@/lib/facility-routes";
@@ -68,7 +73,7 @@ export function TechnologyDetailDialog<T>({
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-            <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+            <DialogContent className="flex flex-col p-0 gap-0 overflow-hidden max-w-4xl">
                 {technology === null ? null : (
                     <>
                         <DialogHeader className="sr-only">
@@ -85,7 +90,8 @@ export function TechnologyDetailDialog<T>({
                             </DialogDescription>
                         </DialogHeader>
 
-                        <div className="space-y-6">
+                        {/* Scrollable body */}
+                        <div className="flex-1 min-h-0 overflow-y-auto p-6 space-y-6">
                             {/* Image */}
                             <div className="w-full overflow-hidden">
                                 <img
@@ -100,53 +106,137 @@ export function TechnologyDetailDialog<T>({
 
                             {/* Header */}
                             <div className="space-y-1">
-                                <div className="flex flex-wrap items-center justify-center gap-3">
-                                    <TypographyH2 className="flex items-center gap-2 mr-auto">
-                                        <TechnologyIcon
-                                            technology={technology.name}
-                                            size={28}
-                                        />
-                                        <AssetName
-                                            assetId={technology.name}
-                                            mode="long"
-                                        />
-                                    </TypographyH2>
-                                    <div className="flex items-center gap-3 shrink-0">
-                                        <div className="text-xl font-semibold">
-                                            <Money amount={technology.price} long />
-                                        </div>
-                                        {/* Knowledge spillover discount */}
-                                        {technology.discount && (
-                                            <div className="text-green-500 text-base">
-                                                <em>
-                                                    (-
-                                                    {Math.round(
-                                                        (1 - technology.discount) *
-                                                            100,
-                                                    )}
-                                                    %)
-                                                </em>
-                                                {technology.prevalence && (
-                                                    <span className="text-xs text-muted-foreground ml-1">
-                                                        ({technology.prevalence}{" "}
-                                                        other player
-                                                        {technology.prevalence > 1
-                                                            ? "s"
-                                                            : ""}
-                                                        )
-                                                    </span>
-                                                )}
-                                            </div>
-                                        )}
-                                    </div>
-                                </div>
-                                <p className="text-3xl text-muted-foreground text-center">
+                                <TypographyH2 className="flex items-center gap-2">
+                                    <TechnologyIcon
+                                        technology={technology.name}
+                                        size={28}
+                                    />
+                                    <AssetName
+                                        assetId={technology.name}
+                                        mode="long"
+                                    />
+                                </TypographyH2>
+                                <p className="text-2xl text-muted-foreground">
                                     Level {technology.level}
                                 </p>
                             </div>
 
-                            {/* Action Button */}
-                            <div className="flex justify-center">
+                            {/* Description & Learn More */}
+                            <CardContent className="space-y-2">
+                                <div className="[&_p:last-of-type]:inline">
+                                    <div
+                                        className="contents"
+                                        dangerouslySetInnerHTML={{
+                                            __html: technology.description,
+                                        }}
+                                    />
+                                    {" "}
+                                    <a
+                                        href={technology.wikipedia_link}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground"
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        <ExternalLink className="w-3 h-3" />
+                                        Learn more
+                                    </a>
+                                </div>
+                                {/* Affected Facilities */}
+                                {technology.affected_facilities.length > 0 && (
+                                    <div>
+                                        <strong>Affected facilities:</strong>{" "}
+                                        <span className="text-hyperlink">
+                                            {technology.affected_facilities.map(
+                                                (facilityName, idx) => {
+                                                    const route =
+                                                        getFacilityRoute(
+                                                            facilityName,
+                                                        );
+                                                    return (
+                                                        <span
+                                                            key={facilityName}
+                                                        >
+                                                            {route ? (
+                                                                <Link
+                                                                    to={route}
+                                                                    className="underline hover:opacity-80"
+                                                                >
+                                                                    <AssetName
+                                                                        assetId={
+                                                                            facilityName
+                                                                        }
+                                                                        mode="long"
+                                                                        className="underline"
+                                                                    />
+                                                                </Link>
+                                                            ) : (
+                                                                <AssetName
+                                                                    assetId={
+                                                                        facilityName
+                                                                    }
+                                                                    mode="long"
+                                                                />
+                                                            )}
+                                                            {idx <
+                                                                technology
+                                                                    .affected_facilities
+                                                                    .length -
+                                                                    1 && ", "}
+                                                        </span>
+                                                    );
+                                                },
+                                            )}
+                                        </span>
+                                    </div>
+                                )}
+                            </CardContent>
+
+                            {/* Requirements */}
+                            {technology.requirements.some(
+                                (r) => r.status !== "satisfied",
+                            ) && (
+                                <CardContent>
+                                    <RequirementsDisplay
+                                        requirements={technology.requirements}
+                                    />
+                                </CardContent>
+                            )}
+
+                            {/* Effects Table */}
+                            <CardContent className="flex justify-around">
+                                {renderEffectsTable(technology)}
+                            </CardContent>
+                        </div>
+
+                        {/* Footer — always visible */}
+                        <div className="shrink-0 border-t border-border bg-background px-6 py-4 flex flex-wrap items-center justify-between gap-4">
+                            <ConstructionInfo
+                                constructionTime={technology.construction_time}
+                                constructionPower={technology.construction_power}
+                            />
+                            <div className="flex items-center gap-3">
+                                {/* Knowledge spillover badge */}
+                                {technology.discount && (
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <span className="inline-flex items-center rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 px-2.5 py-1 text-sm font-semibold cursor-help select-none">
+                                                −
+                                                {Math.round(
+                                                    (1 - technology.discount) *
+                                                        100,
+                                                )}
+                                                %
+                                            </span>
+                                        </TooltipTrigger>
+                                        <TooltipContent className="max-w-56 text-center leading-snug">
+                                            Knowledge spillover
+                                            {technology.prevalence
+                                                ? ` — ${technology.prevalence} other player${technology.prevalence > 1 ? "s have" : " has"} already researched this, reducing your cost.`
+                                                : " reduces your research cost."}
+                                        </TooltipContent>
+                                    </Tooltip>
+                                )}
                                 <Button
                                     size="lg"
                                     onClick={handleResearch}
@@ -160,126 +250,33 @@ export function TechnologyDetailDialog<T>({
                                             ? "destructive"
                                             : "default"
                                     }
-                                    className="px-8 text-lg font-bold"
+                                    className="px-8 text-base font-bold"
                                 >
                                     {technology.requirements_status ===
-                                    "unsatisfied"
-                                        ? "Locked"
-                                        : technology.requirements_status ===
+                                    "unsatisfied" ? (
+                                        "Locked"
+                                    ) : (
+                                        <span className="flex items-center gap-2">
+                                            {technology.requirements_status ===
                                             "queued"
-                                          ? "Queue Research"
-                                          : "Start Research"}
-                                </Button>
-                            </div>
-
-                            {/* Requirements */}
-                            {technology.requirements.some(
-                                (r) => r.status !== "satisfied",
-                            ) && (
-                                <CardContent>
-                                    <RequirementsDisplay
-                                        requirements={technology.requirements}
-                                    />
-                                </CardContent>
-                            )}
-
-                            {/* Research Info */}
-                            <CardContent className="flex justify-around">
-                                <ConstructionInfo
-                                    constructionTime={
-                                        technology.construction_time
-                                    }
-                                    constructionPower={
-                                        technology.construction_power
-                                    }
-                                />
-                            </CardContent>
-
-                            <hr className="border-border" />
-
-                            {/* Description & Affected Facilities */}
-                            <CardContent>
-                                <div className="space-y-2">
-                                    <div
-                                        dangerouslySetInnerHTML={{
-                                            __html: technology.description,
-                                        }}
-                                    />
-                                    {technology.affected_facilities.length >
-                                        0 && (
-                                        <div>
-                                            <strong>
-                                                Affected facilities:
-                                            </strong>{" "}
-                                            <span className="text-hyperlink">
-                                                {technology.affected_facilities.map(
-                                                    (facilityName, idx) => {
-                                                        const route =
-                                                            getFacilityRoute(
-                                                                facilityName,
-                                                            );
-                                                        return (
-                                                            <span
-                                                                key={
-                                                                    facilityName
-                                                                }
-                                                            >
-                                                                {route ? (
-                                                                    <Link
-                                                                        to={
-                                                                            route
-                                                                        }
-                                                                        className="underline hover:opacity-80"
-                                                                    >
-                                                                        <AssetName
-                                                                            assetId={
-                                                                                facilityName
-                                                                            }
-                                                                            mode="long"
-                                                                            className="underline"
-                                                                        />
-                                                                    </Link>
-                                                                ) : (
-                                                                    <AssetName
-                                                                        assetId={
-                                                                            facilityName
-                                                                        }
-                                                                        mode="long"
-                                                                    />
-                                                                )}
-                                                                {idx <
-                                                                    technology
-                                                                        .affected_facilities
-                                                                        .length -
-                                                                        1 &&
-                                                                    ", "}
-                                                            </span>
-                                                        );
-                                                    },
-                                                )}
+                                                ? "Queue Research"
+                                                : "Start Research"}
+                                            <span className="opacity-70 font-normal">
+                                                ·
                                             </span>
-                                        </div>
+                                            <span className="font-normal">
+                                                <Money
+                                                    amount={Math.round(
+                                                        technology.price *
+                                                            (technology.discount ??
+                                                                1),
+                                                    )}
+                                                    long
+                                                />
+                                            </span>
+                                        </span>
                                     )}
-                                </div>
-                            </CardContent>
-
-                            {/* Effects Table */}
-                            <CardContent className="flex justify-around">
-                                {renderEffectsTable(technology)}
-                            </CardContent>
-
-                            {/* Learn More */}
-                            <div className="flex justify-center">
-                                <a
-                                    href={technology.wikipedia_link}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground"
-                                    onClick={(e) => e.stopPropagation()}
-                                >
-                                    <ExternalLink className="w-4 h-4" />
-                                    Learn more
-                                </a>
+                                </Button>
                             </div>
                         </div>
                     </>

--- a/frontend/src/components/technologies/technology-detail-dialog.tsx
+++ b/frontend/src/components/technologies/technology-detail-dialog.tsx
@@ -111,7 +111,7 @@ export function TechnologyDetailDialog<T>({
                                         mode="long"
                                     />
                                 </TypographyH2>
-                                <p className="text-2xl text-muted-foreground">
+                                <p className="text-3xl text-muted-foreground">
                                     Level {technology.level}
                                 </p>
                             </div>

--- a/frontend/src/components/technologies/technology-detail-dialog.tsx
+++ b/frontend/src/components/technologies/technology-detail-dialog.tsx
@@ -139,7 +139,7 @@ export function TechnologyDetailDialog<T>({
                                 {/* Affected Facilities */}
                                 {technology.affected_facilities.length > 0 && (
                                     <div>
-                                        <strong>Affected facilities:</strong>{" "}
+                                        <strong>Affects:</strong>{" "}
                                         <span className="text-hyperlink">
                                             {technology.affected_facilities.map(
                                                 (facilityName, idx) => {

--- a/frontend/src/components/technologies/technology-item.tsx
+++ b/frontend/src/components/technologies/technology-item.tsx
@@ -55,9 +55,9 @@ export function TechnologyItem({
                     <div className="flex items-center gap-2">
                         <Money amount={price} long />
                         {discount && (
-                            <div className="text-success text-xs">
-                                <em>(-{Math.round((1 - discount) * 100)}%)</em>
-                            </div>
+                            <span className="inline-flex items-center rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 px-2 py-0.5 text-xs font-semibold select-none">
+                                −{Math.round((1 - discount) * 100)}%
+                            </span>
                         )}
                     </div>
                     <span>Level {level}</span>

--- a/frontend/src/components/ui/asset-name.tsx
+++ b/frontend/src/components/ui/asset-name.tsx
@@ -66,16 +66,14 @@ export function AssetName({
     if (mode === "auto" && assetName.long !== assetName.short) {
         return (
             <Component className={className} title={assetName.long}>
-                {assetName.short}
-                <div className="text-muted-foreground">{suffix}</div>
+                {assetName.short} {suffix}
             </Component>
         );
     }
 
     return (
         <Component className={cn("inline-flex gap-1", className)}>
-            {displayText}
-            <div className="text-muted-foreground">{suffix}</div>
+            {displayText} {suffix}
         </Component>
     );
 }

--- a/frontend/src/components/ui/catalog-grid.tsx
+++ b/frontend/src/components/ui/catalog-grid.tsx
@@ -4,19 +4,9 @@ interface CatalogGridProps {
     children: ReactNode;
 }
 
-/**
- * Responsive grid layout for catalog pages (facilities, technologies).
- *
- * Breakpoints:
- *
- * - Mobile: 1 column
- * - Small (sm): 2 columns
- * - Large (lg): 3 columns
- * - Extra large (xl): 4 columns
- */
 export function CatalogGrid({ children }: CatalogGridProps) {
     return (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
             {children}
         </div>
     );

--- a/frontend/src/routes/app/facilities/extraction.tsx
+++ b/frontend/src/routes/app/facilities/extraction.tsx
@@ -12,12 +12,7 @@ import {
 } from "@/components/dashboard/projects-panel";
 import { FacilityItem, FacilityDetailDialog } from "@/components/facilities";
 import { GameLayout } from "@/components/layout/game-layout";
-import {
-    ResourceName,
-    CashFlow,
-    Duration,
-    CatalogGrid,
-} from "@/components/ui";
+import { ResourceName, CashFlow, Duration, CatalogGrid } from "@/components/ui";
 import { usePlayerResources } from "@/hooks/use-player-resources";
 import {
     useExtractionFacilitiesCatalog,
@@ -66,7 +61,10 @@ export const Route = createFileRoute("/app/facilities/extraction")({
             isUnlocked: (cap) =>
                 cap.has_warehouse
                     ? { unlocked: true }
-                    : { unlocked: false, reason: "Build a Warehouse to unlock" },
+                    : {
+                          unlocked: false,
+                          reason: "Build a Warehouse to unlock",
+                      },
         },
         infoDialog: {
             contents: <ExtractionFacilitiesHelp />,
@@ -178,14 +176,14 @@ function ExtractionFacilitiesContent() {
                         onClose={() => navigate({ search: {} })}
                         facility={selectedFacility}
                         facilityType="extraction"
-                        renderDescription={(facility) => (
+                        renderDescription={(facility, learnMore) => (
                             <div>
                                 <div
-                                    className="mb-2"
                                     dangerouslySetInnerHTML={{
                                         __html: facility.description,
                                     }}
                                 />
+                                {learnMore}
 
                                 {/* Underground reserves indicator */}
                                 {resourcesData && (
@@ -220,7 +218,6 @@ function ExtractionFacilitiesContent() {
                     />
                 </>
             )}
-
         </div>
     );
 }

--- a/frontend/src/routes/app/facilities/power.tsx
+++ b/frontend/src/routes/app/facilities/power.tsx
@@ -228,14 +228,14 @@ function PowerFacilitiesContent() {
                                     },
                                 })
                             }
-                            renderDescription={(facility) => (
+                            renderDescription={(facility, learnMore) => (
                                 <div>
                                     <div
-                                        className="mb-2"
                                         dangerouslySetInnerHTML={{
                                             __html: facility.description,
                                         }}
                                     />
+                                    {learnMore}
                                     <ResourceStockIndicators
                                         facilityName={facility.name}
                                         windPotential={facility.wind_potential}

--- a/frontend/src/routes/app/facilities/storage.tsx
+++ b/frontend/src/routes/app/facilities/storage.tsx
@@ -287,7 +287,9 @@ function StorageFacilityStatsTable({
 
                     {/* Efficiency */}
                     <tr className="border-b border-border/30">
-                        <td className="py-2 px-4 font-semibold">Efficiency</td>
+                        <td className="py-2 px-4 font-semibold">
+                            Round-trip efficiency
+                        </td>
                         <td className="py-2 px-4 text-center font-mono">
                             {Math.round(facility.efficiency)}%
                         </td>
@@ -393,7 +395,7 @@ function StorageFacilityComparisonRows({
             {/* Efficiency */}
             <tr className="border-b border-border/30">
                 <td className="py-2 px-4 font-semibold bg-muted/30 sticky left-0">
-                    Efficiency
+                    Round-trip efficiency
                 </td>
                 {facilities.map((facility) => (
                     <td


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reworks the facility and technology detail dialogs with a sticky-footer layout: construction/research info and the action button (now embedding the price) are pinned at the bottom, while the rest of the card content scrolls. It also converts `ConstructionInfo` labels to icon-only pairs, redesigns the knowledge-spillover indicator as a tooltip badge, and moves the "Learn more" link inline with the description using a `[&_p:last-of-type]:inline` CSS trick.

All remaining findings are P2 style notes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely presentational with no logic regressions.

All findings are P2 style/robustness suggestions. The scroll-layout relies correctly on DialogContent's built-in max-h-[90vh] (confirmed by reading the component), overflow conflicts are resolved properly via tailwind-merge, and the discount price calculation is correct. No P0/P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/facilities/construction-info.tsx | Replaced text labels with icons (Clock, Zap, Cloud) placed before values; reordered Zap to be a leading icon instead of trailing; minor gap/layout tweaks. |
| frontend/src/components/facilities/requirements-display.tsx | Added className="underline" to AssetName inside a Link that already applies underline — redundant but not harmful. |
| frontend/src/components/facilities/facility-detail-dialog.tsx | Reworked layout to scrollable body + sticky footer with ConstructionInfo and price-embedded action button; description/requirements/stats reordered; compare button moved to stats section. |
| frontend/src/components/technologies/technology-detail-dialog.tsx | Same sticky-footer pattern as facility dialog; knowledge-spillover redesigned as a tooltip badge; research button now embeds the discounted price; description + learn-more link now inline via [&_p:last-of-type]:inline trick. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    DC["DialogContent\nflex-col, p-0, gap-0, overflow-hidden\n(+ max-h-90vh from base)"]
    SR["sr-only DialogHeader"]
    SB["Scrollable Body\nflex-1, min-h-0, overflow-y-auto, p-6"]
    IMG["Image (aspect-[3/1])"]
    HDR["Header (Icon + Name)"]
    DESC["Description + Learn More\n[&_p:last-of-type]:inline trick"]
    REQ["Requirements (if any unsatisfied)"]
    STATS["Stats Table + Compare button"]
    FT["Footer — shrink-0, always visible\nborder-t, bg-background"]
    CI["ConstructionInfo\n(Clock · Zap · Cloud icons)"]
    BTN["Action Button\nLocked | Start Construction · price"]

    DC --> SR
    DC --> SB
    DC --> FT
    SB --> IMG
    SB --> HDR
    SB --> DESC
    SB --> REQ
    SB --> STATS
    FT --> CI
    FT --> BTN
```

<sub>Reviews (1): Last reviewed commit: ["feat: rework facility and research cards"](https://github.com/felixvonsamson/energetica/commit/562a67ddfad6d424f084693ebafbdb5165df6c48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27299495)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->