### PR TITLE
fix: add query key invalidation when marking notifications as read

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -315,8 +315,9 @@ class Player(DBModel):
 
     def delete_notification(self, notification: Notification) -> None:
         """Delete a notification."""
-        if notification.player == self:
-            notification.delete()
+        if notification.player != self:
+            return
+        notification.delete()
         # TODO(mglst): see TODO below for `notifications_read`
         self.invalidate_queries(["notifications"])
 

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -317,11 +317,17 @@ class Player(DBModel):
         """Delete a notification."""
         if notification.player == self:
             notification.delete()
+        # TODO(mglst): see TODO below for `notifications_read`
+        self.invalidate_queries(["notifications"])
 
     def notifications_read(self) -> None:
         """Mark all notifications as read."""
         for notification in self.unread_notifications():
             notification.read = True
+        # TODO(mglst): note that this forces _all_ notification data to be sent. We could do this more strategically,
+        # and only invalidate notifications that were unread, since they're the only ones for which data has changed.
+        # This would require implementing a GET for individual notification IDs, which currently does not exist
+        self.invalidate_queries(["notifications"])
 
     def unread_notifications(self) -> list[Notification]:
         """Return all unread notifications."""


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds React Query cache invalidation after notification mutations (`delete_notification` and `notifications_read`), fixing stale UI state when notifications are deleted or marked as read. The only minor concern is that in `delete_notification`, the `invalidate_queries` call sits outside the `if notification.player == self:` guard, so it fires even when no deletion occurred — causing a needless frontend refetch but no incorrect data.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the single finding is a minor inefficiency that does not affect data correctness.

All findings are P2 style/performance issues. No data integrity, security, or logic bugs were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/player.py | Adds `invalidate_queries(["notifications"])` to `delete_notification` and `notifications_read`; the call in `delete_notification` sits outside the ownership guard and fires unconditionally |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant P as player.py
    participant FE as Frontend (React Query)

    C->>P: delete_notification(notification)
    alt notification.player == self
        P->>P: notification.delete()
    end
    P->>FE: emit("invalidate", ["notifications"])
    FE->>FE: refetch /notifications

    C->>P: notifications_read()
    P->>P: mark all unread notifications as read
    P->>FE: emit("invalidate", ["notifications"])
    FE->>FE: refetch /notifications
```

<sub>Reviews (1): Last reviewed commit: ["fix: add query key invalidation when mar..."](https://github.com/felixvonsamson/energetica/commit/2778970f57cf051f9bc5e4275bffcd458e6c01d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27364313)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->