### PR TITLE
fix: resource double-counting on purchase

### DIFF
--- a/energetica/utils/resource_market.py
+++ b/energetica/utils/resource_market.py
@@ -64,7 +64,6 @@ def purchase_resource(buyer: Player, quantity: float, sale: ResourceOnSale) -> R
         buyer.money -= total_price
         sale.player.money += total_price
         sale.player.resources[sale.resource] -= quantity
-        buyer.resources[sale.resource] += quantity
         sale.player.resources_on_sale[sale.resource] -= quantity
         buyer.progression_metrics["bought_resources"] += quantity
         sale.player.progression_metrics["sold_resources"] += quantity

--- a/tests/integration/test_resource_market.py
+++ b/tests/integration/test_resource_market.py
@@ -10,6 +10,7 @@ from energetica.enums import (
 from energetica.init_test_players import add_asset
 from energetica.utils.auth import generate_password_hash
 from energetica.utils.map_helpers import confirm_location
+from energetica.database.ongoing_shipment import OngoingShipment
 from energetica.utils.resource_market import create_ask, purchase_resource, store_import
 
 
@@ -54,7 +55,13 @@ def test_purchase_resource() -> None:
     player2.money = 200_000
     assert player2.resources[Fuel.COAL] == 0
     remaining_sale = purchase_resource(player2, 100_000, sale)
-    assert player2.resources[Fuel.COAL] == 100_000
+    # Resources are not credited immediately — they arrive via shipment
+    assert player2.resources[Fuel.COAL] == 0
     assert player2.money == 100_000
+    # Verify an OngoingShipment was created for the buyer
+    shipments = list(OngoingShipment.filter(lambda s: s.player == player2))
+    assert len(shipments) == 1
+    assert shipments[0].resource == Fuel.COAL
+    assert shipments[0].quantity == 100_000
     assert player1.resources[Fuel.COAL] == 150_000
     assert player1.money == 100_000


### PR DESCRIPTION
## Summary
- Fixes resource duplication bug where bought resources were credited to the buyer's warehouse immediately on purchase **and** again when the shipment arrived via `store_import()`
- Removed the immediate `buyer.resources[sale.resource] += quantity` in `purchase_resource()` — resources are now only added on shipment arrival

Fixes #645

## Test plan
- [ ] Buy resources from another player on the market
- [ ] Verify warehouse does **not** increase immediately after purchase
- [ ] Verify resources are credited once the shipment arrives
- [ ] Verify the correct quantity is added (no duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a resource double-counting bug where `purchase_resource()` was immediately crediting the buyer's warehouse AND later crediting again when the `OngoingShipment` arrived via `store_import()`. The fix removes the premature `buyer.resources[sale.resource] += quantity` line, so resources are credited only on shipment arrival. The test is updated to assert the correct post-purchase state and verify an `OngoingShipment` is created.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line removal of a well-identified bug with an updated test confirming correct behaviour.

The change is minimal and precisely targets the double-counting root cause. The test update correctly validates the post-fix semantics (no immediate credit, shipment created), and the existing `test_store_import` covers the arrival path. No other paths in the function are affected.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| energetica/utils/resource_market.py | Removed the premature `buyer.resources[sale.resource] += quantity` line — resources are now only credited when the shipment arrives via `store_import()`. |
| tests/integration/test_resource_market.py | Updated assertion to `resources[COAL] == 0` after purchase, and added checks that exactly one `OngoingShipment` was created for the buyer with the correct resource and quantity. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Buyer
    participant purchase_resource
    participant Seller
    participant OngoingShipment
    participant store_import

    Buyer->>purchase_resource: buy(quantity, sale)
    purchase_resource->>Buyer: money -= total_price
    purchase_resource->>Seller: money += total_price
    purchase_resource->>Seller: resources[fuel] -= quantity
    purchase_resource->>Seller: resources_on_sale[fuel] -= quantity
    Note over purchase_resource,Buyer: REMOVED: buyer.resources[fuel] += quantity
    purchase_resource->>OngoingShipment: create(buyer, fuel, quantity, arrival_tick)
    Note over OngoingShipment: Shipment in transit...
    OngoingShipment->>store_import: arrival_tick reached
    store_import->>Buyer: resources[fuel] += quantity
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/integration/test_resource_market.py`, line 57 ([link](https://github.com/felixvonsamson/energetica/blob/895e3170a94dfbf35db3897d64a50ce4bea3be6f/tests/integration/test_resource_market.py#L57)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale assertion contradicts the fix**

   This assertion checks that `player2.resources[Fuel.COAL] == 100_000` immediately after `purchase_resource()`, but the entire point of this PR is that resources are no longer credited at purchase time — they arrive only when the shipment completes. This test will now fail (or pass vacuously if `resources` defaults to 0 == 0 for a different fuel), hiding the regression rather than catching it.

   The test should assert that the buyer's warehouse is **not** immediately updated, and that an `OngoingShipment` was created with the correct quantity instead.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: update purchase test to assert def..."](https://github.com/felixvonsamson/energetica/commit/db010b9025da7180d9a8d7c7ac25dd4f9aa3145b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27999499)</sub>

<!-- /greptile_comment -->