### PR TITLE
feat: add animations to project priority lists

### DIFF
--- a/frontend/src/components/dashboard/progress-lists.tsx
+++ b/frontend/src/components/dashboard/progress-lists.tsx
@@ -51,7 +51,7 @@ export function ProjectList({ projectCategory }: ProjectListProps) {
 
     return (
         <div className="flex flex-col gap-2">
-            <AnimatePresence>
+            <AnimatePresence initial={false}>
                 {projects.map((project) => (
                     <motion.div
                         key={project.id}
@@ -307,9 +307,11 @@ function ProgressCard({
             {/* Header row: Badge, Title, Actions */}
             <div className="flex items-center justify-between gap-2 mb-1.5">
                 <div className="flex items-center gap-2 flex-1 min-w-0">
-                    {!(status === "ongoing" && speed !== undefined && speed === 0) && (
-                        <StatusBadge status={status} size="sm" />
-                    )}
+                    {!(
+                        status === "ongoing" &&
+                        speed !== undefined &&
+                        speed === 0
+                    ) && <StatusBadge status={status} size="sm" />}
                     {speed !== undefined && speed < 1.0 && (
                         <StatusBadge
                             status={speed > 0 ? "slowed" : "stopped"}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `framer-motion` animations to the project priority lists in the dashboard. Each `ProjectItem` is now wrapped in a `motion.div` with fade-in/out (`opacity`) and smooth layout reordering (`layout` prop) animations. The `framer-motion` library is already a declared project dependency, so no new dependency is introduced.

Key changes:
- `AnimatePresence` wraps the project list to handle exit animations when a project is removed/cancelled.
- The `layout` prop enables automatic position animation when items reorder (e.g., on priority change).
- The CSS class was changed from `space-y-2` to `flex flex-col gap-2`, which is a functionally equivalent spacing approach more compatible with flex-based layout animation.
- One UX concern: `AnimatePresence` is missing `initial={false}`, which means all projects in the list will fade in on the component's initial mount (when data first loads), not just newly-added items.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the animation logic is straightforward and the only concern is a minor UX polish issue with initial mount animations.

The change is small and well-scoped — it adds framer-motion animations to an existing list component. framer-motion is already a declared dependency, keys are correctly placed, and the layout + AnimatePresence combination is an idiomatic pattern for animated lists. The only issue is the missing initial={false} on AnimatePresence, which causes all existing items to unnecessarily fade in on first render. This is a cosmetic/UX concern, not a functional bug.

No files require special attention beyond the initial={false} suggestion in progress-lists.tsx.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/dashboard/progress-lists.tsx | Adds framer-motion AnimatePresence + motion.div with layout prop around ProjectItem list items; framer-motion is already a declared dependency. One minor UX concern: missing initial={false} on AnimatePresence causes all existing items to fade in on initial mount. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProjectList mounts] --> B{projects undefined?}
    B -- Yes --> C[Show loading state]
    B -- No --> D[Render flex-col container]
    D --> E[AnimatePresence]
    E --> F[motion.div per project]
    F --> G[ProjectItem renders]
    G --> H[ProgressCard and priority arrows]

    subgraph Framer Motion Animations
        I[Item added] --> J[Fade in via opacity]
        K[Item removed] --> L[Fade out via opacity]
        M[Priority changed] --> N[Slide via layout prop]
    end
```

<sub>Reviews (1): Last reviewed commit: ["feat: add animations to project priority..."](https://github.com/felixvonsamson/energetica/commit/654506a5ac6413d1be9ba23aaafa8b258a914894) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27312131)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->