### PR TITLE
Fix/620 active status for players

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -7,6 +7,7 @@ import json
 from urllib.parse import urlparse
 from collections import defaultdict
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Iterable
@@ -78,6 +79,8 @@ class Player(DBModel):
     def username(self) -> str:
         """Return the username of the associated user."""
         return self.user.username
+
+    last_connection: datetime | None = None
 
     # inactive: bool = False  # True if account is inactive
     show_chat_disclaimer: bool = True
@@ -173,6 +176,8 @@ class Player(DBModel):
         self.__dict__.update(state)
 
         # Backward compatibility: Initialize new fields for old Player objects loaded from pickle
+        if not hasattr(self, "last_connection"):
+            self.last_connection = None
         if not hasattr(self, "renewable_statuses"):
             self.renewable_statuses = {}
         if not hasattr(self, "production_statuses"):

--- a/energetica/routers/players.py
+++ b/energetica/routers/players.py
@@ -34,6 +34,7 @@ def get_me(user: Player = Depends(get_settled_player)) -> PlayerOut:
     return PlayerOut(
         id=user.id,
         username=user.username,
+        last_connection=user.last_connection,
     )
 
 
@@ -45,6 +46,7 @@ def get_all_players() -> list[PlayerOut]:
         PlayerOut(
             id=player.id,
             username=player.username,
+            last_connection=player.last_connection,
         )
         for player in all_players
     ]

--- a/energetica/routers/players.py
+++ b/energetica/routers/players.py
@@ -31,25 +31,13 @@ def get_game_state() -> GameStateOut:
 @router.get("/me")
 def get_me(user: Player = Depends(get_settled_player)) -> PlayerOut:
     """Get the current user's information."""
-    return PlayerOut(
-        id=user.id,
-        username=user.username,
-        last_connection=user.last_connection,
-    )
+    return PlayerOut.from_player(user)
 
 
 @router.get("")
 def get_all_players() -> list[PlayerOut]:
     """Get all user ids and usernames, excluding admins."""
-    all_players = Player.all()
-    return [
-        PlayerOut(
-            id=player.id,
-            username=player.username,
-            last_connection=player.last_connection,
-        )
-        for player in all_players
-    ]
+    return [PlayerOut.from_player(player) for player in Player.all()]
 
 
 @router.get("/me/settings")

--- a/energetica/schemas/players.py
+++ b/energetica/schemas/players.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
@@ -15,6 +16,7 @@ class PlayerOut(BaseModel):
 
     id: int = Field(description="ID of the player")
     username: str = Field(description="Username of the player")
+    last_connection: datetime | None = Field(None, description="Timestamp of the player's last activity")
 
 
 class SettingsOut(BaseModel):

--- a/energetica/schemas/players.py
+++ b/energetica/schemas/players.py
@@ -2,13 +2,29 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import TYPE_CHECKING
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from energetica.database.player import Player
+
+ActivityStatus = Literal["active", "away", "inactive"]
+
+_ACTIVE_THRESHOLD_S = 12 * 60 * 60  # 12 hours
+_AWAY_THRESHOLD_S = 3 * 24 * 60 * 60  # 3 days
+
+
+def _compute_activity_status(last_connection: datetime | None) -> ActivityStatus:
+    if last_connection is None:
+        return "inactive"
+    elapsed = (datetime.now(timezone.utc) - last_connection).total_seconds()
+    if elapsed < _ACTIVE_THRESHOLD_S:
+        return "active"
+    if elapsed < _AWAY_THRESHOLD_S:
+        return "away"
+    return "inactive"
 
 
 class PlayerOut(BaseModel):
@@ -16,7 +32,15 @@ class PlayerOut(BaseModel):
 
     id: int = Field(description="ID of the player")
     username: str = Field(description="Username of the player")
-    last_connection: datetime | None = Field(None, description="Timestamp of the player's last activity")
+    activity_status: ActivityStatus = Field(description="Player's activity status based on last connection time")
+
+    @classmethod
+    def from_player(cls, player: Player) -> PlayerOut:
+        return cls(
+            id=player.id,
+            username=player.username,
+            activity_status=_compute_activity_status(player.last_connection),
+        )
 
 
 class SettingsOut(BaseModel):

--- a/energetica/utils/auth.py
+++ b/energetica/utils/auth.py
@@ -2,7 +2,7 @@
 
 import os
 import secrets
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import bcrypt
 import requests
@@ -74,6 +74,7 @@ def get_settled_player(request: Request) -> Player:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=GameExceptionType.USER_IS_NOT_A_PLAYER)
     if user.player is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=GameExceptionType.PLAYER_NOT_SET_UP)
+    user.player.last_connection = datetime.now(timezone.utc)
     return user.player
 
 

--- a/energetica/utils/auth.py
+++ b/energetica/utils/auth.py
@@ -74,7 +74,8 @@ def get_settled_player(request: Request) -> Player:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=GameExceptionType.USER_IS_NOT_A_PLAYER)
     if user.player is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=GameExceptionType.PLAYER_NOT_SET_UP)
-    user.player.last_connection = datetime.now(timezone.utc)
+    if user.player.last_connection is None or (datetime.now(timezone.utc) - user.player.last_connection).total_seconds() > 300:
+        user.player.last_connection = datetime.now(timezone.utc)
     return user.player
 
 

--- a/frontend/src/components/chat/chat-list-item.tsx
+++ b/frontend/src/components/chat/chat-list-item.tsx
@@ -1,3 +1,5 @@
+import { PlayerName } from "@/components/ui/player-name";
+import { useMyId, usePlayerMap } from "@/hooks/use-players";
 import type { Chat } from "@/types/chats";
 
 interface ChatListItemProps {
@@ -7,6 +9,15 @@ interface ChatListItemProps {
 }
 
 export function ChatListItem({ chat, isSelected, onClick }: ChatListItemProps) {
+    const myId = useMyId();
+    const playerMap = usePlayerMap();
+    const otherPlayer =
+        !chat.is_group && myId && playerMap
+            ? (playerMap[
+                  chat.participant_ids.find((id) => id !== myId) ?? -1
+              ] ?? null)
+            : null;
+
     return (
         <button
             onClick={onClick}
@@ -18,7 +29,11 @@ export function ChatListItem({ chat, isSelected, onClick }: ChatListItemProps) {
         >
             <div className="flex justify-between items-start gap-2">
                 <span className="font-medium truncate flex-1">
-                    {chat.display_name}
+                    {otherPlayer ? (
+                        <PlayerName player={otherPlayer} />
+                    ) : (
+                        chat.display_name
+                    )}
                 </span>
                 {chat.unread_messages_count > 0 && (
                     <span className="bg-red-500 text-white text-xs px-2 py-1 rounded-full shrink-0">

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -2,7 +2,9 @@ import { ArrowLeft } from "lucide-react";
 
 import { MessageContainer } from "@/components/chat/message-container";
 import { MessageInput } from "@/components/chat/message-input";
+import { PlayerName } from "@/components/ui/player-name";
 import { TypographyH2 } from "@/components/ui/typography";
+import { useMyId, usePlayerMap } from "@/hooks/use-players";
 import type { Message, Chat } from "@/types/chats";
 
 interface ChatWindowProps {
@@ -24,6 +26,15 @@ export function ChatWindow({
     onBackClick,
     showBackButton,
 }: ChatWindowProps) {
+    const myId = useMyId();
+    const playerMap = usePlayerMap();
+    const otherPlayer =
+        selectedChat && !selectedChat.is_group && myId && playerMap
+            ? (playerMap[
+                  selectedChat.participant_ids.find((id) => id !== myId) ?? -1
+              ] ?? null)
+            : null;
+
     return (
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
             <div className="flex-1 flex flex-col overflow-hidden bg-card rounded-lg text-foreground">
@@ -39,10 +50,14 @@ export function ChatWindow({
                                 <ArrowLeft className="w-5 h-5" />
                             </button>
                         )}
-                        <TypographyH2 className="text-center flex-1">
-                            {selectedChat
-                                ? selectedChat.display_name
-                                : "Select a chat"}
+                        <TypographyH2 className="text-center flex-1 flex items-center justify-center">
+                            {otherPlayer ? (
+                                <PlayerName player={otherPlayer} />
+                            ) : selectedChat ? (
+                                selectedChat.display_name
+                            ) : (
+                                "Select a chat"
+                            )}
                         </TypographyH2>
                     </div>
                 </div>

--- a/frontend/src/components/chat/message-container.tsx
+++ b/frontend/src/components/chat/message-container.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from "react";
 
+import { PlayerName } from "@/components/ui/player-name";
 import { useAuth } from "@/hooks/use-auth";
 import { usePlayerMap } from "@/hooks/use-players";
 import { formatTimestamp } from "@/lib/format-utils";
 import { cn } from "@/lib/utils";
-import { PlayerName } from "@/components/ui/player-name";
 import type { Message } from "@/types/chats";
 
 interface MessageContainerProps {

--- a/frontend/src/components/chat/message-container.tsx
+++ b/frontend/src/components/chat/message-container.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { usePlayerMap } from "@/hooks/use-players";
 import { formatTimestamp } from "@/lib/format-utils";
 import { cn } from "@/lib/utils";
+import { PlayerName } from "@/components/ui/player-name";
 import type { Message } from "@/types/chats";
 
 interface MessageContainerProps {
@@ -118,9 +119,9 @@ export function MessageContainer({
                     >
                         {/* Show player name and timestamp only for the first message in the group */}
                         {group.showTimestamp && (
-                            <div className="text-sm text-muted-foreground mb-1 px-1">
+                            <div className="text-sm text-muted-foreground mb-1 px-1 inline-flex items-center gap-1">
                                 {showPlayerName && player && (
-                                    <>{player.username} • </>
+                                    <><PlayerName player={player} /> •</>
                                 )}
                                 {formatTimestamp(firstMessage.timestamp)}
                             </div>

--- a/frontend/src/components/electricity-markets/market-detail-dialog.tsx
+++ b/frontend/src/components/electricity-markets/market-detail-dialog.tsx
@@ -1,7 +1,6 @@
 import { Users, Check } from "lucide-react";
 
 import { CardContent, Button, Money } from "@/components/ui";
-import { PlayerName } from "@/components/ui/player-name";
 import {
     Dialog,
     DialogContent,
@@ -10,6 +9,7 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog";
 import { Duration } from "@/components/ui/duration";
+import { PlayerName } from "@/components/ui/player-name";
 import { TypographyH2, TypographyH3 } from "@/components/ui/typography";
 import { useLatestChartDataSlice } from "@/hooks/use-charts";
 import { useMyMarket } from "@/hooks/use-electricity-markets";

--- a/frontend/src/components/electricity-markets/market-detail-dialog.tsx
+++ b/frontend/src/components/electricity-markets/market-detail-dialog.tsx
@@ -1,6 +1,7 @@
 import { Users, Check } from "lucide-react";
 
 import { CardContent, Button, Money } from "@/components/ui";
+import { PlayerName } from "@/components/ui/player-name";
 import {
     Dialog,
     DialogContent,
@@ -183,8 +184,11 @@ function MarketContent(
                                 key={memberId}
                                 className="px-3 py-2 bg-muted/30 rounded text-sm"
                             >
-                                {playerMap[memberId]?.username ||
-                                    `Player ${memberId}`}
+                                {playerMap[memberId] ? (
+                                    <PlayerName player={playerMap[memberId]} />
+                                ) : (
+                                    `Player ${memberId}`
+                                )}
                             </div>
                         ))}
                     </div>

--- a/frontend/src/components/map/map-tooltip.tsx
+++ b/frontend/src/components/map/map-tooltip.tsx
@@ -3,13 +3,15 @@
  * tile.
  */
 
+import { PlayerName } from "@/components/ui/player-name";
 import type { ApiResponse } from "@/types/api-helpers";
+import type { Player } from "@/types/players";
 
 type HexTileData = ApiResponse<"/api/v1/map", "get">[number];
 
 interface MapTooltipProps {
     tile: HexTileData;
-    username: string | null;
+    player: Player | null;
     distance: number;
     x: number;
     y: number;
@@ -30,7 +32,7 @@ const TOOLTIP_HEIGHT = 360;
 
 export function MapTooltip({
     tile,
-    username,
+    player,
     distance,
     x,
     y,
@@ -118,8 +120,8 @@ export function MapTooltip({
             <div className="bg-card border border-border px-6 py-3 rounded shadow-lg">
                 {/* Title */}
                 <div className="text-center text-xl mb-3">
-                    {username ? (
-                        <span className="text-foreground">{username}</span>
+                    {player ? (
+                        <PlayerName player={player} className="justify-center" />
                     ) : (
                         <span className="text-brand-green dark:text-gray-100">
                             Vacant tile

--- a/frontend/src/components/ui/player-name.tsx
+++ b/frontend/src/components/ui/player-name.tsx
@@ -4,29 +4,29 @@ import { usePlayer } from "@/hooks/use-players";
 import { cn } from "@/lib/utils";
 import type { Player } from "@/types/players";
 
-type ActivityStatus = "online" | "away" | "offline";
+type ActivityStatus = "active" | "away" | "inactive";
 
-const ONLINE_THRESHOLD_MS = 15 * 60 * 1000;
-const AWAY_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+const ACTIVE_THRESHOLD_MS = 12 * 60 * 60 * 1000; // 12 hours
+const AWAY_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
 
 function getActivityStatus(lastConnection: string | null): ActivityStatus {
-    if (!lastConnection) return "offline";
+    if (!lastConnection) return "inactive";
     const elapsed = Date.now() - new Date(lastConnection).getTime();
-    if (elapsed < ONLINE_THRESHOLD_MS) return "online";
+    if (elapsed < ACTIVE_THRESHOLD_MS) return "active";
     if (elapsed < AWAY_THRESHOLD_MS) return "away";
-    return "offline";
+    return "inactive";
 }
 
 const statusStyles: Record<ActivityStatus, string> = {
-    online: "text-green-500",
-    away: "text-yellow-500",
-    offline: "text-muted-foreground/40",
+    active: "text-green-500",
+    away: "text-orange-500",
+    inactive: "text-muted-foreground/40",
 };
 
 const statusLabels: Record<ActivityStatus, string> = {
-    online: "Online",
-    away: "Recently active",
-    offline: "Offline",
+    active: "Active",
+    away: "Away",
+    inactive: "Inactive",
 };
 
 interface ActivityDotProps {

--- a/frontend/src/components/ui/player-name.tsx
+++ b/frontend/src/components/ui/player-name.tsx
@@ -1,0 +1,76 @@
+import { Circle } from "lucide-react";
+
+import { usePlayer } from "@/hooks/use-players";
+import { cn } from "@/lib/utils";
+import type { Player } from "@/types/players";
+
+type ActivityStatus = "online" | "away" | "offline";
+
+const ONLINE_THRESHOLD_MS = 15 * 60 * 1000;
+const AWAY_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+function getActivityStatus(lastConnection: string | null): ActivityStatus {
+    if (!lastConnection) return "offline";
+    const elapsed = Date.now() - new Date(lastConnection).getTime();
+    if (elapsed < ONLINE_THRESHOLD_MS) return "online";
+    if (elapsed < AWAY_THRESHOLD_MS) return "away";
+    return "offline";
+}
+
+const statusStyles: Record<ActivityStatus, string> = {
+    online: "text-green-500",
+    away: "text-yellow-500",
+    offline: "text-muted-foreground/40",
+};
+
+const statusLabels: Record<ActivityStatus, string> = {
+    online: "Online",
+    away: "Recently active",
+    offline: "Offline",
+};
+
+interface ActivityDotProps {
+    lastConnection: string | null;
+    className?: string;
+}
+
+export function ActivityDot({ lastConnection, className }: ActivityDotProps) {
+    const status = getActivityStatus(lastConnection);
+    return (
+        <Circle
+            className={cn("size-2 shrink-0", statusStyles[status], className)}
+            fill="currentColor"
+            strokeWidth={0}
+            aria-label={statusLabels[status]}
+        />
+    );
+}
+
+interface PlayerNameProps {
+    player: Player;
+    className?: string;
+    dotClassName?: string;
+}
+
+export function PlayerName({ player, className, dotClassName }: PlayerNameProps) {
+    return (
+        <span className={cn("inline-flex items-center gap-1.5", className)}>
+            <ActivityDot lastConnection={player.last_connection ?? null} className={dotClassName} />
+            {player.username}
+        </span>
+    );
+}
+
+interface PlayerNameByIdProps {
+    playerId: number;
+    className?: string;
+    dotClassName?: string;
+}
+
+export function PlayerNameById({ playerId, className, dotClassName }: PlayerNameByIdProps) {
+    const player = usePlayer(playerId);
+
+    if (!player) return null;
+
+    return <PlayerName player={player} className={className} dotClassName={dotClassName} />;
+}

--- a/frontend/src/components/ui/player-name.tsx
+++ b/frontend/src/components/ui/player-name.tsx
@@ -6,17 +6,6 @@ import type { Player } from "@/types/players";
 
 type ActivityStatus = "active" | "away" | "inactive";
 
-const ACTIVE_THRESHOLD_MS = 12 * 60 * 60 * 1000; // 12 hours
-const AWAY_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
-
-function getActivityStatus(lastConnection: string | null): ActivityStatus {
-    if (!lastConnection) return "inactive";
-    const elapsed = Date.now() - new Date(lastConnection).getTime();
-    if (elapsed < ACTIVE_THRESHOLD_MS) return "active";
-    if (elapsed < AWAY_THRESHOLD_MS) return "away";
-    return "inactive";
-}
-
 const statusStyles: Record<ActivityStatus, string> = {
     active: "text-green-500",
     away: "text-orange-500",
@@ -30,12 +19,11 @@ const statusLabels: Record<ActivityStatus, string> = {
 };
 
 interface ActivityDotProps {
-    lastConnection: string | null;
+    status: ActivityStatus;
     className?: string;
 }
 
-export function ActivityDot({ lastConnection, className }: ActivityDotProps) {
-    const status = getActivityStatus(lastConnection);
+export function ActivityDot({ status, className }: ActivityDotProps) {
     return (
         <Circle
             className={cn("size-2 shrink-0", statusStyles[status], className)}
@@ -55,7 +43,7 @@ interface PlayerNameProps {
 export function PlayerName({ player, className, dotClassName }: PlayerNameProps) {
     return (
         <span className={cn("inline-flex items-center gap-1.5", className)}>
-            <ActivityDot lastConnection={player.last_connection ?? null} className={dotClassName} />
+            <ActivityDot status={player.activity_status} className={dotClassName} />
             {player.username}
         </span>
     );

--- a/frontend/src/routes/app/community/leaderboards.tsx
+++ b/frontend/src/routes/app/community/leaderboards.tsx
@@ -5,8 +5,10 @@ import { useState } from "react";
 
 import { GameLayout } from "@/components/layout/game-layout";
 import { PageCard, CardContent, CashFlow } from "@/components/ui";
+import { PlayerName } from "@/components/ui/player-name";
 import { useHasCapability } from "@/hooks/use-capabilities";
 import { useLeaderboards } from "@/hooks/use-leaderboards";
+import { usePlayerMap } from "@/hooks/use-players";
 import { formatPower, formatEnergy, formatMass } from "@/lib/format-utils";
 import type { PlayerDetailStats } from "@/types/leaderboards";
 
@@ -65,6 +67,7 @@ function LeaderboardsContent() {
     const [sortConfig, setSortConfig] = useState<SortConfig>(null);
 
     const { data: leaderboards, isLoading, error } = useLeaderboards();
+    const playerMap = usePlayerMap();
     const hasGreenhouseGasEffect = useHasCapability(
         "has_greenhouse_gas_effect",
     );
@@ -590,9 +593,12 @@ function LeaderboardsContent() {
     };
 
     const renderTableRow = (row: PlayerDetailStats) => {
+        const player = playerMap?.[row.player_id];
         const commonCells = (
             <>
-                <td className="py-3 px-4">{row.username}</td>
+                <td className="py-3 px-4">
+                    {player ? <PlayerName player={player} /> : row.username}
+                </td>
                 <td className="py-3 px-4">{row.general.network_name || "-"}</td>
             </>
         );
@@ -658,7 +664,9 @@ function LeaderboardsContent() {
             case "technologies":
                 return (
                     <>
-                        <td className="py-3 px-4">{row.username}</td>
+                        <td className="py-3 px-4">
+                            {player ? <PlayerName player={player} /> : row.username}
+                        </td>
                         <td className="py-3 px-4 text-right">
                             {row.technologies.total_technologies}
                         </td>

--- a/frontend/src/routes/app/community/map.tsx
+++ b/frontend/src/routes/app/community/map.tsx
@@ -11,7 +11,7 @@ import { ResourceButton } from "@/components/map/resource-button";
 import { useMapContext } from "@/contexts/map-context";
 import { useAuth } from "@/hooks/use-auth";
 import { useMap } from "@/hooks/use-map";
-import { usePlayers } from "@/hooks/use-players";
+import { usePlayerMap, usePlayers } from "@/hooks/use-players";
 import { getHexPosition } from "@/lib/hex-utils";
 import { RESOURCES, ResourceId } from "@/lib/map-resources";
 
@@ -50,21 +50,20 @@ export const Route = createFileRoute("/app/community/map")({
 
 /** Renders the hovered-tile tooltip; must be inside a MapCanvas (uses context). */
 function MapTooltipLayer({
-    playerMap,
     calculateDistance,
 }: {
-    playerMap: Record<number, string>;
     calculateDistance: (tileId: number) => number;
 }) {
     const { width, height, s, w, hoveredTile } = useMapContext();
+    const playerMap = usePlayerMap();
     if (!hoveredTile) return null;
     const { x, y } = getHexPosition(hoveredTile.q, hoveredTile.r, s, w);
     return (
         <foreignObject x={-width / 2} y={-height / 2} width={width} height={height} overflow="visible" style={{ pointerEvents: "none" }}>
             <MapTooltip
                 tile={hoveredTile}
-                username={
-                    hoveredTile.player_id
+                player={
+                    hoveredTile.player_id && playerMap
                         ? (playerMap[hoveredTile.player_id] ?? null)
                         : null
                 }
@@ -87,7 +86,7 @@ function MapContent() {
     const { data: playersData, isLoading: isPlayersLoading } = usePlayers();
     const { user } = useAuth();
 
-    const playerMap = useMemo(() => {
+    const playerUsernameMap = useMemo(() => {
         const map: Record<number, string> = {};
         playersData?.forEach((p) => { map[p.id] = p.username; });
         return map;
@@ -151,12 +150,11 @@ function MapContent() {
                     <MapCanvas className="absolute inset-0" mapData={mapData}>
                         <MapTiles
                             mapData={mapData}
-                            playerMap={playerMap}
+                            playerMap={playerUsernameMap}
                             activeResourceId={activeResourceId}
                             currentPlayerId={user?.player_id}
                         />
                         <MapTooltipLayer
-                            playerMap={playerMap}
                             calculateDistance={calculateDistance}
                         />
                     </MapCanvas>

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3375,6 +3375,12 @@ export interface components {
              * Username of the player
              */
             username: string;
+            /**
+             * Last Connection
+             *
+             * Timestamp of the player's last activity
+             */
+            last_connection?: string | null;
         };
         /** PowerAndEnergyStats */
         PowerAndEnergyStats: {

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3376,11 +3376,13 @@ export interface components {
              */
             username: string;
             /**
-             * Last Connection
+             * Activity Status
              *
-             * Timestamp of the player's last activity
+             * Player's activity status based on last connection time
+             *
+             * @enum {string}
              */
-            last_connection?: string | null;
+            activity_status: "active" | "away" | "inactive";
         };
         /** PowerAndEnergyStats */
         PowerAndEnergyStats: {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `last_connection` timestamp to the `Player` model, updates it on every authenticated request via `get_settled_player`, and surfaces it through the API so the frontend can display an activity status dot (active / away / inactive) next to player names in chat, the map tooltip, and leaderboards.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style suggestions.

The implementation is correct end-to-end: backward-compat pickle guard is present, types are consistent across backend and frontend, activity thresholds are reasonable relative to the 5-minute cache stale time, and the -1 fallback in player map lookups is safe. The only note is that writing last_connection on every API call is more frequent than needed, but it causes no correctness issue.

energetica/utils/auth.py — consider throttling the `last_connection` write to avoid unnecessary object mutations on every request.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/player.py | Adds `last_connection: datetime | None = None` field with correct backward-compatibility guard in `__setstate__`. |
| energetica/utils/auth.py | Sets `last_connection` on every authenticated request via `get_settled_player`; no throttling means unnecessary writes on high-frequency calls. |
| energetica/schemas/players.py | Adds optional `last_connection` field to `PlayerOut` schema; correctly typed as `datetime | None`. |
| energetica/routers/players.py | Includes `last_connection` in both `/me` and `/players` responses correctly. |
| frontend/src/components/ui/player-name.tsx | New component rendering an activity dot (active/away/inactive) alongside a player's username; thresholds and status logic look correct. |
| frontend/src/hooks/use-players.ts | `usePlayerMap` now maps IDs to full `Player` objects instead of plain strings; 5-minute stale time is appropriate given the 12-hour/3-day activity thresholds. |
| frontend/src/components/map/map-tooltip.tsx | Switched from plain `username` string to full `Player` object to enable activity dot rendering. |
| frontend/src/components/chat/chat-list-item.tsx | Shows `PlayerName` with activity dot for 1-on-1 chats; falls back to `chat.display_name` for group chats. |
| frontend/src/routes/app/community/leaderboards.tsx | Replaces plain username text with `PlayerName` component in leaderboard rows; falls back to `row.username` when player not in map. |
| frontend/src/types/api.generated.ts | Auto-generated type updated to include optional `last_connection?: string | null` on `PlayerOut`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant A as FastAPI (auth.py)
    participant P as Player (DB)
    participant FE as Frontend

    C->>A: Any authenticated request (get_settled_player)
    A->>P: player.last_connection = datetime.now(UTC)
    A-->>C: Response (includes last_connection in PlayerOut)

    C->>FE: GET /api/v1/players
    FE->>FE: usePlayerMap() → Record<id, Player>
    FE->>FE: getActivityStatus(last_connection)
    Note over FE: < 12h → active (green)<br/>< 3d → away (orange)<br/>else → inactive (grey)
    FE->>FE: PlayerName renders ActivityDot + username
```

<sub>Reviews (1): Last reviewed commit: ["added status on chat list and title"](https://github.com/felixvonsamson/energetica/commit/381fa5b811f9a8212aa35f46e287360532d05f85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28864812)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->