### PR TITLE
feat : 50% overdraft notification

### DIFF
--- a/energetica/database/messages.py
+++ b/energetica/database/messages.py
@@ -52,6 +52,7 @@ NotificationType = Literal[
     "resource_sold",
     "shipment_arrived",
     "network_expelled",
+    "network_overdraft_warning",
     "achievement_milestone",
     "achievement_unlock",
 ]

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -150,6 +150,10 @@ class Player(DBModel):
         },
     )
 
+    # True while player money is below 50% of their max overdraft (within a network).
+    # Reset when they recover or leave the network, so each new dip triggers one warning.
+    overdraft_warning_sent: bool = False
+
     # Browser push notification subscriptions (push subscription objects)
     push_subscriptions: list[Subscription] = field(default_factory=list)
     # Server-side feed subscriptions: opt-in to specific notification streams.
@@ -186,6 +190,8 @@ class Player(DBModel):
             }
         if not hasattr(self, "push_subscriptions"):
             self.push_subscriptions = []
+        if not hasattr(self, "overdraft_warning_sent"):
+            self.overdraft_warning_sent = False
         # Migrate old notification_opt_ins field
         if hasattr(self, "notification_opt_ins"):
             del self.__dict__["notification_opt_ins"]

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -56,8 +56,7 @@ def update_electricity() -> None:
     for os in ongoing_shipments:
         os.reset_speed()
 
-
-    for network in Network.all():
+    for network in list(Network.all()):
         # --- Market resolution ---
         market = init_market()
         for player in network.members:

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -33,7 +33,7 @@ from energetica.enums import (
 )
 from energetica.globals import engine
 from energetica.schemas.electricity_markets import AskType
-from energetica.schemas.notifications import NetworkExpelledPayload
+from energetica.schemas.notifications import NetworkExpelledPayload, NetworkOverdraftWarningPayload
 from energetica.utils import network_helpers
 from energetica.types.facility_statuses import ProductionStatus
 from energetica.utils.misc import calculate_river_speed, calculate_solar_irradiance, calculate_wind_speed
@@ -126,6 +126,21 @@ def update_electricity() -> None:
         # add industry revenues to player money
         player.money += new_values[player.id]["revenues"]["industry"]
         money_balance(new_values[player.id], player)
+        # --- Overdraft warning ---
+        if player.network is not None:
+            max_overdraft = -player.config["industry"]["income_per_day"]
+            if player.money < max_overdraft * 0.5:
+                if not player.overdraft_warning_sent:
+                    player.overdraft_warning_sent = True
+                    overdraft_pct = player.money / max_overdraft
+                    player.notify(
+                        NetworkOverdraftWarningPayload(
+                            network_name=player.network.name,
+                            overdraft_pct=round(overdraft_pct, 2),
+                        )
+                    )
+            elif player.overdraft_warning_sent:
+                player.overdraft_warning_sent = False
         player.rolling_history.append_value(new_values[player.id])
         update_player_progress_values(player, new_values)
         # send new data to clients

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -56,15 +56,6 @@ def update_electricity() -> None:
     for os in ongoing_shipments:
         os.reset_speed()
 
-    # --- Expel bankrupt players from their networks ---
-    for network in list(Network.all()):
-        for player in list(network.members):
-            max_overdraft = -player.config["industry"]["income_per_day"]
-            if player.money < max_overdraft:
-                network_name = network.name
-                network_helpers.leave_network(player)
-                player.notify(NetworkExpelledPayload(network_name=network_name))
-                engine.log(f"{player.username} was expelled from {network_name} due to insufficient funds")
 
     for network in Network.all():
         # --- Market resolution ---
@@ -126,17 +117,21 @@ def update_electricity() -> None:
         # add industry revenues to player money
         player.money += new_values[player.id]["revenues"]["industry"]
         money_balance(new_values[player.id], player)
-        # --- Overdraft warning ---
+        # --- Expel bankrupt players and warn those nearing their overdraft limit ---
         if player.network is not None:
             max_overdraft = -player.config["industry"]["income_per_day"]
-            if player.money < max_overdraft * 0.5:
+            if player.money < max_overdraft:
+                network_name = player.network.name
+                network_helpers.leave_network(player)
+                player.notify(NetworkExpelledPayload(network_name=network_name))
+                engine.log(f"{player.username} was expelled from {network_name} due to insufficient funds")
+            elif player.money < max_overdraft * 0.5:
                 if not player.overdraft_warning_sent:
                     player.overdraft_warning_sent = True
-                    overdraft_pct = player.money / max_overdraft
                     player.notify(
                         NetworkOverdraftWarningPayload(
                             network_name=player.network.name,
-                            overdraft_pct=round(overdraft_pct, 2),
+                            overdraft_pct=round(player.money / max_overdraft, 2),
                         )
                     )
             elif player.overdraft_warning_sent:

--- a/energetica/schemas/notifications.py
+++ b/energetica/schemas/notifications.py
@@ -90,6 +90,12 @@ class NetworkExpelledPayload(BaseModel):
     network_name: str
 
 
+class NetworkOverdraftWarningPayload(BaseModel):
+    type: Literal["network_overdraft_warning"] = "network_overdraft_warning"
+    network_name: str
+    overdraft_pct: float  # current money as a percentage of max overdraft (e.g. 0.6 = 60%)
+
+
 class AchievementUnlockPayload(BaseModel):
     """One-shot achievement unlocked by constructing a specific facility."""
 
@@ -187,6 +193,7 @@ PersistableNotificationPayload = Union[
     ResourceSoldPayload,
     ShipmentArrivedPayload,
     NetworkExpelledPayload,
+    NetworkOverdraftWarningPayload,
     AchievementMilestonePowerConsumptionPayload,
     AchievementMilestoneEnergyStoragePayload,
     AchievementMilestoneBasePayload,

--- a/energetica/utils/network_helpers.py
+++ b/energetica/utils/network_helpers.py
@@ -60,6 +60,7 @@ def leave_network(player: Player) -> Network | None:
     if network is None:
         raise GameError(GameExceptionType.NOT_IN_NETWORK)
     player.network = None
+    player.overdraft_warning_sent = False
     network.members.remove(player)
     engine.log(f"{player.username} left the network {network.name}")
 

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -122,6 +122,15 @@ const INBOX_NOTIFICATION_CONFIG = {
         inGameBody: (p) =>
             `You have been expelled from ${p.network_name} due to insufficient funds. Recover a positive balance to rejoin.`,
     },
+    network_overdraft_warning: {
+        category: "market",
+        path: () => "/app/community/electricity-markets",
+        title: "Overdraft warning",
+        pushBody: (p) =>
+            `Your balance in ${p.network_name} has reached ${Math.round(p.overdraft_pct * 100)}% of your maximum overdraft. Recover funds to avoid being expelled.`,
+        inGameBody: (p) =>
+            `Your balance in ${p.network_name} has reached ${Math.round(p.overdraft_pct * 100)}% of your maximum overdraft. Recover funds to avoid being expelled.`,
+    },
     achievement_milestone: {
         category: "achievements",
         // TODO: redirect to a dedicated achievements page when it exists

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -127,9 +127,9 @@ const INBOX_NOTIFICATION_CONFIG = {
         path: () => "/app/community/electricity-markets",
         title: "Overdraft warning",
         pushBody: (p) =>
-            `Your balance in ${p.network_name} has reached ${Math.round(p.overdraft_pct * 100)}% of your maximum overdraft. Recover funds to avoid being expelled.`,
+            `Your balance has reached ${Math.round(p.overdraft_pct * 100)}% of your maximum overdraft. Recover funds to avoid being expelled from ${p.network_name}.`,
         inGameBody: (p) =>
-            `Your balance in ${p.network_name} has reached ${Math.round(p.overdraft_pct * 100)}% of your maximum overdraft. Recover funds to avoid being expelled.`,
+            `Your balance has reached ${Math.round(p.overdraft_pct * 100)}% of your maximum overdraft. Recover funds to avoid being expelled from ${p.network_name}.`,
     },
     achievement_milestone: {
         category: "achievements",
@@ -257,9 +257,7 @@ const getInboxDef = (type: NotificationType) =>
     INBOX_NOTIFICATION_CONFIG[type] as unknown as AnyInboxDef;
 
 /** Get the inbox category for a notification type (inbox items only). */
-export function getNotificationCategory(
-    type: NotificationType,
-): InboxCategory {
+export function getNotificationCategory(type: NotificationType): InboxCategory {
     return INBOX_NOTIFICATION_CONFIG[type].category;
 }
 

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3220,6 +3220,20 @@ export interface components {
             /** Network Name */
             network_name: string;
         };
+        /** NetworkOverdraftWarningPayload */
+        NetworkOverdraftWarningPayload: {
+            /**
+             * Type
+             *
+             * @constant
+             * @default network_overdraft_warning
+             */
+            type: "network_overdraft_warning";
+            /** Network Name */
+            network_name: string;
+            /** Overdraft Pct */
+            overdraft_pct: number;
+        };
         /**
          * NonFacilityBidType
          *
@@ -3271,6 +3285,7 @@ export interface components {
                 | components["schemas"]["ResourceSoldPayload"]
                 | components["schemas"]["ShipmentArrivedPayload"]
                 | components["schemas"]["NetworkExpelledPayload"]
+                | components["schemas"]["NetworkOverdraftWarningPayload"]
                 | components["schemas"]["AchievementMilestonePowerConsumptionPayload"]
                 | components["schemas"]["AchievementMilestoneEnergyStoragePayload"]
                 | components["schemas"]["AchievementMilestoneBasePayload"]


### PR DESCRIPTION
fixes #673

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a one-time push/in-game notification that fires when a network player's balance drops below 50% of their maximum overdraft, giving them a heads-up before automatic expulsion kicks in at 100%. The feature is implemented end-to-end: new `overdraft_warning_sent` boolean on `Player` (with migration), the check wired into the per-tick `update_electricity` loop, a new `NetworkOverdraftWarningPayload` schema, frontend notification config, and regenerated API types.

<h3>Confidence Score: 5/5</h3>

Safe to merge — implementation is correct and complete across all layers.

The flag lifecycle is sound: initialized to False, set on first dip below 50%, reset on recovery (via elif) and on all network-leave paths (voluntary, expulsion, network-switch, network-create). Division by zero is not possible because income_per_day always includes a universal_income_per_day floor (4400). No security or data-integrity issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/production_update.py | Adds overdraft warning check after each player's money update; correctly guards with network membership, uses one-notification-per-dip flag, and resets the flag on recovery above the 50% threshold. |
| energetica/database/player.py | Adds `overdraft_warning_sent: bool = False` field with a correct migration guard in `__post_init__`. |
| energetica/utils/network_helpers.py | Resets `overdraft_warning_sent` in `leave_network`, which covers voluntary leave, expulsion, and network-switching paths. |
| energetica/schemas/notifications.py | New `NetworkOverdraftWarningPayload` model added and correctly appended to the `PersistableNotificationPayload` union. |
| energetica/database/messages.py | Adds `network_overdraft_warning` to the `NotificationType` literal. |
| frontend/src/lib/notification-config.tsx | New notification config entry with accurate push/in-game body text and correct redirect path. |
| frontend/src/types/api.generated.ts | Auto-generated type added for `NetworkOverdraftWarningPayload` and included in the union type. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Tick as update_electricity()
    participant Player
    participant Notify as player.notify()

    Tick->>Player: check money < max_overdraft?
    alt money below expulsion threshold
        Tick->>Player: leave_network() → overdraft_warning_sent = False
        Tick->>Notify: NetworkExpelledPayload
    end

    Tick->>Player: money += industry_revenue
    Tick->>Player: check money < max_overdraft * 0.5?

    alt money below 50% overdraft AND warning not yet sent
        Player->>Player: overdraft_warning_sent = True
        Tick->>Notify: NetworkOverdraftWarningPayload(network_name, overdraft_pct)
    else money recovered above 50% AND warning was sent
        Player->>Player: overdraft_warning_sent = False
    end
```

<sub>Reviews (1): Last reviewed commit: ["feat : 50% overdraft notification"](https://github.com/felixvonsamson/energetica/commit/91ca87b7d1241bb6384ea70e174c422c7fbed0c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28855008)</sub>

<!-- /greptile_comment -->