### PR TITLE
refactor: decouple push notifications from inbox system

### DIFF
--- a/energetica/database/messages.py
+++ b/energetica/database/messages.py
@@ -23,13 +23,10 @@ if TYPE_CHECKING:
 #       a. Add a *Payload class with `type: Literal["your_type"]`.
 #       b. Add it to PersistableNotificationPayload.
 #    3. Run `bun run generate-types`.
-#    4. In frontend/src/types/notifications.ts:
-#       Add an entry to INBOX_NOTIFICATION_CATEGORIES.
-#    5. In frontend/src/lib/notification-config.tsx:
-#       Add an entry to INBOX_NOTIFICATION_CONFIG.
-#    6. In frontend/src/lib/notification-config.tsx:
-#       Add an entry to PUSH_NOTIFICATION_CONFIG.
-#    7. Call player.notify(YourPayload(...)) at the relevant backend site.
+#    4. In frontend/src/lib/notification-config.tsx:
+#       Add an entry to INBOX_NOTIFICATION_CONFIG (TypeScript will error if missing).
+#    5. Run `bun run generate-types`.
+#    6. Call player.notify(YourPayload(...)) at the relevant backend site.
 #
 # B) PUSH-ONLY — triggers a browser push but NO inbox entry.
 #    Use player.push_only(YourPayload(...)).
@@ -39,7 +36,7 @@ if TYPE_CHECKING:
 #       b. Add it to PushOnlyPayload.
 #    2. Run `bun run generate-types`.
 #    3. In frontend/src/lib/notification-config.tsx:
-#       Add an entry to PUSH_NOTIFICATION_CONFIG (NOT INBOX_NOTIFICATION_CONFIG).
+#       Add an entry to PUSH_ONLY_CONFIG (NOT INBOX_NOTIFICATION_CONFIG).
 #    4. In frontend/src/types/notifications.ts:
 #       If needed, add a new PushCategory for user opt-out.
 #    5. Call player.push_only(YourPayload(...)) at the relevant backend site.

--- a/energetica/database/messages.py
+++ b/energetica/database/messages.py
@@ -13,31 +13,36 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# Adding a new notification type? Here is the full checklist:
+# Adding a new notification type? There are two kinds:
 #
-# 1. Add the type string to NotificationType below (you are here).
+# A) INBOX NOTIFICATION — appears in the in-game inbox AND triggers a push.
+#    Use player.notify(YourPayload(...)).
 #
-# 2. In energetica/schemas/notifications.py:
-#    a. Add a new *Payload class with `type: Literal["your_type"]` as its
-#       first field (the Literal is required for Pydantic's discriminator).
-#    b. Add that class to the NotificationPayload union.
+#    1. Add the type string to NotificationType below.
+#    2. In energetica/schemas/notifications.py:
+#       a. Add a *Payload class with `type: Literal["your_type"]`.
+#       b. Add it to PersistableNotificationPayload.
+#    3. Run `bun run generate-types`.
+#    4. In frontend/src/types/notifications.ts:
+#       Add an entry to INBOX_NOTIFICATION_CATEGORIES.
+#    5. In frontend/src/lib/notification-config.tsx:
+#       Add an entry to INBOX_NOTIFICATION_CONFIG.
+#    6. In frontend/src/lib/notification-config.tsx:
+#       Add an entry to PUSH_NOTIFICATION_CONFIG.
+#    7. Call player.notify(YourPayload(...)) at the relevant backend site.
 #
-# 3. Run `bun run generate-types` to regenerate the TypeScript types from
-#    the updated OpenAPI schema. This propagates the new type to the frontend.
+# B) PUSH-ONLY — triggers a browser push but NO inbox entry.
+#    Use player.push_only(YourPayload(...)).
 #
-# 4. In frontend/src/types/notifications.ts:
-#    Add an entry to NOTIFICATION_CATEGORIES (TypeScript will error if missing).
-#
-# 5. In frontend/src/components/layout/notification-popup.tsx:
-#    Add a case to getNotificationText (TypeScript will error if missing).
-#
-# 6. In frontend/src/service-worker.ts:
-#    Add cases to getNotificationText and getNotificationUrl.
-#    NOTE: these switches have `default` fallbacks, so TypeScript will NOT
-#    catch a missing case — you must add it manually.
-#
-# 7. Add a player.notify(YourTypePayload(...)) call at the relevant backend
-#    event site (utils/, production_update.py, etc.).
+#    1. In energetica/schemas/notifications.py:
+#       a. Add a *Payload class with `type: Literal["your_type"]`.
+#       b. Add it to PushOnlyPayload.
+#    2. Run `bun run generate-types`.
+#    3. In frontend/src/lib/notification-config.tsx:
+#       Add an entry to PUSH_NOTIFICATION_CONFIG (NOT INBOX_NOTIFICATION_CONFIG).
+#    4. In frontend/src/types/notifications.ts:
+#       If needed, add a new PushCategory for user opt-out.
+#    5. Call player.push_only(YourPayload(...)) at the relevant backend site.
 # ---------------------------------------------------------------------------
 
 NotificationType = Literal[
@@ -52,7 +57,6 @@ NotificationType = Literal[
     "network_expelled",
     "achievement_milestone",
     "achievement_unlock",
-    "push_notification_test",
 ]
 
 

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -22,6 +22,7 @@ from energetica.database.engine_data.cumulative_emissions_data import Cumulative
 from energetica.database.messages import Chat, Notification
 from energetica.schemas.notifications import (
     PersistableNotificationPayload,
+    PushOnlyPayload,
     AchievementMilestoneBasePayload,
     AchievementMilestoneEnergyStoragePayload,
     AchievementMilestonePowerConsumptionPayload,
@@ -458,6 +459,11 @@ class Player(DBModel):
                 engine.socketio.emit("invalidate", {"queries": [["notifications"]]}, to=sid), MAIN_EVENT_LOOP
             )
         # Web push
+        for subscription in list(self.push_subscriptions):
+            self.notify_subscription(subscription, payload)
+
+    def push_only(self, payload: PushOnlyPayload) -> None:
+        """Send a browser push notification without creating an inbox entry."""
         for subscription in list(self.push_subscriptions):
             self.notify_subscription(subscription, payload)
 

--- a/energetica/routers/browser_notifications.py
+++ b/energetica/routers/browser_notifications.py
@@ -53,10 +53,9 @@ def test_push_notification(
 ) -> None:
     """Send a test push notification. If endpoint is provided, sends only to that subscription; otherwise broadcasts to all."""
     payload = PushNotificationTestPayload()
-    subscriptions = (
-        [s for s in player.push_subscriptions if s.endpoint == body.endpoint]
-        if body.endpoint is not None
-        else player.push_subscriptions
-    )
-    for subscription in subscriptions:
-        player.notify_subscription(subscription, payload)
+    if body.endpoint is not None:
+        subscriptions = [s for s in player.push_subscriptions if s.endpoint == body.endpoint]
+        for subscription in subscriptions:
+            player.notify_subscription(subscription, payload)
+    else:
+        player.push_only(payload)

--- a/energetica/schemas/notifications.py
+++ b/energetica/schemas/notifications.py
@@ -176,6 +176,7 @@ AchievementMilestonePayload = Annotated[
 # it will never be reachable; no error will be raised.
 # ---------------------------------------------------------------------------
 
+# Payloads that create a persistent Notification record (the in-game inbox).
 PersistableNotificationPayload = Union[
     ConstructionFinishedPayload,
     TechnologyResearchedPayload,
@@ -190,12 +191,19 @@ PersistableNotificationPayload = Union[
     AchievementMilestoneEnergyStoragePayload,
     AchievementMilestoneBasePayload,
     AchievementUnlockPayload,
+]
+
+# Payloads that only trigger a browser push — no inbox entry.
+PushOnlyPayload = Union[
+    ChatMessagePayload,
     PushNotificationTestPayload,
 ]
 
-NotificationPayload = Union[ChatMessagePayload, PersistableNotificationPayload]
+# Full union — used by the service worker / push text generation.
+NotificationPayload = Union[PersistableNotificationPayload, PushOnlyPayload]
 
 _payload_adapter = TypeAdapter(NotificationPayload)
+_persistable_payload_adapter = TypeAdapter(PersistableNotificationPayload)
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +217,7 @@ class NotificationOut(BaseModel):
     read: bool
     flagged: bool
     archived: bool
-    payload: NotificationPayload
+    payload: PersistableNotificationPayload
 
     @classmethod
     def from_notification(cls, n: Notification) -> NotificationOut | None:
@@ -222,7 +230,7 @@ class NotificationOut(BaseModel):
         one malformed notification does not block the rest.
         """
         try:
-            payload = _payload_adapter.validate_python({**n.payload, "type": n.type})
+            payload = _persistable_payload_adapter.validate_python({**n.payload, "type": n.type})
         except ValidationError:
             return None
         return cls(

--- a/energetica/utils/chat.py
+++ b/energetica/utils/chat.py
@@ -79,8 +79,7 @@ def add_message(player: Player, message_text: str, chat: Chat) -> Message:
         # Ensure the "unread chats" is updated
         if participant != player:
             participant.invalidate_queries(["chats"])
-            for subscription in list(participant.push_subscriptions):
-                participant.notify_subscription(subscription, payload)
+            participant.push_only(payload)
 
         participant.invalidate_queries(
             ["chats"],

--- a/frontend/src/components/layout/notification-popup.tsx
+++ b/frontend/src/components/layout/notification-popup.tsx
@@ -29,9 +29,9 @@ import {
 } from "@/hooks/use-notifications";
 import { getNotificationCategory, getNotificationContent } from "@/lib/notification-config";
 import { cn } from "@/lib/utils";
-import { CATEGORY_LABELS, type NotificationCategory } from "@/types/notifications";
+import { INBOX_CATEGORY_LABELS, type InboxCategory } from "@/types/notifications";
 
-const CATEGORIES = Object.keys(CATEGORY_LABELS) as NotificationCategory[];
+const CATEGORIES = Object.keys(INBOX_CATEGORY_LABELS) as InboxCategory[];
 
 interface NotificationPopupProps {
     isOpen: boolean;
@@ -47,7 +47,7 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
     const { mutate: flagNotification } = useFlagNotification();
 
     const [activeCategory, setActiveCategory] = useState<
-        NotificationCategory | "all"
+        InboxCategory | "all"
     >("all");
     const [selectedId, setSelectedId] = useState<number | null>(null);
 
@@ -185,7 +185,7 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
                                             : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
                                     )}
                                 >
-                                    {CATEGORY_LABELS[cat]}
+                                    {INBOX_CATEGORY_LABELS[cat]}
                                 </button>
                             ))}
                         </div>

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -164,6 +164,10 @@ const INBOX_NOTIFICATION_CONFIG = {
 
 // Push-only types are not in the generated API types since they don't appear
 // in the inbox API. We define their payload shapes manually here.
+// ⚠ Keep in sync with the corresponding Python classes in
+//   energetica/schemas/notifications.py — generate-types won't catch drift.
+
+/** Mirror of ChatMessagePayload (energetica/schemas/notifications.py) */
 type ChatMessagePushPayload = {
     type: "chat_message";
     sender_username: string;
@@ -171,6 +175,7 @@ type ChatMessagePushPayload = {
     chat_id: number;
 };
 
+/** Mirror of PushNotificationTestPayload (energetica/schemas/notifications.py) */
 type PushNotificationTestPushPayload = {
     type: "push_notification_test";
 };

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -9,30 +9,29 @@ import { CLIMATE_EVENT_CONFIG } from "@/lib/climate-event-config";
 import { formatMass, formatMoney } from "@/lib/format-utils";
 import type { AppRoute } from "@/types/app-routes";
 import type {
-    NotificationCategory,
+    InboxCategory,
     NotificationPayload,
     NotificationPayloadOf,
     NotificationType,
+    PushCategory,
 } from "@/types/notifications";
 
 type AppPath = AppRoute | `${AppRoute}?${string}`;
 
-type NotificationDef<T extends NotificationType> = {
-    category: NotificationCategory;
+// ---------------------------------------------------------------------------
+// Inbox notification config — only types that create persistent records.
+// Used by the notification popup to render inbox items.
+// ---------------------------------------------------------------------------
+
+type InboxNotificationDef<T extends NotificationType> = {
+    category: InboxCategory;
     path: (payload: NotificationPayloadOf<T>) => AppPath;
     title: string;
     pushBody: (payload: NotificationPayloadOf<T>) => string;
     inGameBody: (payload: NotificationPayloadOf<T>) => ReactNode;
 };
 
-const NOTIFICATION_CONFIG = {
-    chat_message: {
-        category: "messages",
-        path: (p) => `/app/community/messages?selectedChatId=${p.chat_id}`,
-        title: "New message",
-        pushBody: (p) => `${p.sender_username}: ${p.message}`,
-        inGameBody: (p) => `${p.sender_username}: ${p.message}`,
-    },
+const INBOX_NOTIFICATION_CONFIG = {
     construction_finished: {
         category: "projects",
         path: () => "/app/facilities/manage",
@@ -156,58 +155,137 @@ const NOTIFICATION_CONFIG = {
         inGameBody: (p) =>
             `${ACHIEVEMENT_UNLOCK_CONFIG[p.achievement_key].body} (+${p.xp} XP)`,
     },
+} satisfies { [T in NotificationType]: InboxNotificationDef<T> };
+
+// ---------------------------------------------------------------------------
+// Push notification config — all types that can trigger a browser push,
+// including push-only types (chat, test) that have no inbox entry.
+// ---------------------------------------------------------------------------
+
+// Push-only types are not in the generated API types since they don't appear
+// in the inbox API. We define their payload shapes manually here.
+type ChatMessagePushPayload = {
+    type: "chat_message";
+    sender_username: string;
+    message: string;
+    chat_id: number;
+};
+
+type PushNotificationTestPushPayload = {
+    type: "push_notification_test";
+};
+
+type PushOnlyPayload = ChatMessagePushPayload | PushNotificationTestPushPayload;
+
+// All payloads the service worker may receive.
+export type AnyPushPayload = NotificationPayload | PushOnlyPayload;
+
+type PushNotificationDef<P> = {
+    pushCategory: PushCategory;
+    path: (payload: P) => string;
+    title: string;
+    pushBody: (payload: P) => string;
+};
+
+const PUSH_ONLY_CONFIG = {
+    chat_message: {
+        pushCategory: "chat",
+        path: (p: ChatMessagePushPayload) =>
+            `/app/community/messages?selectedChatId=${p.chat_id}`,
+        title: "New message",
+        pushBody: (p: ChatMessagePushPayload) =>
+            `${p.sender_username}: ${p.message}`,
+    },
     push_notification_test: {
-        category: "events",
+        pushCategory: "events",
         path: () => "/app/dashboard",
         title: "Push notification test",
         pushBody: () =>
             "If you see this, browser push notifications are working.",
-        inGameBody: () =>
-            "If you see this, browser push notifications are working.",
     },
-} satisfies { [T in NotificationType]: NotificationDef<T> };
+} satisfies Record<string, PushNotificationDef<never>>;
+
+// Build a merged lookup for the service worker.
+// Inbox types inherit their push config from the inbox config.
+const PUSH_CONFIG_FROM_INBOX: Record<
+    string,
+    PushNotificationDef<never>
+> = Object.fromEntries(
+    Object.entries(INBOX_NOTIFICATION_CONFIG).map(([type, def]) => [
+        type,
+        {
+            pushCategory: def.category,
+            path: def.path,
+            title: def.title,
+            pushBody: def.pushBody,
+        } as PushNotificationDef<never>,
+    ]),
+);
+
+const FULL_PUSH_CONFIG: Record<string, PushNotificationDef<never>> = {
+    ...PUSH_CONFIG_FROM_INBOX,
+    ...PUSH_ONLY_CONFIG,
+};
+
+// ---------------------------------------------------------------------------
+// Public API — used by the notification popup (inbox) and service worker (push).
+// ---------------------------------------------------------------------------
 
 // Widen the payload-specific function signatures so callers can pass any NotificationPayload.
-// Safe because the discriminant on NotificationPayload guarantees the right variant is passed.
-type AnyNotificationDef = {
-    category: NotificationCategory;
+type AnyInboxDef = {
+    category: InboxCategory;
     path: (payload: NotificationPayload) => AppPath;
     title: string;
     pushBody: (payload: NotificationPayload) => string;
     inGameBody: (payload: NotificationPayload) => ReactNode;
 };
-const getDef = (type: NotificationType) =>
-    NOTIFICATION_CONFIG[type] as unknown as AnyNotificationDef;
+const getInboxDef = (type: NotificationType) =>
+    INBOX_NOTIFICATION_CONFIG[type] as unknown as AnyInboxDef;
 
-export function getNotificationPushText(payload: NotificationPayload): {
-    title: string;
-    body: string;
-} {
-    const def = getDef(payload.type);
-    return { title: def.title, body: def.pushBody(payload) };
-}
-
-export function getNotificationPath(payload: NotificationPayload): string {
-    return getDef(payload.type).path(payload);
-}
-
+/** Get the inbox category for a notification type (inbox items only). */
 export function getNotificationCategory(
     type: NotificationType,
-): NotificationCategory {
-    return NOTIFICATION_CONFIG[type].category;
+): InboxCategory {
+    return INBOX_NOTIFICATION_CONFIG[type].category;
 }
 
-export const NOTIFICATION_TYPE_TO_CATEGORY = Object.fromEntries(
-    Object.entries(NOTIFICATION_CONFIG).map(([type, def]) => [
-        type,
-        def.category,
-    ]),
-) as Record<NotificationType, NotificationCategory>;
-
+/** Get the title and body for rendering an inbox notification. */
 export function getNotificationContent(payload: NotificationPayload): {
     title: string;
     body: ReactNode;
 } {
-    const def = getDef(payload.type);
+    const def = getInboxDef(payload.type);
     return { title: def.title, body: def.inGameBody(payload) };
 }
+
+/** Get the push category for any push payload (inbox or push-only). */
+export function getPushCategory(type: string): PushCategory {
+    return (FULL_PUSH_CONFIG[type]?.pushCategory ?? "events") as PushCategory;
+}
+
+/** Get push notification title and body for any push payload. */
+export function getPushText(payload: AnyPushPayload): {
+    title: string;
+    body: string;
+} {
+    const def = FULL_PUSH_CONFIG[payload.type];
+    if (!def) return { title: "Energetica", body: "" };
+    const pushBody = def.pushBody as (payload: AnyPushPayload) => string;
+    return { title: def.title, body: pushBody(payload) };
+}
+
+/** Get the navigation path for any push payload. */
+export function getPushPath(payload: AnyPushPayload): string {
+    const def = FULL_PUSH_CONFIG[payload.type];
+    if (!def) return "/app/dashboard";
+    const path = def.path as (payload: AnyPushPayload) => string;
+    return path(payload);
+}
+
+/** Map from inbox notification type to its inbox category. */
+export const INBOX_TYPE_TO_CATEGORY = Object.fromEntries(
+    Object.entries(INBOX_NOTIFICATION_CONFIG).map(([type, def]) => [
+        type,
+        def.category,
+    ]),
+) as Record<NotificationType, InboxCategory>;

--- a/frontend/src/lib/push-notification-prefs.ts
+++ b/frontend/src/lib/push-notification-prefs.ts
@@ -1,6 +1,5 @@
 /**
- * Browser push notification preferences — per notification category, per
- * device.
+ * Browser push notification preferences — per push category, per device.
  *
  * Stored in IndexedDB so the service worker can read them before deciding
  * whether to show a notification. (localStorage is not accessible from service
@@ -9,20 +8,11 @@
  * Defaults to enabled for all categories.
  */
 
-import type { NotificationCategory } from "@/types/notifications";
+import { PUSH_CATEGORY_LABELS, type PushCategory } from "@/types/notifications";
 
-export const PUSH_NOTIF_CATEGORY_LABELS: Record<NotificationCategory, string> =
-    {
-        messages: "Messages",
-        projects: "Projects",
-        market: "Market",
-        events: "Events",
-        achievements: "Achievements",
-    };
-
-export const PUSH_NOTIF_CATEGORIES = Object.keys(
-    PUSH_NOTIF_CATEGORY_LABELS,
-) as NotificationCategory[];
+export const PUSH_CATEGORIES = Object.keys(
+    PUSH_CATEGORY_LABELS,
+) as PushCategory[];
 
 const DB_NAME = "energetica";
 const DB_VERSION = 1;
@@ -43,7 +33,7 @@ function openDB(): Promise<IDBDatabase> {
 }
 
 export async function getPushPref(
-    category: NotificationCategory,
+    category: PushCategory,
 ): Promise<boolean> {
     const db = await openDB();
     return new Promise((resolve) => {
@@ -56,7 +46,7 @@ export async function getPushPref(
 }
 
 export async function setPushPref(
-    category: NotificationCategory,
+    category: PushCategory,
     enabled: boolean,
 ): Promise<void> {
     const db = await openDB();
@@ -69,12 +59,12 @@ export async function setPushPref(
 }
 
 export async function getAllPushPrefs(): Promise<
-    Record<NotificationCategory, boolean>
+    Record<PushCategory, boolean>
 > {
     const entries = await Promise.all(
-        PUSH_NOTIF_CATEGORIES.map(
+        PUSH_CATEGORIES.map(
             async (cat) => [cat, await getPushPref(cat)] as const,
         ),
     );
-    return Object.fromEntries(entries) as Record<NotificationCategory, boolean>;
+    return Object.fromEntries(entries) as Record<PushCategory, boolean>;
 }

--- a/frontend/src/routes/app/settings.tsx
+++ b/frontend/src/routes/app/settings.tsx
@@ -34,10 +34,9 @@ import { handleApiError } from "@/lib/error-utils";
 import {
     getAllPushPrefs,
     setPushPref,
-    PUSH_NOTIF_CATEGORIES,
-    PUSH_NOTIF_CATEGORY_LABELS,
+    PUSH_CATEGORIES,
 } from "@/lib/push-notification-prefs";
-import type { NotificationCategory } from "@/types/notifications";
+import { PUSH_CATEGORY_LABELS, type PushCategory } from "@/types/notifications";
 
 function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
     const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
@@ -94,7 +93,7 @@ function SettingsContent() {
         null,
     );
     const [pushPrefs, setPushPrefs] = useState<Record<
-        NotificationCategory,
+        PushCategory,
         boolean
     > | null>(null);
 
@@ -239,7 +238,7 @@ function SettingsContent() {
     };
 
     const handleCategoryToggle = async (
-        category: NotificationCategory,
+        category: PushCategory,
         enabled: boolean,
     ) => {
         await setPushPref(category, enabled);
@@ -295,13 +294,13 @@ function SettingsContent() {
                     )}
                     {notificationsEnabled && pushPrefs && (
                         <CardContent className="flex flex-col gap-3 border-t pt-4">
-                            {PUSH_NOTIF_CATEGORIES.map((category) => (
+                            {PUSH_CATEGORIES.map((category) => (
                                 <div
                                     key={category}
                                     className="flex items-center justify-between"
                                 >
                                     <Label htmlFor={`push-pref-${category}`}>
-                                        {PUSH_NOTIF_CATEGORY_LABELS[category]}
+                                        {PUSH_CATEGORY_LABELS[category]}
                                     </Label>
                                     <Switch
                                         id={`push-pref-${category}`}

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -2,14 +2,11 @@
 
 // Run `bun run build:sw` after modifying this file
 
-import type {
-    NotificationPayload,
-    NotificationType,
-} from "@/types/notifications";
+import type { AnyPushPayload } from "@/lib/notification-config";
 import {
-    getNotificationPushText,
-    getNotificationPath,
-    NOTIFICATION_TYPE_TO_CATEGORY,
+    getPushText,
+    getPushPath,
+    getPushCategory,
 } from "@/lib/notification-config";
 import { getPushPref } from "@/lib/push-notification-prefs";
 
@@ -17,15 +14,15 @@ import { getPushPref } from "@/lib/push-notification-prefs";
 const sw = self as unknown as ServiceWorkerGlobalScope;
 
 interface PushData {
-    type: NotificationType;
+    type: string;
     payload: Record<string, unknown>;
 }
 
 sw.addEventListener("push", (event: PushEvent) => {
     if (!event.data) return;
     const data: PushData = event.data.json() as PushData;
-    const payload = { type: data.type, ...data.payload } as NotificationPayload;
-    const category = NOTIFICATION_TYPE_TO_CATEGORY[data.type] ?? "events";
+    const payload = { type: data.type, ...data.payload } as AnyPushPayload;
+    const category = getPushCategory(data.type);
 
     event.waitUntil(
         getPushPref(category).then((enabled) => {
@@ -36,8 +33,8 @@ sw.addEventListener("push", (event: PushEvent) => {
                 );
                 return;
             }
-            const { title, body } = getNotificationPushText(payload);
-            const path = getNotificationPath(payload);
+            const { title, body } = getPushText(payload);
+            const path = getPushPath(payload);
             console.log("[SW] Showing notification:", data.type, title);
             return sw.registration.showNotification(title, {
                 body,

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -24,9 +24,11 @@ sw.addEventListener("push", (event: PushEvent) => {
     const payload = { type: data.type, ...data.payload } as AnyPushPayload;
     const category = getPushCategory(data.type);
 
+    const alwaysShow = data.type === "push_notification_test";
+
     event.waitUntil(
         getPushPref(category).then((enabled) => {
-            if (!enabled) {
+            if (!enabled && !alwaysShow) {
                 console.log(
                     `[SW] Push suppressed (category "${category}" disabled):`,
                     data.type,

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2236,22 +2236,6 @@ export interface components {
             /** Unread Chat Count */
             unread_chat_count: number;
         };
-        /** ChatMessagePayload */
-        ChatMessagePayload: {
-            /**
-             * Type
-             *
-             * @constant
-             * @default chat_message
-             */
-            type: "chat_message";
-            /** Sender Username */
-            sender_username: string;
-            /** Message */
-            message: string;
-            /** Chat Id */
-            chat_id: number;
-        };
         /**
          * ChatOut
          *
@@ -3189,18 +3173,6 @@ export interface components {
             /** Money */
             money: number;
         };
-        /** NetworkExpelledPayload */
-        NetworkExpelledPayload: {
-            /**
-             * Type
-             *
-             * @constant
-             * @default network_expelled
-             */
-            type: "network_expelled";
-            /** Network Name */
-            network_name: string;
-        };
         /**
          * MoneyResponse
          *
@@ -3235,6 +3207,18 @@ export interface components {
             series: {
                 [key: string]: number[];
             };
+        };
+        /** NetworkExpelledPayload */
+        NetworkExpelledPayload: {
+            /**
+             * Type
+             *
+             * @constant
+             * @default network_expelled
+             */
+            type: "network_expelled";
+            /** Network Name */
+            network_name: string;
         };
         /**
          * NonFacilityBidType
@@ -3278,7 +3262,6 @@ export interface components {
             archived: boolean;
             /** Payload */
             payload:
-                | components["schemas"]["ChatMessagePayload"]
                 | components["schemas"]["ConstructionFinishedPayload"]
                 | components["schemas"]["TechnologyResearchedPayload"]
                 | components["schemas"]["FacilityDecommissionedPayload"]
@@ -3291,8 +3274,7 @@ export interface components {
                 | components["schemas"]["AchievementMilestonePowerConsumptionPayload"]
                 | components["schemas"]["AchievementMilestoneEnergyStoragePayload"]
                 | components["schemas"]["AchievementMilestoneBasePayload"]
-                | components["schemas"]["AchievementUnlockPayload"]
-                | components["schemas"]["PushNotificationTestPayload"];
+                | components["schemas"]["AchievementUnlockPayload"];
         };
         /** NotificationPatchIn */
         NotificationPatchIn: {
@@ -3788,21 +3770,6 @@ export interface components {
              * available quantity.
              */
             quantity?: number | null;
-        };
-        /**
-         * PushNotificationTestPayload
-         *
-         * Dummy notification used exclusively for end-to-end push notification
-         * testing.
-         */
-        PushNotificationTestPayload: {
-            /**
-             * Type
-             *
-             * @constant
-             * @default push_notification_test
-             */
-            type: "push_notification_test";
         };
         /**
          * RequirementOut

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -11,15 +11,33 @@ export type NotificationPayloadOf<T extends NotificationType> = Extract<
     { type: T }
 >;
 
-export type NotificationCategory =
+// ---------------------------------------------------------------------------
+// Inbox categories — used for filtering the in-game notification inbox.
+// These only include types that create persistent Notification records.
+// ---------------------------------------------------------------------------
+
+export type InboxCategory =
     | "projects"
     | "market"
     | "events"
-    | "achievements"
-    | "messages";
+    | "achievements";
 
-export const CATEGORY_LABELS: Record<NotificationCategory, string> = {
-    messages: "Messages",
+export const INBOX_CATEGORY_LABELS: Record<InboxCategory, string> = {
+    projects: "Projects",
+    market: "Market",
+    events: "Events",
+    achievements: "Achievements",
+};
+
+// ---------------------------------------------------------------------------
+// Push categories — used for browser push notification opt-in/opt-out.
+// Superset of inbox categories, plus push-only categories like chat.
+// ---------------------------------------------------------------------------
+
+export type PushCategory = InboxCategory | "chat";
+
+export const PUSH_CATEGORY_LABELS: Record<PushCategory, string> = {
+    chat: "Chat messages",
     projects: "Projects",
     market: "Market",
     events: "Events",


### PR DESCRIPTION
## Summary

- **Separates inbox notifications from push-only notifications.** Previously, `chat_message` and `push_notification_test` were squeezed into the inbox notification type system despite never creating DB records. This made the type system lie about what the inbox API returns, and the frontend had a phantom "Messages" filter tab with zero items.
- **Adds `player.push_only(payload)`** — sends a browser push without creating an inbox entry. `player.notify()` (persist + push) is unchanged.
- **Splits frontend categories** into `InboxCategory` (projects, market, events, achievements) and `PushCategory` (adds chat). Push preference UI now correctly reflects what's actually configurable.

This unblocks adding push-only features (e.g. daily quiz reminders) without polluting the inbox type system.

### Backend
- New `PushOnlyPayload` union in `schemas/notifications.py` (contains `ChatMessagePayload`, `PushNotificationTestPayload`)
- `NotificationOut` API schema now uses `PersistableNotificationPayload` only
- `player.push_only()` method on `Player`
- Chat push routing simplified to use `push_only()`
- `push_notification_test` removed from `NotificationType` (was never persisted)

### Frontend
- `InboxCategory` / `PushCategory` split in `types/notifications.ts`
- `notification-config.tsx` split into inbox config + push-only config with separate public APIs
- Service worker uses new `getPushCategory` / `getPushText` / `getPushPath`
- Push prefs use `PushCategory` with "Chat messages" as its own toggle
- "Messages" filter tab removed from notification popup

## Test plan

- [ ] Open notification popup — verify no "Messages" filter tab, all other tabs work
- [ ] Receive a chat message — verify browser push arrives (if enabled)
- [ ] Toggle "Chat messages" off in push settings — verify chat pushes are suppressed
- [ ] Trigger an inbox notification (e.g. construction finish) — verify it appears in inbox AND triggers push
- [ ] Test push notification button in settings still works
- [ ] Verify no regressions in notification read/flag/delete/archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleanly decouples push-only notifications (chat, test) from the in-game inbox system by introducing `PushOnlyPayload`, `player.push_only()`, and a split `InboxCategory`/`PushCategory` type hierarchy on the frontend. The refactor correctly removes phantom `ChatMessagePayload` and `PushNotificationTestPayload` entries from `NotificationOut`, eliminating the empty \"Messages\" filter tab and the lying type system.

The implementation is structurally sound — all three layers (schema, player methods, frontend config) are updated consistently, and the service worker's push preference check now routes through the correct category union.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/docs suggestions with no correctness or data-integrity impact.

The refactor is architecturally clean: the schema split is correct, the new push_only() method is a thin wrapper with no side effects, and the frontend category split is consistent across notifications.ts, notification-config.tsx, push-notification-prefs.ts, and the service worker. Three P2 notes exist (stale checklist names, test-push category suppression edge case, manually-duplicated TS types), none of which affect runtime correctness today.

energetica/database/messages.py (checklist constant names), frontend/src/lib/notification-config.tsx (push_notification_test category and manual type definitions)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/schemas/notifications.py | Cleanly separates PersistableNotificationPayload and PushOnlyPayload unions; NotificationOut.payload now uses the former only, eliminating phantom types from the API schema. |
| energetica/database/player.py | Adds push_only() method mirroring the push-loop in notify() without DB persistence; straightforward and correct. |
| energetica/database/messages.py | Updated developer checklist for adding notification types; contains incorrect constant names that will mislead future contributors. |
| energetica/utils/chat.py | Replaces player.notify() with player.push_only() for chat messages; correctly skips the sender and avoids creating inbox records. |
| energetica/routers/browser_notifications.py | Test push endpoint correctly uses notify_subscription() for targeted delivery and push_only() for broadcast; no issues. |
| frontend/src/lib/notification-config.tsx | Splits inbox and push config cleanly; manually redefines push-only payload types since they're absent from the generated API types — creates a potential type-drift risk if backend schemas change. |
| frontend/src/types/notifications.ts | Clean InboxCategory/PushCategory split with correct label maps; messages tab removed. |
| frontend/src/service-worker.ts | Now delegates to getPushCategory/getPushText/getPushPath; simpler and correctly handles both inbox and push-only payloads. |
| frontend/src/lib/push-notification-prefs.ts | Correctly switches to PushCategory (superset including chat); existing users' orphaned messages pref key is harmless since chat defaults to true. |
| frontend/src/components/layout/notification-popup.tsx | Removed Messages filter tab; now uses InboxCategory and INBOX_CATEGORY_LABELS; no issues. |
| frontend/src/types/api.generated.ts | Auto-generated; ChatMessagePayload and PushNotificationTestPayload correctly removed from NotificationOut union. |
| frontend/src/routes/app/settings.tsx | Now uses PushCategory/PUSH_CATEGORY_LABELS/PUSH_CATEGORIES for push preference toggles; correctly surfaces Chat messages as a separate toggle. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Backend
    participant Player
    participant SW as Service Worker
    participant UI as Frontend Inbox

    Note over Backend,UI: Inbox Notification (e.g. construction_finished)
    Backend->>Player: player.notify(ConstructionFinishedPayload)
    Player->>Player: Persist Notification record in DB
    Player->>UI: socketio invalidate → refetch /notifications
    Player->>SW: webpush (PersistableNotificationPayload)
    SW->>SW: getPushCategory → check pref
    SW->>SW: showNotification()

    Note over Backend,UI: Push-Only (e.g. chat_message)
    Backend->>Player: player.push_only(ChatMessagePayload)
    Note right of Player: No DB write
    Player->>SW: webpush (PushOnlyPayload)
    SW->>SW: getPushCategory(chat_message) → chat
    SW->>SW: check PUSH_PREF[chat]
    SW->>SW: showNotification() if enabled
```

<sub>Reviews (1): Last reviewed commit: ["refactor: decouple push notifications fr..."](https://github.com/felixvonsamson/energetica/commit/ebf73a8f78da2b1c4d1824a493e1182c551b4621) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28039909)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->