### PR TITLE
feat: add windspeed cutoff status badge for wind facilities in the facility management page

### DIFF
--- a/frontend/src/routes/app/facilities/manage.tsx
+++ b/frontend/src/routes/app/facilities/manage.tsx
@@ -5,11 +5,12 @@ import { useState } from "react";
 
 import { FacilityGroupTable } from "@/components/facilities/facility-group-table";
 import { GameLayout } from "@/components/layout/game-layout";
+import { StatusBadge } from "@/components/power-priorities/status-badge";
 import { CardContent, CardHeader, CardTitle, PageCard } from "@/components/ui";
 import { FacilityGauge } from "@/components/ui/facility-gauge";
 import { dummyFacilities } from "@/data/dummyFacilities";
 import { useHasCapability } from "@/hooks/use-capabilities";
-import { useFacilities } from "@/hooks/use-facilities";
+import { useFacilities, useFacilityStatuses } from "@/hooks/use-facilities";
 import { formatPower, formatEnergy, formatMassRate } from "@/lib/format-utils";
 
 type FacilityCategory = "power" | "storage" | "extraction";
@@ -63,6 +64,7 @@ function FacilityManagementContent() {
         isLoading: facilitiesLoading,
         error: facilitiesError,
     } = useFacilities();
+    const { data: statusesData } = useFacilityStatuses();
     const hasStorage = useHasCapability("has_storage");
     const hasWarehouse = useHasCapability("has_warehouse");
 
@@ -123,6 +125,51 @@ function FacilityManagementContent() {
                                         displayFacilities.power_facilities
                                     }
                                     columns={[
+                                        {
+                                            header: "Status",
+                                            className: "text-center",
+                                            render: (f) => {
+                                                const renewableStatus =
+                                                    statusesData?.renewables[
+                                                        f.facility
+                                                    ];
+                                                if (!renewableStatus)
+                                                    return null;
+                                                return (
+                                                    <div className="inline-flex justify-center">
+                                                        <StatusBadge
+                                                            status={
+                                                                renewableStatus
+                                                            }
+                                                            variant="iconOnly"
+                                                        />
+                                                    </div>
+                                                );
+                                            },
+                                            renderSummary: (facilities) => {
+                                                const facilityType =
+                                                    facilities[0]?.facility;
+                                                const renewableStatus =
+                                                    facilityType
+                                                        ? statusesData
+                                                              ?.renewables[
+                                                              facilityType
+                                                          ]
+                                                        : undefined;
+                                                if (!renewableStatus)
+                                                    return null;
+                                                return (
+                                                    <div className="inline-flex justify-center">
+                                                        <StatusBadge
+                                                            status={
+                                                                renewableStatus
+                                                            }
+                                                            variant="iconOnly"
+                                                        />
+                                                    </div>
+                                                );
+                                            },
+                                        },
                                         {
                                             header: "Max Power",
                                             className: "text-right",


### PR DESCRIPTION
Fixes windspeed cutoff badge should also be in managment table Fixes #637

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes issue #637 by adding a "Status" column to the Power Facilities management table that displays the `StatusBadge` (wind cutoff icon with tooltip) for wind facilities experiencing high-wind cutoff, reusing the existing `useFacilityStatuses` hook and `StatusBadge` component already in use on the power priorities page. The implementation correctly guards with `!renewableStatus` so non-renewable facilities and normally-operating renewables render nothing in the cell.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the implementation is correct and follows existing codebase patterns

Single-file UI change with no logic errors. The renderSummary correctly picks facilities[0].facility since all items in a group share the same type. The !renewableStatus guard correctly handles both non-renewable facilities and normally-operating renewables. The only finding is a P2 UX note about the Status header being visible even when no renewable facilities exist, which does not block merge.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/app/facilities/manage.tsx | Adds Status column to Power Facilities table showing windspeed cutoff badge for renewable facilities via useFacilityStatuses hook |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Power Facilities Table renders] --> B[useFacilityStatuses hook]
    B --> C{statusesData available?}
    C -- No --> D[Status cell returns null]
    C -- Yes --> E{renewables map has entry\nfor f.facility type?}
    E -- No entry --> F[Return null\nnormal op or non-renewable]
    E -- Has entry --> G[Render StatusBadge\nvariant=iconOnly]
    G --> H{Status value}
    H -- high_wind_cutoff --> I[Red Wind icon\nTooltip: High Wind Cutoff]
    H -- other --> J[Corresponding badge icon]
```

<sub>Reviews (1): Last reviewed commit: ["feat: add windspeed cutoff status badge ..."](https://github.com/felixvonsamson/energetica/commit/3403da66f62f10c1bb813118c8704f8116428d07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27398937)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->