### PR TITLE
fix same styling for levels on functional facilities

### DIFF
--- a/frontend/src/components/facilities/facility-detail-dialog.tsx
+++ b/frontend/src/components/facilities/facility-detail-dialog.tsx
@@ -151,7 +151,7 @@ function FacilityContent<T>(
                 </div>
 
                 {/* Header */}
-                <div className="flex flex-wrap items-center gap-3">
+                <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
                     <TypographyH2 className="flex items-center gap-2 mr-auto">
                         <FacilityIcon facility={facility.name} size={28} />
                         <FacilityName facility={facility.name} mode="long" />

--- a/frontend/src/components/facilities/facility-item.tsx
+++ b/frontend/src/components/facilities/facility-item.tsx
@@ -19,6 +19,7 @@ interface FacilityItemProps {
     facilityType: "power" | "storage" | "extraction" | "functional";
     price: number;
     isLocked: boolean;
+    level?: number;
     // imageExtension?: "png" | "jpg";
     onClick: () => void;
 }
@@ -32,6 +33,7 @@ export function FacilityItem({
     facilityType,
     price,
     isLocked,
+    level,
     // imageExtension = "jpg",
     onClick,
 }: FacilityItemProps) {
@@ -55,8 +57,9 @@ export function FacilityItem({
                     <FacilityName facility={facilityName} mode="long" />
                     <div className="grow" />
                 </CardTitle>
-                <CardDescription>
+                <CardDescription className="flex items-center justify-between gap-2">
                     <Money amount={price} long />
+                    {level !== undefined && <span>Level {level}</span>}
                 </CardDescription>
             </CardHeader>
             {/* Image with lock overlay */}

--- a/frontend/src/routes/app/facilities/functional.tsx
+++ b/frontend/src/routes/app/facilities/functional.tsx
@@ -104,9 +104,9 @@ function FunctionalFacilitiesContent() {
 
     const extraHeaderContent = useCallback(
         (facility: FunctionalFacility) => (
-            <span className="text-lg">
-                lvl. <em className="text-xl">{facility.level}</em>
-            </span>
+            <p className="text-3xl text-muted-foreground">
+                Level {facility.level}
+            </p>
         ),
         [],
     );
@@ -159,6 +159,7 @@ function FunctionalFacilitiesContent() {
                                     facility.requirements_status ===
                                     "unsatisfied"
                                 }
+                                level={facility.level}
                                 onClick={() =>
                                     navigate({
                                         search: { facility: facility.name },


### PR DESCRIPTION
Before : 
<img width="508" height="475" alt="image" src="https://github.com/user-attachments/assets/eda4dbd1-0561-4d12-a093-ee25c54d3f73" />

After: 
<img width="508" height="475" alt="image" src="https://github.com/user-attachments/assets/15cf14ba-1ac8-499e-a45c-8193202071c5" />

Before :
<img width="1029" height="913" alt="image" src="https://github.com/user-attachments/assets/1654fd4e-d9fe-4fb8-a97a-8b46143c185a" />

After:
<img width="1029" height="913" alt="image" src="https://github.com/user-attachments/assets/bba0a6d4-2b5a-49f1-b016-60f2e8294730" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes the display of facility levels for functional facilities by replacing the `lvl. X` label (italic, small text) with a consistent `Level X` label styled as `text-3xl text-muted-foreground` in the detail dialog header, and by also surfacing the level on the grid card via a new optional `level` prop on `FacilityItem`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are purely cosmetic/styling with no functional or data-handling risk.

All three changes are straightforward UI-only fixes: a flex alignment tweak in the dialog header, a new optional prop with a safe `!== undefined` guard, and a label reformatting from `lvl. X` to `Level X`. No logic, data flow, or security concerns are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/facilities/facility-item.tsx | Adds optional `level` prop; renders "Level X" in the `CardDescription` alongside price when defined. Guard `!== undefined` is correct for numeric levels including 0. |
| frontend/src/routes/app/facilities/functional.tsx | Replaces small italic `lvl. X` span with a prominent `text-3xl text-muted-foreground` paragraph in the dialog header and passes `facility.level` to `FacilityItem`. |
| frontend/src/components/facilities/facility-detail-dialog.tsx | Switches header container from `items-center gap-3` to `items-baseline gap-x-4 gap-y-1` for better baseline alignment between the h2 title and the level label. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[functional.tsx] -->|passes level prop| B[FacilityItem]
    A -->|extraHeaderContent callback| C[FacilityDetailDialog]

    B --> D["CardDescription\nMoney + Level X"]
    C --> E["Dialog Header\nH2 title + Level X (text-3xl)"]

    style D fill:#d4edda
    style E fill:#d4edda
```

<sub>Reviews (1): Last reviewed commit: ["fix same styling for levels on functiona..."](https://github.com/felixvonsamson/energetica/commit/557a1a8b333e679df009eab696369ffdb912c4fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28854042)</sub>

<!-- /greptile_comment -->
