### PR TITLE
fix: double badge bug

### DIFF
--- a/frontend/src/components/dashboard/progress-lists.tsx
+++ b/frontend/src/components/dashboard/progress-lists.tsx
@@ -307,16 +307,13 @@ function ProgressCard({
             {/* Header row: Badge, Title, Actions */}
             <div className="flex items-center justify-between gap-2 mb-1.5">
                 <div className="flex items-center gap-2 flex-1 min-w-0">
-                    {!(
-                        status === "ongoing" &&
-                        speed !== undefined &&
-                        speed === 0
-                    ) && <StatusBadge status={status} size="sm" />}
-                    {speed !== undefined && speed < 1.0 && (
+                    {speed !== undefined && speed < 1.0 ? (
                         <StatusBadge
                             status={speed > 0 ? "slowed" : "stopped"}
                             size="sm"
                         />
+                    ) : (
+                        <StatusBadge status={status} size="sm" />
                     )}
                     {label}
                 </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces two independent conditional renders with a single ternary in `ProgressCard`, ensuring only one `StatusBadge` is shown at a time. Previously, when `speed` was between 0 (exclusive) and 1.0 (exclusive), both the `status` badge and the `"slowed"` badge would render simultaneously; the only suppression condition guarded `speed === 0`, leaving the `"slowed"` case uncovered. The ternary correctly unifies these branches so the speed-derived badge (`"slowed"` / `"stopped"`) takes precedence whenever `speed !== undefined && speed < 1.0`, and the original status badge is shown in all other cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a targeted, correct fix for a visual double-badge bug.

The logic change is small and all edge cases (speed=undefined, speed=0, 0<speed<1, speed≥1) are handled correctly by the ternary. No P0/P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/dashboard/progress-lists.tsx | Ternary replaces two independent conditionals to fix double-badge rendering when speed is between 0 and 1. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Render ProgressCard header] --> B{speed !== undefined
AND speed < 1.0?}
    B -- Yes --> C{speed > 0?}
    C -- Yes --> D[StatusBadge: 'slowed']
    C -- No --> E[StatusBadge: 'stopped']
    B -- No --> F[StatusBadge: status prop]
```

<sub>Reviews (1): Last reviewed commit: ["fix: double badge bug"](https://github.com/felixvonsamson/energetica/commit/a547a4b72614b1980486804d74ab281b61f5a0f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27389411)</sub>

<!-- /greptile_comment -->