### PR TITLE
Use google forms instead of github to report issues

### DIFF
--- a/frontend/src/components/development-banner.tsx
+++ b/frontend/src/components/development-banner.tsx
@@ -18,10 +18,17 @@ export function DevelopmentBanner() {
                     </li>
                     <li>
                         <a
+                            href="https://forms.gle/GJqaK9KCNkGF8G7b7"
+                            className="underline font-medium hover:opacity-70"
+                        >
+                            Report bugs
+                        </a>{" "}
+                        and follow development on{" "}
+                        <a
                             href="https://github.com/felixvonsamson/Energetica"
                             className="underline font-medium hover:opacity-70"
                         >
-                            Report bugs and follow development on GitHub
+                            GitHub
                         </a>
                     </li>
                     <li>

--- a/frontend/src/components/layout/top-bar.tsx
+++ b/frontend/src/components/layout/top-bar.tsx
@@ -203,7 +203,7 @@ export function TopBar() {
                                 <DropdownMenuItem asChild>
                                     <a
                                         href={
-                                            "https://github.com/felixvonsamson/Energetica/issues/new"
+                                            "https://forms.gle/GJqaK9KCNkGF8G7b7"
                                         }
                                         target="_blank"
                                         rel="noreferrer"
@@ -276,7 +276,7 @@ export function TopBar() {
                                 <DropdownMenuItem asChild>
                                     <a
                                         href={
-                                            "https://github.com/felixvonsamson/Energetica/issues/new"
+                                            "https://forms.gle/GJqaK9KCNkGF8G7b7"
                                         }
                                         target="_blank"
                                         rel="noreferrer"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the GitHub new-issue link with a Google Forms URL (`https://forms.gle/GJqaK9KCNkGF8G7b7`) for bug reporting in two places: the development banner and the top-bar dropdown menus (both desktop and mobile). The GitHub repository link is preserved in the banner for following development.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely cosmetic link swap with no logic changes.

All changes are URL replacements in anchor tags. No logic, state, or API surface is touched. Both locations in top-bar.tsx correctly retain target=_blank and rel=noreferrer. The banner's omission of target=_blank is consistent with its pre-existing style for all external links.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/development-banner.tsx | Splits the combined "Report bugs and follow development on GitHub" link into two separate links — "Report bugs" → Google Forms, "GitHub" → repository — keeping the existing no-target-blank pattern consistent with other banner links. |
| frontend/src/components/layout/top-bar.tsx | Updates both desktop and mobile "Report an issue" dropdown items to point to the Google Forms URL; `target="_blank"` and `rel="noreferrer"` are correctly retained on both. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User] --> B{Entry point}
    B --> C[Development Banner]
    B --> D[Top-Bar Dropdown]
    C --> E[Report bugs link - Google Forms - same tab]
    C --> F[GitHub link - repository - same tab]
    D --> G[Report an issue - Google Forms - new tab with noreferrer]
```

<sub>Reviews (1): Last reviewed commit: ["Use google forms instead of github to re..."](https://github.com/felixvonsamson/energetica/commit/942392e420d0ed03944448c91737efe3b76e2902) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28060707)</sub>

<!-- /greptile_comment -->