### PR TITLE
Hotfix/migrating pickle keys

### DIFF
--- a/energetica/database/engine_data/circular_buffer_player.py
+++ b/energetica/database/engine_data/circular_buffer_player.py
@@ -56,6 +56,14 @@ class CircularBufferPlayer:
             },
         }
 
+    def __setstate__(self, state: dict) -> None:
+        """Migrate old pickle data by adding missing keys introduced in newer versions."""
+        self.__dict__.update(state)
+        if "storage_soc" not in self._data:
+            self._data["storage_soc"] = {
+                facility: deque([0.0] * 360, maxlen=360) for facility in self._data.get("storage", {})
+            }
+
     def append_value(self, new_value: dict) -> None:
         """Add one new tick of data to the buffer."""
         for category, subcategories in new_value.items():

--- a/energetica/database/engine_data/circular_buffer_player.py
+++ b/energetica/database/engine_data/circular_buffer_player.py
@@ -59,10 +59,14 @@ class CircularBufferPlayer:
     def __setstate__(self, state: dict) -> None:
         """Migrate old pickle data by adding missing keys introduced in newer versions."""
         self.__dict__.update(state)
-        if "storage_soc" not in self._data:
-            self._data["storage_soc"] = {
-                facility: deque([0.0] * 360, maxlen=360) for facility in self._data.get("storage", {})
-            }
+        fresh = CircularBufferPlayer()
+        for key, default_subcategories in fresh._data.items():
+            if key not in self._data:
+                self._data[key] = {sub: deque([0.0] * 360, maxlen=360) for sub in default_subcategories}
+        # storage_soc mirrors storage facilities, not just the defaults
+        for facility in self._data.get("storage", {}):
+            if facility not in self._data["storage_soc"]:
+                self._data["storage_soc"][facility] = deque([0.0] * 360, maxlen=360)
 
     def append_value(self, new_value: dict) -> None:
         """Add one new tick of data to the buffer."""

--- a/energetica/database/engine_data/circular_buffer_player.py
+++ b/energetica/database/engine_data/circular_buffer_player.py
@@ -63,6 +63,10 @@ class CircularBufferPlayer:
         for key, default_subcategories in fresh._data.items():
             if key not in self._data:
                 self._data[key] = {sub: deque([0.0] * 360, maxlen=360) for sub in default_subcategories}
+            else:
+                for sub in default_subcategories:
+                    if sub not in self._data[key]:
+                        self._data[key][sub] = deque([0.0] * 360, maxlen=360)
         # storage_soc mirrors storage facilities, not just the defaults
         for facility in self._data.get("storage", {}):
             if facility not in self._data["storage_soc"]:

--- a/energetica/routers/charts.py
+++ b/energetica/routers/charts.py
@@ -66,7 +66,10 @@ def _load_pickle_data(
         return defaultdict(lambda: defaultdict(list))
     try:
         with open(file_path, "rb") as file:
-            return pickle.load(file)
+            data = pickle.load(file)
+        result: dict = defaultdict(lambda: defaultdict(list))
+        result.update(data)
+        return result
     except Exception:
         # Return empty structure if pickle is corrupted
         return defaultdict(lambda: defaultdict(list))


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix addresses backward-compatibility issues when deserializing older pickle files that are missing keys introduced in newer versions of the code — specifically the `storage_soc` key. The PR takes a two-pronged approach: adding a `__setstate__` method to `CircularBufferPlayer` for in-memory migration of missing top-level keys during unpickling, and wrapping loaded pickle data in a `defaultdict` in `_load_pickle_data` so missing category keys don't raise `KeyError` in the charts router.

- `__setstate__` correctly handles missing top-level keys by diffing against a fresh instance's defaults, and correctly syncs `storage_soc` facilities from the `storage` dict with proper ordering
- The `charts.py` `defaultdict` wrapping is safe because downstream subcategory access in `_get_time_series_data` is guarded by `if series_key in pickle_data[data_category]`
- The `__setstate__` only migrates missing *top-level* keys — missing subcategories within existing top-level keys (e.g. a new item added to `"revenues"`) would not be migrated, which is a latent gap if new fixed subcategories are introduced in future versions

<h3>Confidence Score: 4/5</h3>

Safe to merge as a hotfix; correctly addresses the production storage_soc KeyError with no regressions introduced

The two changes are targeted and logically correct for the stated problem. The charts.py fix is entirely safe. The __setstate__ fix handles the primary migration scenario correctly with proper ordering. One point deducted because __setstate__ leaves a latent gap: missing subcategories within existing top-level keys are not migrated, which could cause KeyError crashes if new fixed subcategories are added to categories like revenues or demand in future versions.

circular_buffer_player.py — the __setstate__ subcategory migration gap should be addressed before new default subcategories are added to existing top-level categories

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/engine_data/circular_buffer_player.py | Adds __setstate__ for pickle migration of missing top-level keys and storage_soc facilities; does not handle missing subcategories within existing top-level keys |
| energetica/routers/charts.py | Wraps loaded pickle data in defaultdict to handle missing top-level category keys gracefully; safe because all subcategory accesses are guarded by 'in' checks |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as charts.py
    participant P as pickle.load()
    participant CB as CircularBufferPlayer
    participant SS as __setstate__

    C->>P: open(file_path, 'rb')
    P-->>C: data (plain dict or defaultdict)
    C->>C: result = defaultdict(lambda: defaultdict(list))
    C->>C: result.update(data)
    Note over C: Missing top-level keys → defaultdict(list)<br/>Existing keys → plain dict values from pickle
    C-->>C: return result

    Note over CB,SS: On pickle.load() for CircularBufferPlayer
    P->>SS: __setstate__(state)
    SS->>SS: self.__dict__.update(state)
    SS->>CB: fresh = CircularBufferPlayer()
    loop For each key in fresh._data
        SS->>SS: if key not in self._data → add with defaults
    end
    loop For each facility in self._data["storage"]
        SS->>SS: if facility not in self._data["storage_soc"] → add
    end
    SS-->>P: migration complete
```

<sub>Reviews (1): Last reviewed commit: ["hotfix: pickle files"](https://github.com/felixvonsamson/energetica/commit/20f54eafbe603f56e9668343c4638bce3304736d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27402400)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->