### PR TITLE
Fix/626/prices when outside network

### DIFF
--- a/energetica/routers/electricity_markets.py
+++ b/energetica/routers/electricity_markets.py
@@ -87,8 +87,6 @@ async def change_electricity_market_prices(
     """Update the asking prices and bid prices for a player on their electricity market."""
     if not player.achievements["network"]:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail=UNLOCK_NETWORK_MESSAGE)
-    if player.network is None:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     player.network_prices.update(
         updated_asks={ask.type: ask.price for ask in prices_change_request.asks},
         updated_bids={bid.type: bid.price for bid in prices_change_request.bids},


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #626 by removing the `player.network is None` guard in `change_electricity_market_prices`, allowing players to update their market ask/bid prices even when they are not currently a member of any electricity market network.

- The removed guard was overly restrictive: `NetworkPrices.update()` only modifies the player's internal `ask_prices` and `bid_prices` dictionaries with no dependency on `player.network`, making it safe to call at any time
- `player.network_prices` is always initialized via `default_factory=NetworkPrices`, so there is no risk of a null-reference error
- This is consistent with the `power_priorities.py` routes, which also call `player.network_prices` methods without checking network membership
- `frontend/src/components/dashboard/progress-lists.tsx` appears in the diff due to the base branch delta from a prior merge (PR #624 animations) and is unrelated to this fix

<h3>Confidence Score: 5/5</h3>

Safe to merge — the removed check was unnecessary and the fix is consistent with the rest of the codebase

The only meaningful change is removing a superfluous null-network guard. NetworkPrices.update() operates solely on internal price dictionaries and has no dependency on network membership. All other routes in power_priorities.py call network_prices methods without this guard. No new risk is introduced.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/routers/electricity_markets.py | Removes overly-restrictive `player.network is None` guard; `NetworkPrices.update()` is safe to call regardless of network membership |
| frontend/src/components/dashboard/progress-lists.tsx | Animations added via framer-motion (from prior PR #624 merge); no issues related to this fix |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PATCH /electricity-markets/prices] --> B{Has network achievement?}
    B -- No --> C[403 Forbidden<br/>Unlock Network first]
    B -- Yes --> D[player.network_prices.update<br/>updated_asks + updated_bids]
    D --> E[engine.log]
    E --> F[player.invalidate_queries<br/>power-priorities]
    F --> G[204 No Content]
```

<sub>Reviews (1): Last reviewed commit: ["fix: allow players to change prices when..."](https://github.com/felixvonsamson/energetica/commit/1e022a25bcae5f9db7e17294812e0b668c9492d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27366193)</sub>

<!-- /greptile_comment -->