### PR TITLE
fix: reverse cumulative emissions accumulation order

### DIFF
--- a/frontend/src/components/charts/emissions-chart.tsx
+++ b/frontend/src/components/charts/emissions-chart.tsx
@@ -46,8 +46,8 @@ export function EmissionsChart({
             const cumulativeData: Array<Record<string, unknown>> = [];
             const cumulative: Record<string, number> = {};
 
-            // Process in reverse order (oldest to newest)
-            for (let i = chartData.length - 1; i >= 0; i--) {
+            // Process from oldest to newest (data is sorted by tick ascending)
+            for (let i = 0; i < chartData.length; i++) {
                 const dp = chartData[i] as Record<string, unknown>;
                 const result: Record<string, unknown> = {
                     tick: typeof dp.tick === "number" ? dp.tick : 0,
@@ -66,7 +66,7 @@ export function EmissionsChart({
                     result[key] = cumulative[key];
                 });
 
-                cumulativeData.unshift(result);
+                cumulativeData.push(result);
             }
 
             processedData = cumulativeData;


### PR DESCRIPTION
## Summary
- Fixes #654 — cumulative emissions chart was inverted
- The accumulation loop iterated backwards (newest→oldest) and used `unshift()`, causing the chart to show cumulative emissions in reverse
- Changed to iterate forwards (oldest→newest) with `push()` so emissions correctly grow over time

## Test plan
- [ ] Open `/app/overviews/emissions`, switch to cumulative mode, verify "Your Emissions" chart increases over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an inversion bug in the cumulative emissions chart where the oldest data point was being assigned the maximum cumulative value (sum of all rates) while the newest was assigned only its own rate. Changing the loop from reverse iteration with `unshift()` to forward iteration with `push()` correctly accumulates emissions from oldest to newest, so the chart now grows monotonically over time.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, correct, and directly addresses the reported chart inversion.

The change is a straightforward two-line fix (loop direction + push vs unshift) that produces the correct monotonically-increasing cumulative output. No regressions are introduced; the rest of the transformation pipeline (percent mode, filtering) is untouched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/charts/emissions-chart.tsx | Two-line fix: loop direction changed from reverse to forward, and array insertion changed from `unshift()` to `push()`, correctly producing monotonically increasing cumulative emissions per tick. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["chartData (sorted ascending by tick)"] --> B{cumulativeMode === 'cumulative'?}
    B -- No --> E["processedData = chartData"]
    B -- Yes --> C["for i = 0 → chartData.length-1\n(oldest to newest)"]
    C --> D["cumulative[key] += rate\nresult[key] = cumulative[key]\ncumulativeData.push(result)"]
    D --> F["processedData = cumulativeData\n(ascending ticks, growing values ✓)"]
    F --> G{viewMode === 'percent'?}
    E --> G
    G -- Yes --> H["Map each point to percentages"]
    G -- No --> I["Return processedData"]
    H --> I
```

<sub>Reviews (1): Last reviewed commit: ["fix: reverse cumulative emissions accumu..."](https://github.com/felixvonsamson/energetica/commit/a959b8cb4deb3975cd29661188a71e658c7a79e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28010133)</sub>

<!-- /greptile_comment -->