### PR TITLE
added website whitelist for daily quiz tests

### DIFF
--- a/tests/unit/test_daily_quiz_links.py
+++ b/tests/unit/test_daily_quiz_links.py
@@ -16,6 +16,16 @@ REQUEST_TIMEOUT = 10
 # User agent to use in requests
 USER_AGENT = "Mozilla/5.0 (compatible; Energetica-LinkChecker/1.0)"
 
+# Domains that block automated requests (bot detection) but are verified to work manually
+BOT_PROTECTED_DOMAINS = {
+    "time.com",
+    "www.visualcapitalist.com",
+    "www.researchgate.net",
+    "www.montana.edu",
+    "ourworldindata.org",
+    "unfccc.int",
+}
+
 
 def load_quiz_links() -> list[dict[str, str]]:
     """Load all learn_more_links from the quiz CSV file."""
@@ -52,6 +62,10 @@ def test_quiz_link_accessible(link_data: dict[str, str]) -> None:
     parsed = urlparse(url)
     assert parsed.scheme in ("http", "https"), f"Row {row}: Invalid URL scheme: {url}"
     assert parsed.netloc, f"Row {row}: Invalid URL (no domain): {url}"
+
+    # Skip domains known to block automated requests (verified to work manually)
+    if parsed.netloc in BOT_PROTECTED_DOMAINS:
+        pytest.skip(f"Row {row}: Skipping bot-protected domain: {parsed.netloc}")
 
     # Make request with timeout and user agent
     headers = {"User-Agent": USER_AGENT}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `BOT_PROTECTED_DOMAINS` allowlist to skip known bot-blocking sites in the daily quiz link tests, preventing false CI failures on sites that are verified to work manually.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only finding is a minor brittleness in exact netloc matching that is a low-risk P2 concern for a test-only file.

The change is confined to a test file, the intent is clear and well-documented, and the single finding (exact netloc vs. www variant) is P2 – it would only cause a CI false-negative if a CSV URL uses a variant not listed, not a data or production issue.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/unit/test_daily_quiz_links.py | Adds a `BOT_PROTECTED_DOMAINS` set and a `pytest.skip()` guard before HTTP requests for known bot-blocking sites; exact netloc matching may miss www/non-www variants. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[test_quiz_link_accessible] --> B[Validate URL scheme & netloc]
    B --> C{netloc in BOT_PROTECTED_DOMAINS?}
    C -- Yes --> D[pytest.skip]
    C -- No --> E[HEAD request]
    E --> F{status == 405?}
    F -- Yes --> G[GET request]
    F -- No --> H{status < 400?}
    G --> H
    H -- Pass --> I[Test passes]
    H -- Fail --> J[assert failure]
```

<sub>Reviews (1): Last reviewed commit: ["added website whitelist for daily quiz t..."](https://github.com/felixvonsamson/energetica/commit/59c94c3af97f69d3744ec7550129d142964a74f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28032461)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->