### PR TITLE
changed default theme to light

### DIFF
--- a/frontend/src/contexts/theme-context.tsx
+++ b/frontend/src/contexts/theme-context.tsx
@@ -25,7 +25,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         }
 
         // Default to auto mode
-        return "auto";
+        return "light";
     });
 
     const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">(() => {

--- a/frontend/src/contexts/theme-context.tsx
+++ b/frontend/src/contexts/theme-context.tsx
@@ -24,7 +24,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
             return stored;
         }
 
-        // Default to auto mode
+        // Default to light mode
         return "light";
     });
 


### PR DESCRIPTION
I think it's good that we provide the option for a dark and auto theme but I'd really like to set the default theme as the light one. I really want to promote the visual identity of Energetica that is clearly more compelling in light theme. Players that need the dark theme will find it without problems.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes the default theme for new users (no stored `localStorage` preference) from `\"auto\"` (system preference) to `\"light\"`. Existing users who have already chosen a theme are unaffected, as the `localStorage` check still runs first.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line default value update with no correctness issues.

The only finding is a stale inline comment (P2). The logic is correct: existing users keep their stored preference, and new users now default to light instead of auto.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/contexts/theme-context.tsx | Default fallback theme changed from "auto" to "light" for first-time users (no localStorage entry); stale comment remains on line 27. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ThemeProvider mounts] --> B{localStorage 'theme' set?}
    B -- yes --> C[Use stored theme]
    B -- no --> D["Default: 'light' (was 'auto')"]
    C --> E[Apply theme to document]
    D --> E
    E --> F{theme === 'auto'?}
    F -- yes --> G[Resolve via prefers-color-scheme]
    F -- no --> H[Use theme directly]
    G --> I[Save to localStorage]
    H --> I
```

<sub>Reviews (1): Last reviewed commit: ["changed default theme to light"](https://github.com/felixvonsamson/energetica/commit/25f5ea8506706354c3e6d8e988ceaf829d993ea0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27871088)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->