### PR TITLE
fix: use fetch+reset instead of pull in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -211,9 +211,9 @@ main() {
         log_success "Code is pushed to remote"
         echo ""
 
-        # Step 5: Pull latest code on remote
-        log_step "Pulling latest code on remote..."
-        ssh "${REMOTE_USER}@${REMOTE_HOST}" "sudo -u www-data git -C ${REMOTE_PATH} pull origin ${CURRENT_BRANCH}" > /dev/null
+        # Step 5: Sync code on remote (fetch + reset to match origin exactly)
+        log_step "Syncing code on remote..."
+        ssh "${REMOTE_USER}@${REMOTE_HOST}" "sudo -u www-data git -C ${REMOTE_PATH} fetch origin ${CURRENT_BRANCH} && sudo -u www-data git -C ${REMOTE_PATH} reset --hard origin/${CURRENT_BRANCH}" > /dev/null
         log_success "Code updated on VPS"
         echo ""
     fi


### PR DESCRIPTION
## Summary
- Replaces `git pull` with `git fetch + git reset --hard` in the deploy script's remote sync step
- Prevents deploy failures when the server repo has divergent branches (e.g. leftover hotfix state)
- The server should always match origin exactly, so a hard reset is the correct behavior

## Test plan
- [ ] Run `bash ./scripts/deploy.sh --yes` and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces `git pull` with `git fetch origin ${CURRENT_BRANCH} && git reset --hard origin/${CURRENT_BRANCH}` in Step 5 of the deploy script so the server always matches origin exactly, even when the remote repo has diverged. The logic is sound — the `&&` ensures the reset only runs after a successful fetch, and `set -e` plus SSH exit-code propagation will abort the script if either command fails.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a standard and well-understood deploy pattern with no regressions.

The only remaining finding is a P2 cosmetic inconsistency in the summary text; the core logic change is correct and an improvement over the previous `git pull` approach.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/deploy.sh | Replaces `git pull` with `git fetch + git reset --hard` in Step 5 to ensure the remote always matches origin exactly; the deployment summary string on line 162 still says "Pull latest code" and should be updated. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant L as Local Machine
    participant O as Origin (GitHub)
    participant V as VPS (www-data)

    L->>O: git push origin BRANCH
    L->>O: git fetch origin (verify pushed)
    L->>V: ssh: git fetch origin BRANCH
    O-->>V: Updated remote-tracking ref
    L->>V: ssh: git reset --hard origin/BRANCH
    Note over V: Working tree matches origin exactly
    L->>V: rsync frontend files
    L->>V: sudo systemctl restart energetica
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/deploy.sh`, line 162 ([link](https://github.com/felixvonsamson/energetica/blob/851556b747de7a55e8d66702a2265e2d176d71cb/scripts/deploy.sh#L162)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale summary description**

   The human-readable deployment summary still says "Pull latest code on VPS", but the actual step now performs a fetch + hard reset. Consider updating this string to match the new behavior.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: use fetch+reset instead of pull in ..."](https://github.com/felixvonsamson/energetica/commit/851556b747de7a55e8d66702a2265e2d176d71cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28036712)</sub>

<!-- /greptile_comment -->