### PR TITLE
toast appear below top bar

### DIFF
--- a/frontend/src/components/layout/game-layout.tsx
+++ b/frontend/src/components/layout/game-layout.tsx
@@ -47,7 +47,7 @@ export function GameLayout({ children }: GameLayoutProps) {
                                 {children}
                             </div>
                         </main>
-                        <Toaster position="top-center" richColors />
+                        <Toaster position="top-center" richColors offset="calc(var(--topbar-height) + 0.5rem)" />
                     </SidebarInset>
                 </div>
             </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `offset` prop to the `Toaster` component so toast notifications appear below the top bar instead of overlapping it, using the existing `--topbar-height` CSS variable plus `0.5rem` of padding.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line layout fix with no logic changes.

The change is minimal: one prop addition using a well-defined CSS variable. The `offset` prop is correctly forwarded through the Sonner wrapper, and `--topbar-height` is already used throughout the codebase.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/layout/game-layout.tsx | Adds `offset="calc(var(--topbar-height) + 0.5rem)"` to Toaster; `--topbar-height` is defined in global.css and `offset` is forwarded via `{...props}` in the Sonner wrapper — straightforward and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant GameLayout
    participant TopBar
    participant Toaster

    App->>GameLayout: render
    GameLayout->>TopBar: render (height = --topbar-height = 3.5rem)
    GameLayout->>Toaster: render with offset="calc(var(--topbar-height) + 0.5rem)"
    Note over Toaster: Toast notifications appear<br/>below the top bar
```

<sub>Reviews (1): Last reviewed commit: ["toast appear below top bar"](https://github.com/felixvonsamson/energetica/commit/e531a45397ae8b633eb4749af7cf228ce02b6d31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28039813)</sub>

<!-- /greptile_comment -->