### PR TITLE
Fix/650

### DIFF
--- a/frontend/src/components/charts/echarts-time-series.tsx
+++ b/frontend/src/components/charts/echarts-time-series.tsx
@@ -848,7 +848,7 @@ export function EChartsTimeSeries({
     // Chart div always rendered to keep the ECharts instance stable.
     // Loading and error states are overlaid so the chart never unmounts.
     return (
-        <div className="relative">
+        <div className="relative min-w-0 overflow-hidden">
             <div
                 ref={chartRef}
                 className="w-full"

--- a/frontend/src/components/charts/market-depth-chart.tsx
+++ b/frontend/src/components/charts/market-depth-chart.tsx
@@ -391,7 +391,7 @@ function MarketDepthChartInner({
     }
 
     return (
-        <div className="relative" style={{ height: `${height}px` }}>
+        <div className="relative min-w-0 overflow-hidden" style={{ height: `${height}px` }}>
             <div ref={chartRef} className="w-full h-full" />
             {tooltipState && (
                 <div

--- a/frontend/src/components/charts/supply-demand-chart.tsx
+++ b/frontend/src/components/charts/supply-demand-chart.tsx
@@ -821,7 +821,7 @@ function MeritOrderChartInner({
             </div>
 
             {/* Chart */}
-            <div className="relative" style={{ height: `${height}px` }}>
+            <div className="relative min-w-0 overflow-hidden" style={{ height: `${height}px` }}>
                 <div ref={chartRef} className="w-full h-full" />
 
                 {/* Full-height highlight band for the hovered block column */}

--- a/frontend/src/components/layout/game-layout.tsx
+++ b/frontend/src/components/layout/game-layout.tsx
@@ -38,7 +38,7 @@ export function GameLayout({ children }: GameLayoutProps) {
                 {/* Sidebar + content row */}
                 <div className="flex flex-1 min-h-0">
                     <AppSidebar bgLogoRef={bgLogoRef} />
-                    <SidebarInset>
+                    <SidebarInset className="min-w-0">
                         <main
                             className="flex-1 overflow-auto min-w-0"
                             onScroll={handleScroll}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes chart overflow issues (related to #650) by adding `min-w-0 overflow-hidden` to the chart container divs in all three chart components and `min-w-0` to the `SidebarInset` in the game layout. The fix properly constrains flex children that were previously expanding beyond their parent containers. All custom tooltips in the affected charts use `position: fixed` (viewport-relative), so `overflow-hidden` does not clip them.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted CSS fixes with no logic changes.

All changes are single-line Tailwind class additions to fix a known overflow issue. Tooltips across all three chart components use `position: fixed` so they are unaffected by `overflow-hidden`. No logic, data handling, or API contracts are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/layout/game-layout.tsx | Adds `min-w-0` to `SidebarInset` so the flex child can shrink below its intrinsic width, preventing chart content from overflowing the sidebar container. |
| frontend/src/components/charts/echarts-time-series.tsx | Adds `min-w-0 overflow-hidden` to the outer wrapper div; the custom tooltip uses `position: fixed` so it is unaffected by `overflow-hidden`. |
| frontend/src/components/charts/market-depth-chart.tsx | Adds `min-w-0 overflow-hidden` to the chart container; `DepthTooltip` uses `position: fixed` and is not clipped. |
| frontend/src/components/charts/supply-demand-chart.tsx | Adds `min-w-0 overflow-hidden` to the chart div; `BlockTooltip` uses `position: fixed` and the absolute-positioned highlight band is intentionally clipped to the chart boundary. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SidebarProvider"] --> B["SidebarInset\n(+ min-w-0 NEW)"]
    B --> C["main (flex-1 overflow-auto min-w-0)"]
    C --> D["Page content"]
    D --> E1["EChartsTimeSeries\nouter div\n(+ min-w-0 overflow-hidden NEW)"]
    D --> E2["MarketDepthChart\nouter div\n(+ min-w-0 overflow-hidden NEW)"]
    D --> E3["MeritOrderChart\nouter div\n(+ min-w-0 overflow-hidden NEW)"]
    E1 --> F1["ECharts canvas\n(w-full)"]
    E1 -. position:fixed .-> T1["TSTooltip\n(viewport)"]
    E2 --> F2["ECharts canvas\n(w-full h-full)"]
    E2 -. position:fixed .-> T2["DepthTooltip\n(viewport)"]
    E3 --> F3["ECharts canvas\n(w-full h-full)"]
    E3 --> F4["highlightRef\n(position:absolute — clipped ✓)"]
    E3 -. position:fixed .-> T3["BlockTooltip\n(viewport)"]
```

<sub>Reviews (1): Last reviewed commit: ["fixed same issue fro 3 last overviews"](https://github.com/felixvonsamson/energetica/commit/42a1de8e7d1f7dc89111609cd5ca5d347695b43f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28853293)</sub>

<!-- /greptile_comment -->