### PR TITLE
feat: add table and % capacity view to resources overview

### DIFF
--- a/energetica/database/engine_data/circular_buffer_player.py
+++ b/energetica/database/engine_data/circular_buffer_player.py
@@ -48,6 +48,7 @@ class CircularBufferPlayer:
             "storage": {},  # + storage facilities
             "storage_soc": {},  # + storage facilities (state of charge, 0-1 fraction)
             "resources": {},  # + all resources when warehouse is built
+            "resources_soc": {},  # + all resources (fraction of warehouse capacity, 0-1)
             "emissions": {
                 "construction": deque([0.0] * 360, maxlen=360),  # + controllable facilities
             },
@@ -68,6 +69,8 @@ class CircularBufferPlayer:
             self._data[category][subcategory] = deque([0.0] * 360, maxlen=360)
         if category == "storage" and subcategory not in self._data["storage_soc"]:
             self._data["storage_soc"][subcategory] = deque([0.0] * 360, maxlen=360)
+        if category == "resources" and subcategory not in self._data["resources_soc"]:
+            self._data["resources_soc"][subcategory] = deque([0.0] * 360, maxlen=360)
 
     def get_data(self, t: int = 216) -> dict[str, dict[str, list[float]]]:
         """Return the last t ticks of the data."""
@@ -93,7 +96,7 @@ class CircularBufferPlayer:
         for category, subcategories in self._data.items():
             result[category] = {}
             for subcategory, buffer in subcategories.items():
-                if category in ["storage", "resources"]:
+                if category in ["storage", "resources", "resources_soc"]:
                     result[category][subcategory] = buffer[-1]
                 else:
                     result[category][subcategory] = 0.0

--- a/energetica/database/engine_data/circular_buffer_player.py
+++ b/energetica/database/engine_data/circular_buffer_player.py
@@ -96,7 +96,7 @@ class CircularBufferPlayer:
         for category, subcategories in self._data.items():
             result[category] = {}
             for subcategory, buffer in subcategories.items():
-                if category in ["storage", "resources", "resources_soc"]:
+                if category in ["storage", "resources"]:
                     result[category][subcategory] = buffer[-1]
                 else:
                     result[category][subcategory] = 0.0

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -882,6 +882,9 @@ def resources_and_pollution(new_values: dict, player: Player) -> None:
                     emissions,
                 )
             new_values["resources"][fuel] = player.resources[fuel]
+            new_values["resources_soc"][fuel] = (
+                player.resources[fuel] / warehouse_caps[fuel] if warehouse_caps[fuel] > 0 else 0.0
+            )
 
     # Carbon capture CO2 absorption
     if player.functional_facility_lvl[FunctionalFacilityType.CARBON_CAPTURE] > 0:

--- a/energetica/routers/charts.py
+++ b/energetica/routers/charts.py
@@ -41,6 +41,7 @@ from energetica.schemas.charts import (
     PowerSinksResponse,
     PowerSourcesResponse,
     ResourcesResponse,
+    ResourcesSocResponse,
     RevenuesResponse,
     StorageLevelResponse,
     StorageSocResponse,
@@ -52,7 +53,16 @@ router = APIRouter(prefix="/charts", tags=["Charts"])
 
 Resolution = Literal["1", "6", "36", "216", "1296"]
 PickleChartKey = Literal[
-    "revenues", "op_costs", "generation", "demand", "storage", "storage_soc", "resources", "emissions", "money"
+    "revenues",
+    "op_costs",
+    "generation",
+    "demand",
+    "storage",
+    "storage_soc",
+    "resources",
+    "resources_soc",
+    "emissions",
+    "money",
 ]
 ClimatePickleKey = Literal["emissions", "temperature"]
 PickleNetworkKey = Literal["network_data", "exports", "imports", "generation", "consumption"]
@@ -549,6 +559,27 @@ def get_resources(
     """
     data = _get_chart_data(player, start_tick, count, "resources", resolution)
     return ResourcesResponse(resolution=resolution, **data)
+
+
+@router.get("/resources-soc/{resolution}")
+def get_resources_soc(
+    player: Annotated[Player, Depends(get_settled_player)],
+    resolution: Resolution,
+    start_tick: int,
+    count: int,
+) -> ResourcesSocResponse:
+    """
+    Get resource stocks as fraction of warehouse capacity at the specified resolution.
+
+    Parameters:
+        resolution: Aggregation level (1/6/36/216/1296 ticks per datapoint)
+        start_tick: First tick to include (must be aligned to resolution)
+        count: Number of datapoints to retrieve
+
+    Returns values as a fraction (0-1) of the warehouse's capacity at the time of recording.
+    """
+    data = _get_chart_data(player, start_tick, count, "resources_soc", resolution)
+    return ResourcesSocResponse(resolution=resolution, **data)
 
 
 @router.get("/markets/{market_id}/clearing/{resolution}")

--- a/energetica/schemas/charts.py
+++ b/energetica/schemas/charts.py
@@ -180,6 +180,14 @@ class ResourcesResponse(ChartDataResponse[ResourcesKey]):
     )
 
 
+class ResourcesSocResponse(ChartDataResponse[ResourcesKey]):
+    """Response model for resource stocks as fraction of warehouse capacity."""
+
+    series: dict[ResourcesKey, list[float]] = Field(
+        description="Time series data for resource stocks, as a fraction (0-1) of warehouse capacity",
+    )
+
+
 MoneyKey = Literal["balance"]
 
 

--- a/frontend/src/components/charts/resources-chart.tsx
+++ b/frontend/src/components/charts/resources-chart.tsx
@@ -18,7 +18,7 @@ interface ResourcesChartProps {
     isLoading: boolean;
     isError: boolean;
     hiddenResources: Set<string>;
-    viewMode: "normal" | "percent";
+    viewMode: "mass" | "percent";
 }
 
 export function ResourcesChart({
@@ -34,7 +34,7 @@ export function ResourcesChart({
     // In percent mode, chartData already contains server-computed SoC (0-1 fraction).
     // Scale to 0-100 for display.
     const displayData: Array<Record<string, unknown>> = useMemo(() => {
-        if (viewMode === "normal" || chartData.length === 0) {
+        if (viewMode === "mass" || chartData.length === 0) {
             return chartData;
         }
         return chartData.map((dataPoint) => {
@@ -50,17 +50,17 @@ export function ResourcesChart({
 
     const chartConfig: EChartsTimeSeriesConfig = useMemo(
         () => ({
-            chartType: viewMode === "normal" ? "resources" : "resources-soc",
-            chartVariant: viewMode === "normal" ? "area" : "smoothLine",
+            chartType: viewMode === "mass" ? "resources" : "resources-soc",
+            chartVariant: viewMode === "mass" ? "area" : "smoothLine",
             stacked: false,
             getColor,
             filterDataKeys,
             formatValue:
-                viewMode === "normal"
+                viewMode === "mass"
                     ? formatMass
                     : (value: number) => `${value.toFixed(1)}%`,
             formatYAxis: (value: number) =>
-                viewMode === "normal" ? formatMass(value) : `${value}%`,
+                viewMode === "mass" ? formatMass(value) : `${value}%`,
         }),
         [viewMode, getColor, filterDataKeys],
     );
@@ -84,11 +84,10 @@ interface ResourcesOverviewTableProps {
 interface ResourceRow {
     resource: string;
     currentStock: number;
-    capacity: number;
     percentFull: number;
 }
 
-type SortKey = "resource" | "stock" | "capacity" | "percent";
+type SortKey = "resource" | "stock" | "percent";
 type SortDirection = "asc" | "desc";
 
 export function ResourcesOverviewTable({
@@ -110,9 +109,7 @@ export function ResourcesOverviewTable({
         });
         return (
             resourceTypes.size > 0 &&
-            Array.from(resourceTypes).every((type) =>
-                hiddenResources.has(type),
-            )
+            Array.from(resourceTypes).every((type) => hiddenResources.has(type))
         );
     }, [chartData, hiddenResources]);
 
@@ -159,7 +156,7 @@ export function ResourcesOverviewTable({
             const percentFull =
                 capacity > 0 ? (currentStock / capacity) * 100 : 0;
 
-            return { resource, currentStock, capacity, percentFull };
+            return { resource, currentStock, percentFull };
         });
     }, [chartData, resourcesData]);
 
@@ -177,10 +174,6 @@ export function ResourcesOverviewTable({
                 case "stock":
                     aVal = a.currentStock;
                     bVal = b.currentStock;
-                    break;
-                case "capacity":
-                    aVal = a.capacity;
-                    bVal = b.capacity;
                     break;
                 case "percent":
                     aVal = a.percentFull;
@@ -237,12 +230,6 @@ export function ResourcesOverviewTable({
                             Current Stock{getSortIndicator("stock")}
                         </th>
                         <th
-                            className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
-                            onClick={() => handleSort("capacity")}
-                        >
-                            Warehouse Capacity{getSortIndicator("capacity")}
-                        </th>
-                        <th
                             className="py-3 px-4 text-center font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors min-w-37.5"
                             onClick={() => handleSort("percent")}
                         >
@@ -280,9 +267,6 @@ export function ResourcesOverviewTable({
                                 </td>
                                 <td className="py-3 px-4 text-right font-mono">
                                     {formatMass(row.currentStock)}
-                                </td>
-                                <td className="py-3 px-4 text-right font-mono">
-                                    {formatMass(row.capacity)}
                                 </td>
                                 <td className="py-3 px-4 text-center min-w-37.5">
                                     <FacilityGauge

--- a/frontend/src/components/charts/resources-chart.tsx
+++ b/frontend/src/components/charts/resources-chart.tsx
@@ -1,45 +1,326 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import {
     EChartsTimeSeries,
     EChartsTimeSeriesConfig,
 } from "@/components/charts/echarts-time-series";
+import { ResourceIcon } from "@/components/ui/asset-icon";
+import { ResourceName } from "@/components/ui/asset-name";
+import { FacilityGauge } from "@/components/ui/facility-gauge";
 import { useAssetColorGetter } from "@/hooks/use-asset-color-getter";
-import { filterNonZeroSeries } from "@/lib/charts/filter-utils";
+import { useChartFilters } from "@/hooks/use-chart-filters";
+import { usePlayerResources } from "@/hooks/use-player-resources";
 import { formatMass } from "@/lib/format-utils";
+import { Fuel } from "@/types/fuel";
 
 interface ResourcesChartProps {
     chartData: Array<Record<string, unknown>>;
     isLoading: boolean;
     isError: boolean;
+    hiddenResources: Set<string>;
+    viewMode: "normal" | "percent";
 }
 
 export function ResourcesChart({
     chartData,
     isLoading,
     isError,
+    hiddenResources,
+    viewMode,
 }: ResourcesChartProps) {
     const getColor = useAssetColorGetter();
+    const filterDataKeys = useChartFilters(hiddenResources);
+    const { data: resourcesData } = usePlayerResources();
+
+    // In percent mode, convert absolute kg values to % of warehouse capacity
+    const displayData: Array<Record<string, unknown>> = useMemo(() => {
+        if (viewMode === "normal" || chartData.length === 0 || !resourcesData) {
+            return chartData;
+        }
+
+        const capacities: Record<string, number> = {
+            coal: resourcesData.coal.capacity,
+            gas: resourcesData.gas.capacity,
+            uranium: resourcesData.uranium.capacity,
+        };
+
+        return chartData.map((dataPoint) => {
+            const result: Record<string, unknown> = { tick: dataPoint.tick };
+            Object.keys(dataPoint).forEach((key) => {
+                if (key === "tick") return;
+                const val = dataPoint[key];
+                const cap = capacities[key];
+                if (typeof val === "number" && cap && cap > 0) {
+                    result[key] = (val / cap) * 100;
+                } else {
+                    result[key] = 0;
+                }
+            });
+            return result;
+        });
+    }, [chartData, viewMode, resourcesData]);
 
     const chartConfig: EChartsTimeSeriesConfig = useMemo(
         () => ({
             chartType: "resources",
-            chartVariant: "area",
+            chartVariant: viewMode === "normal" ? "area" : "smoothLine",
             stacked: false,
             getColor,
-            filterDataKeys: [filterNonZeroSeries],
-            formatValue: formatMass,
-            formatYAxis: (value: number) => formatMass(value),
+            filterDataKeys,
+            formatValue:
+                viewMode === "normal"
+                    ? formatMass
+                    : (value: number) => `${value.toFixed(1)}%`,
+            formatYAxis: (value: number) =>
+                viewMode === "normal" ? formatMass(value) : `${value}%`,
         }),
-        [getColor],
+        [viewMode, getColor, filterDataKeys],
     );
 
     return (
         <EChartsTimeSeries
-            data={chartData as Array<Record<string, unknown>>}
+            data={displayData}
             config={chartConfig}
             isLoading={isLoading}
             isError={isError}
         />
+    );
+}
+
+interface ResourcesOverviewTableProps {
+    chartData: Array<Record<string, number>>;
+    hiddenResources: Set<string>;
+    onToggleResource: (resource: string) => void;
+}
+
+interface ResourceRow {
+    resource: string;
+    currentStock: number;
+    capacity: number;
+    percentFull: number;
+}
+
+type SortKey = "resource" | "stock" | "capacity" | "percent";
+type SortDirection = "asc" | "desc";
+
+export function ResourcesOverviewTable({
+    chartData,
+    hiddenResources,
+    onToggleResource,
+}: ResourcesOverviewTableProps) {
+    const [sortKey, setSortKey] = useState<SortKey>("stock");
+    const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+    const { data: resourcesData } = usePlayerResources();
+
+    const allHidden = useMemo(() => {
+        if (chartData.length === 0) return false;
+        const resourceTypes = new Set<string>();
+        chartData.forEach((dataPoint) => {
+            Object.keys(dataPoint).forEach((key) => {
+                if (key !== "tick") resourceTypes.add(key);
+            });
+        });
+        return (
+            resourceTypes.size > 0 &&
+            Array.from(resourceTypes).every((type) =>
+                hiddenResources.has(type),
+            )
+        );
+    }, [chartData, hiddenResources]);
+
+    const handleToggleAll = () => {
+        if (chartData.length === 0) return;
+        const resourceTypes = new Set<string>();
+        chartData.forEach((dataPoint) => {
+            Object.keys(dataPoint).forEach((key) => {
+                if (key !== "tick") resourceTypes.add(key);
+            });
+        });
+
+        if (allHidden) {
+            resourceTypes.forEach((type) => {
+                if (hiddenResources.has(type)) onToggleResource(type);
+            });
+        } else {
+            resourceTypes.forEach((type) => {
+                if (!hiddenResources.has(type)) onToggleResource(type);
+            });
+        }
+    };
+
+    const resourceRows = useMemo(() => {
+        if (chartData.length === 0 || !resourcesData) return [];
+
+        const capacities: Record<string, number> = {
+            coal: resourcesData.coal.capacity,
+            gas: resourcesData.gas.capacity,
+            uranium: resourcesData.uranium.capacity,
+        };
+
+        const resourceTypes = new Set<string>();
+        chartData.forEach((dataPoint) => {
+            Object.keys(dataPoint).forEach((key) => {
+                if (key !== "tick") resourceTypes.add(key);
+            });
+        });
+
+        return Array.from(resourceTypes).map((resource): ResourceRow => {
+            const currentStock =
+                chartData[chartData.length - 1]?.[resource] ?? 0;
+            const capacity = capacities[resource] ?? 0;
+            const percentFull =
+                capacity > 0 ? (currentStock / capacity) * 100 : 0;
+
+            return { resource, currentStock, capacity, percentFull };
+        });
+    }, [chartData, resourcesData]);
+
+    const sortedRows = useMemo(() => {
+        const sorted = [...resourceRows];
+        sorted.sort((a, b) => {
+            let aVal: number | string;
+            let bVal: number | string;
+
+            switch (sortKey) {
+                case "resource":
+                    aVal = a.resource;
+                    bVal = b.resource;
+                    break;
+                case "stock":
+                    aVal = a.currentStock;
+                    bVal = b.currentStock;
+                    break;
+                case "capacity":
+                    aVal = a.capacity;
+                    bVal = b.capacity;
+                    break;
+                case "percent":
+                    aVal = a.percentFull;
+                    bVal = b.percentFull;
+                    break;
+                default:
+                    return 0;
+            }
+
+            if (aVal < bVal) return sortDirection === "asc" ? -1 : 1;
+            if (aVal > bVal) return sortDirection === "asc" ? 1 : -1;
+            return 0;
+        });
+        return sorted;
+    }, [resourceRows, sortKey, sortDirection]);
+
+    const handleSort = (key: SortKey) => {
+        if (sortKey === key) {
+            setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+        } else {
+            setSortKey(key);
+            setSortDirection("desc");
+        }
+    };
+
+    const getSortIndicator = (key: SortKey) => {
+        if (sortKey !== key) return null;
+        return sortDirection === "asc" ? " ▲" : " ▼";
+    };
+
+    if (sortedRows.length === 0) {
+        return (
+            <div className="text-center py-8 text-gray-500">
+                No resource data available
+            </div>
+        );
+    }
+
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+                <thead>
+                    <tr className="bg-secondary">
+                        <th
+                            className="py-3 px-4 text-left font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
+                            onClick={() => handleSort("resource")}
+                        >
+                            Resource{getSortIndicator("resource")}
+                        </th>
+                        <th
+                            className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
+                            onClick={() => handleSort("stock")}
+                        >
+                            Current Stock{getSortIndicator("stock")}
+                        </th>
+                        <th
+                            className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
+                            onClick={() => handleSort("capacity")}
+                        >
+                            Warehouse Capacity{getSortIndicator("capacity")}
+                        </th>
+                        <th
+                            className="py-3 px-4 text-center font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors min-w-37.5"
+                            onClick={() => handleSort("percent")}
+                        >
+                            Fill Level{getSortIndicator("percent")}
+                        </th>
+                        <th className="py-3 px-4 text-center font-semibold">
+                            <button
+                                onClick={handleToggleAll}
+                                className="px-3 py-1 text-xs font-semibold bg-brand hover:bg-brand/80 text-white rounded transition-colors"
+                            >
+                                {allHidden ? "Show All" : "Hide All"}
+                            </button>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {sortedRows.map((row) => {
+                        const isVisible = !hiddenResources.has(row.resource);
+                        return (
+                            <tr
+                                key={row.resource}
+                                className="border-b border-border/30 hover:bg-tan-green/20 dark:hover:bg-muted/30 transition-colors"
+                            >
+                                <td className="py-3 px-4">
+                                    <div className="flex items-center gap-2">
+                                        <ResourceIcon
+                                            resource={row.resource}
+                                            size={20}
+                                        />
+                                        <ResourceName
+                                            resource={row.resource as Fuel}
+                                            mode="long"
+                                        />
+                                    </div>
+                                </td>
+                                <td className="py-3 px-4 text-right font-mono">
+                                    {formatMass(row.currentStock)}
+                                </td>
+                                <td className="py-3 px-4 text-right font-mono">
+                                    {formatMass(row.capacity)}
+                                </td>
+                                <td className="py-3 px-4 text-center min-w-37.5">
+                                    <FacilityGauge
+                                        facilityType={row.resource}
+                                        value={row.percentFull}
+                                    />
+                                </td>
+                                <td className="py-3 px-4 text-center">
+                                    <button
+                                        onClick={() =>
+                                            onToggleResource(row.resource)
+                                        }
+                                        className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+                                            isVisible
+                                                ? "bg-brand hover:bg-brand/80 text-white"
+                                                : "bg-gray-300 hover:bg-gray-400 dark:bg-gray-600 dark:hover:bg-gray-500 text-gray-700 dark:text-gray-300"
+                                        }`}
+                                    >
+                                        {isVisible ? "Hide" : "Show"}
+                                    </button>
+                                </td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
     );
 }

--- a/frontend/src/components/charts/resources-chart.tsx
+++ b/frontend/src/components/charts/resources-chart.tsx
@@ -32,10 +32,15 @@ export function ResourcesChart({
     const filterDataKeys = useChartFilters(hiddenResources);
     const { data: resourcesData } = usePlayerResources();
 
-    // In percent mode, convert absolute kg values to % of warehouse capacity
+    // In percent mode, convert absolute kg values to % of warehouse capacity.
+    // If resourcesData hasn't loaded yet, return empty to avoid showing raw kg
+    // values with % formatting.
     const displayData: Array<Record<string, unknown>> = useMemo(() => {
-        if (viewMode === "normal" || chartData.length === 0 || !resourcesData) {
+        if (viewMode === "normal" || chartData.length === 0) {
             return chartData;
+        }
+        if (!resourcesData) {
+            return [];
         }
 
         const capacities: Record<string, number> = {

--- a/frontend/src/components/charts/resources-chart.tsx
+++ b/frontend/src/components/charts/resources-chart.tsx
@@ -30,44 +30,27 @@ export function ResourcesChart({
 }: ResourcesChartProps) {
     const getColor = useAssetColorGetter();
     const filterDataKeys = useChartFilters(hiddenResources);
-    const { data: resourcesData } = usePlayerResources();
 
-    // In percent mode, convert absolute kg values to % of warehouse capacity.
-    // If resourcesData hasn't loaded yet, return empty to avoid showing raw kg
-    // values with % formatting.
+    // In percent mode, chartData already contains server-computed SoC (0-1 fraction).
+    // Scale to 0-100 for display.
     const displayData: Array<Record<string, unknown>> = useMemo(() => {
         if (viewMode === "normal" || chartData.length === 0) {
             return chartData;
         }
-        if (!resourcesData) {
-            return [];
-        }
-
-        const capacities: Record<string, number> = {
-            coal: resourcesData.coal.capacity,
-            gas: resourcesData.gas.capacity,
-            uranium: resourcesData.uranium.capacity,
-        };
-
         return chartData.map((dataPoint) => {
             const result: Record<string, unknown> = { tick: dataPoint.tick };
             Object.keys(dataPoint).forEach((key) => {
                 if (key === "tick") return;
                 const val = dataPoint[key];
-                const cap = capacities[key];
-                if (typeof val === "number" && cap && cap > 0) {
-                    result[key] = (val / cap) * 100;
-                } else {
-                    result[key] = 0;
-                }
+                result[key] = typeof val === "number" ? val * 100 : 0;
             });
             return result;
         });
-    }, [chartData, viewMode, resourcesData]);
+    }, [chartData, viewMode]);
 
     const chartConfig: EChartsTimeSeriesConfig = useMemo(
         () => ({
-            chartType: "resources",
+            chartType: viewMode === "normal" ? "resources" : "resources-soc",
             chartVariant: viewMode === "normal" ? "area" : "smoothLine",
             stacked: false,
             getColor,

--- a/frontend/src/lib/charts/key-order.ts
+++ b/frontend/src/lib/charts/key-order.ts
@@ -119,6 +119,8 @@ export const TEMPERATURE_KEYS = ["deviation", "reference"] as const;
 
 export const RESOURCES_KEYS = ["coal", "gas", "uranium"] as const;
 
+export const RESOURCES_SOC_KEYS = RESOURCES_KEYS;
+
 export const MARKET_CLEARING_DATA_KEYS = ["price", "quantity"] as const;
 
 // Market exports/imports have dynamic player IDs, so no fixed order
@@ -170,6 +172,7 @@ export type ChartDataKeys = {
     climate: (typeof CLIMATE_KEYS)[number];
     temperature: (typeof TEMPERATURE_KEYS)[number];
     resources: (typeof RESOURCES_KEYS)[number];
+    "resources-soc": (typeof RESOURCES_SOC_KEYS)[number];
     "market-clearing": (typeof MARKET_CLEARING_DATA_KEYS)[number];
     "market-exports": string; // Dynamic player IDs
     "market-imports": string; // Dynamic player IDs
@@ -201,6 +204,7 @@ export const KEY_ORDER_BY_CHART_TYPE: Record<ChartType, readonly string[]> = {
     climate: CLIMATE_KEYS,
     temperature: TEMPERATURE_KEYS,
     resources: RESOURCES_KEYS,
+    "resources-soc": RESOURCES_SOC_KEYS,
     "market-clearing": MARKET_CLEARING_DATA_KEYS,
     "market-exports": MARKET_EXPORTS_KEYS,
     "market-imports": MARKET_IMPORTS_KEYS,

--- a/frontend/src/routes/app/overviews/resources.tsx
+++ b/frontend/src/routes/app/overviews/resources.tsx
@@ -1,16 +1,26 @@
 /** Resources overview page - Resource stocks visualization. */
 
 import { createFileRoute } from "@tanstack/react-router";
-import { Package, TrendingUp, Warehouse } from "lucide-react";
+import { Package, TrendingUp, Warehouse, BarChart3, Funnel } from "lucide-react";
+import { useState } from "react";
 
-import { ResourcesChart } from "@/components/charts/resources-chart";
+import {
+    ResourcesChart,
+    ResourcesOverviewTable,
+} from "@/components/charts/resources-chart";
 import { GameLayout } from "@/components/layout/game-layout";
 import { CardContent, PageCard } from "@/components/ui";
 import { ChartCard } from "@/components/ui/chart-card";
+import { Label } from "@/components/ui/label";
 import { ResolutionPicker } from "@/components/ui/resolution-picker";
+import {
+    SegmentedPicker,
+    SegmentedPickerOption,
+} from "@/components/ui/segmented-picker";
 import { useResolution } from "@/contexts/resolution-context";
 import { useChartData } from "@/hooks/use-charts";
 import { useGameTick } from "@/hooks/use-game-tick";
+import { useToggleSet } from "@/hooks/use-toggle-set";
 
 export const Route = createFileRoute("/app/overviews/resources")({
     component: ResourcesOverviewPage,
@@ -58,6 +68,20 @@ function ResourcesOverviewHelp() {
                         resource market
                     </span>
                 </li>
+                <li className="flex items-center gap-2">
+                    <BarChart3 className="w-4 h-4 shrink-0" />
+                    <span>
+                        Toggle between absolute view and percent of warehouse
+                        capacity
+                    </span>
+                </li>
+                <li className="flex items-center gap-2">
+                    <Funnel className="w-4 h-4 shrink-0" />
+                    <span>
+                        Use the table to toggle individual resources on/off in
+                        the chart to focus on specific resources
+                    </span>
+                </li>
             </ul>
             <p>
                 Resources are consumed by certain power facilities and can be
@@ -75,8 +99,15 @@ function ResourcesOverviewPage() {
     );
 }
 
+const VIEW_MODE_OPTIONS = [
+    { value: "percent", label: "% of Capacity" },
+    { value: "normal", label: "Absolute" },
+] as const;
+
 function ResourcesOverviewContent() {
     const { currentTick } = useGameTick();
+    const [viewMode, setViewMode] = useState<"normal" | "percent">("percent");
+    const [hiddenResources, toggleResource] = useToggleSet<string>();
     const { selectedResolution } = useResolution();
 
     // Fetch resources chart data
@@ -96,7 +127,27 @@ function ResourcesOverviewContent() {
         <div className="py-4 md:p-8 space-y-6">
             <PageCard>
                 <CardContent>
-                    <ResolutionPicker currentTick={currentTick} />
+                    <div className="space-y-4">
+                        <div>
+                            <Label className="mb-2">View Mode</Label>
+                            <SegmentedPicker
+                                value={viewMode}
+                                onValueChange={(value) =>
+                                    setViewMode(value as "normal" | "percent")
+                                }
+                            >
+                                {VIEW_MODE_OPTIONS.map((option) => (
+                                    <SegmentedPickerOption
+                                        key={option.value}
+                                        value={option.value}
+                                    >
+                                        {option.label}
+                                    </SegmentedPickerOption>
+                                ))}
+                            </SegmentedPicker>
+                        </div>
+                        <ResolutionPicker currentTick={currentTick} />
+                    </div>
                 </CardContent>
             </PageCard>
 
@@ -109,6 +160,14 @@ function ResourcesOverviewContent() {
                     chartData={resourcesData}
                     isLoading={isResourcesLoading}
                     isError={isResourcesError}
+                    hiddenResources={hiddenResources}
+                    viewMode={viewMode}
+                />
+
+                <ResourcesOverviewTable
+                    chartData={resourcesData}
+                    hiddenResources={hiddenResources}
+                    onToggleResource={toggleResource}
                 />
             </ChartCard>
         </div>

--- a/frontend/src/routes/app/overviews/resources.tsx
+++ b/frontend/src/routes/app/overviews/resources.tsx
@@ -1,7 +1,13 @@
 /** Resources overview page - Resource stocks visualization. */
 
 import { createFileRoute } from "@tanstack/react-router";
-import { Package, TrendingUp, Warehouse, BarChart3, Funnel } from "lucide-react";
+import {
+    Package,
+    TrendingUp,
+    Warehouse,
+    BarChart3,
+    Funnel,
+} from "lucide-react";
 import { useState } from "react";
 
 import {
@@ -32,7 +38,10 @@ export const Route = createFileRoute("/app/overviews/resources")({
             isUnlocked: (cap) =>
                 cap.has_warehouse
                     ? { unlocked: true }
-                    : { unlocked: false, reason: "Build a Warehouse to unlock" },
+                    : {
+                          unlocked: false,
+                          reason: "Build a Warehouse to unlock",
+                      },
         },
         infoDialog: {
             contents: <ResourcesOverviewHelp />,
@@ -100,13 +109,13 @@ function ResourcesOverviewPage() {
 }
 
 const VIEW_MODE_OPTIONS = [
-    { value: "percent", label: "% of Capacity" },
-    { value: "normal", label: "Absolute" },
+    { value: "percent", label: "%" },
+    { value: "mass", label: "t" },
 ] as const;
 
 function ResourcesOverviewContent() {
     const { currentTick } = useGameTick();
-    const [viewMode, setViewMode] = useState<"normal" | "percent">("percent");
+    const [viewMode, setViewMode] = useState<"mass" | "percent">("percent");
     const [hiddenResources, toggleResource] = useToggleSet<string>();
     const { selectedResolution } = useResolution();
 
@@ -136,8 +145,7 @@ function ResourcesOverviewContent() {
         maxDatapoints: selectedResolution.datapoints,
     });
 
-    const chartData =
-        viewMode === "percent" ? resourcesSocData : resourcesData;
+    const chartData = viewMode === "percent" ? resourcesSocData : resourcesData;
     const isChartLoading =
         viewMode === "percent" ? isSocLoading : isResourcesLoading;
     const isError = viewMode === "percent" ? isSocError : isResourcesError;
@@ -152,7 +160,7 @@ function ResourcesOverviewContent() {
                             <SegmentedPicker
                                 value={viewMode}
                                 onValueChange={(value) =>
-                                    setViewMode(value as "normal" | "percent")
+                                    setViewMode(value as "mass" | "percent")
                                 }
                             >
                                 {VIEW_MODE_OPTIONS.map((option) => (

--- a/frontend/src/routes/app/overviews/resources.tsx
+++ b/frontend/src/routes/app/overviews/resources.tsx
@@ -110,7 +110,7 @@ function ResourcesOverviewContent() {
     const [hiddenResources, toggleResource] = useToggleSet<string>();
     const { selectedResolution } = useResolution();
 
-    // Fetch resources chart data
+    // Fetch absolute resource stocks for the table (always needed)
     const {
         chartData: resourcesData,
         isLoading: isResourcesLoading,
@@ -122,6 +122,25 @@ function ResourcesOverviewContent() {
         },
         maxDatapoints: selectedResolution.datapoints,
     });
+
+    // Fetch server-computed SoC (0-1 fraction) for the percent view
+    const {
+        chartData: resourcesSocData,
+        isLoading: isSocLoading,
+        isError: isSocError,
+    } = useChartData({
+        config: {
+            chartType: "resources-soc",
+            resolution: selectedResolution.resolution,
+        },
+        maxDatapoints: selectedResolution.datapoints,
+    });
+
+    const chartData =
+        viewMode === "percent" ? resourcesSocData : resourcesData;
+    const isChartLoading =
+        viewMode === "percent" ? isSocLoading : isResourcesLoading;
+    const isError = viewMode === "percent" ? isSocError : isResourcesError;
 
     return (
         <div className="py-4 md:p-8 space-y-6">
@@ -157,9 +176,9 @@ function ResourcesOverviewContent() {
                 title="Resource Stocks"
             >
                 <ResourcesChart
-                    chartData={resourcesData}
-                    isLoading={isResourcesLoading}
-                    isError={isResourcesError}
+                    chartData={chartData}
+                    isLoading={isChartLoading}
+                    isError={isError}
                     hiddenResources={hiddenResources}
                     viewMode={viewMode}
                 />

--- a/frontend/src/types/charts.ts
+++ b/frontend/src/types/charts.ts
@@ -11,6 +11,7 @@ export type ChartType =
     | "climate"
     | "temperature"
     | "resources"
+    | "resources-soc"
     | "market-clearing"
     | "market-exports"
     | "market-imports"


### PR DESCRIPTION
## Summary
- Add a sortable toggle table under the resources chart (matching other overview pages like storage/power) so players can show/hide individual resource series
- Add a "% of Capacity" view mode (default) that displays resource stocks as percentage of warehouse capacity, making it easier to compare fill levels across coal/gas/uranium
- Closes #672

## Test plan
- [ ] Navigate to Resources Overview page
- [ ] Verify "% of Capacity" is the default view and chart shows 0-100% scale
- [ ] Switch to "Absolute" mode and verify chart shows kg/t values
- [ ] Use the table to hide/show individual resources and verify chart updates
- [ ] Verify "Hide All" / "Show All" button works
- [ ] Verify sortable columns (Resource, Current Stock, Warehouse Capacity, Fill Level)
- [ ] Verify fill level gauge bars render correctly per resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a sortable resource table (matching the storage/power overview pages) and a \"% of Capacity\" chart view mode to the Resources Overview page. The implementation is well-structured, consistent with existing patterns, and correctly uses React Query deduplication for the shared `usePlayerResources` calls.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only P2 findings remain (transient loading flash in percent mode and a design note about historical capacity accuracy)

No P0 or P1 issues found. Both P2 comments describe an accepted transient visual state and a data-design limitation inherent to client-side capacity lookups — neither causes incorrect stored data or broken user paths.

frontend/src/components/charts/resources-chart.tsx — percent-mode displayData fallback during resourcesData loading

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/charts/resources-chart.tsx | Adds percent-of-capacity conversion in `ResourcesChart` and a new `ResourcesOverviewTable` with sort/toggle; minor loading-state flash in percent mode when player-resources data lags behind chart data |
| frontend/src/routes/app/overviews/resources.tsx | Wires up `viewMode` state, `hiddenResources` toggle set, `SegmentedPicker`, and `ResourcesOverviewTable`; clean and consistent with other overview pages |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Page as ResourcesOverviewContent
    participant Chart as ResourcesChart
    participant Table as ResourcesOverviewTable
    participant API1 as useChartData (charts API)
    participant API2 as usePlayerResources (resources API)

    Page->>API1: fetch chart time series
    API1-->>Page: chartData[]

    Page->>Chart: chartData, viewMode, hiddenResources
    Page->>Table: chartData, hiddenResources, onToggleResource

    Chart->>API2: usePlayerResources (capacities for % mode)
    API2-->>Chart: { coal, gas, uranium }.capacity

    Table->>API2: usePlayerResources (RQ dedupes, same cache)
    API2-->>Table: { coal, gas, uranium }.capacity + .stock

    Chart->>Chart: convert kg to % of current capacity (percent mode)
    Table->>Table: read last chartData point as currentStock
```

<sub>Reviews (1): Last reviewed commit: ["feat: add table and % capacity view to r..."](https://github.com/felixvonsamson/energetica/commit/f06c7d05d95e0c466fc8e305f9163e97eae8108d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28563755)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->