### PR TITLE
feat: inform player about push notification after 3rd project

### DIFF
--- a/energetica/database/messages.py
+++ b/energetica/database/messages.py
@@ -54,6 +54,7 @@ NotificationType = Literal[
     "network_expelled",
     "achievement_milestone",
     "achievement_unlock",
+    "tutorial_push_notifications",
 ]
 
 

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -144,6 +144,7 @@ class Player(DBModel):
             "bought_resources": 0,
             "sold_resources": 0,
             "total_technologies": 0,
+            "total_projects": 0,
             "imported_energy": 0,
             "exported_energy": 0,
             "captured_co2": 0,

--- a/energetica/schemas/leaderboards.py
+++ b/energetica/schemas/leaderboards.py
@@ -22,6 +22,7 @@ class GeneralStats(BaseModel):
     average_revenues: float
     xp: float
     total_technologies: int
+    total_projects: int
 
 
 class PowerAndEnergyStats(BaseModel):
@@ -87,6 +88,7 @@ class PlayerDetailStats(BaseModel):
             average_revenues=metrics.get("average_revenues", 0),
             xp=metrics.get("xp", 0),
             total_technologies=int(metrics.get("total_technologies", 0)),
+            total_projects=int(metrics.get("total_projects", 0)),
         )
 
         power_and_energy = PowerAndEnergyStats(

--- a/energetica/schemas/notifications.py
+++ b/energetica/schemas/notifications.py
@@ -98,6 +98,12 @@ class AchievementUnlockPayload(BaseModel):
     xp: int
 
 
+class TutorialPushNotificationsPayload(BaseModel):
+    """Tutorial notification encouraging the player to enable browser push notifications."""
+
+    type: Literal["tutorial_push_notifications"] = "tutorial_push_notifications"
+
+
 class ChatMessagePayload(BaseModel):
     type: Literal["chat_message"] = "chat_message"
     sender_username: str
@@ -197,6 +203,7 @@ PersistableNotificationPayload = Union[
     AchievementMilestoneEnergyStoragePayload,
     AchievementMilestoneBasePayload,
     AchievementUnlockPayload,
+    TutorialPushNotificationsPayload,
 ]
 
 # Payloads that only trigger a browser push — no inbox entry.

--- a/energetica/schemas/players.py
+++ b/energetica/schemas/players.py
@@ -165,6 +165,7 @@ class ProgressionMetrics(BaseModel):
     bought_resources: float = Field(description="Total bought resources in kg")
     sold_resources: float = Field(description="Total sold resources in kg")
     total_technologies: int = Field(description="Total number of technologies researched")
+    total_projects: int = Field(description="Total number of projects completed")
     xp: float = Field(description="Player experience points")
     captured_co2: float = Field(description="Total captured CO2 in kg")
     net_emissions: float = Field(description="Net CO2 emissions in kg")
@@ -221,6 +222,7 @@ class ProfileOut(BaseModel):
             bought_resources=metrics.get("bought_resources", 0),
             sold_resources=metrics.get("sold_resources", 0),
             total_technologies=int(metrics.get("total_technologies", 0)),
+            total_projects=int(metrics.get("total_projects", 0)),
             xp=metrics.get("xp", 0),
             captured_co2=metrics.get("captured_co2", 0),
             net_emissions=player.calculate_net_emissions(),

--- a/energetica/utils/projects.py
+++ b/energetica/utils/projects.py
@@ -21,7 +21,7 @@ from energetica.enums import (
 )
 from energetica.game_error import GameError, GameExceptionType
 from energetica.globals import engine
-from energetica.schemas.notifications import ConstructionFinishedPayload, TechnologyResearchedPayload
+from energetica.schemas.notifications import ConstructionFinishedPayload, TechnologyResearchedPayload, TutorialPushNotificationsPayload
 from energetica.schemas.projects import ProjectListOut
 from energetica.utils.workers import deploy_available_workers
 from energetica.utils.hashing import stable_hash
@@ -339,6 +339,9 @@ def complete_project(project: OngoingProject, *, skip_notifications: bool = Fals
 
     player.check_construction_achievements(project.project_type)
 
+    total_projects = player.progression_metrics.get("total_projects", 0) + 1
+    player.progression_metrics["total_projects"] = total_projects
+
     project.delete()
 
     worker_type = project.project_type.worker_type
@@ -374,6 +377,9 @@ def complete_project(project: OngoingProject, *, skip_notifications: bool = Fals
                 )
             )
             engine.log(f"{player.username} : + 1 {project_name}")
+
+        if total_projects == 3 and not player.push_subscriptions:
+            player.notify(TutorialPushNotificationsPayload())
     if isinstance(project.project_type, PowerFacilityType | StorageFacilityType | ExtractionFacilityType):
         eol = engine.total_t + math.ceil(
             engine.const_config["assets"][project.project_type]["lifespan"] / engine.in_game_seconds_per_tick,

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -160,9 +160,9 @@ const INBOX_NOTIFICATION_CONFIG = {
         path: () => "/app/settings",
         title: "Tip: Enable push notifications",
         pushBody: () =>
-            "Stay on top of your energy empire! Enable browser notifications in Settings to get updates on construction, market activity, and more — even when the game is closed.",
+            "Enable browser notifications in Settings to get updates on construction, market activity, and more, even when the game is closed.",
         inGameBody: () =>
-            "Stay on top of your energy empire! Enable browser notifications in Settings to get updates on construction, market activity, and more — even when the game is closed.",
+            "Enable browser notifications in Settings to get updates on construction, market activity, and more, even when the game is closed.",
     },
 } satisfies { [T in NotificationType]: InboxNotificationDef<T> };
 
@@ -271,9 +271,7 @@ const getInboxDef = (type: NotificationType) =>
     INBOX_NOTIFICATION_CONFIG[type] as unknown as AnyInboxDef;
 
 /** Get the inbox category for a notification type (inbox items only). */
-export function getNotificationCategory(
-    type: NotificationType,
-): InboxCategory {
+export function getNotificationCategory(type: NotificationType): InboxCategory {
     return INBOX_NOTIFICATION_CONFIG[type].category;
 }
 

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -155,6 +155,15 @@ const INBOX_NOTIFICATION_CONFIG = {
         inGameBody: (p) =>
             `${ACHIEVEMENT_UNLOCK_CONFIG[p.achievement_key].body} (+${p.xp} XP)`,
     },
+    tutorial_push_notifications: {
+        category: "tutorials",
+        path: () => "/app/settings",
+        title: "Tip: Enable push notifications",
+        pushBody: () =>
+            "Stay on top of your energy empire! Enable browser notifications in Settings to get updates on construction, market activity, and more — even when the game is closed.",
+        inGameBody: () =>
+            "Stay on top of your energy empire! Enable browser notifications in Settings to get updates on construction, market activity, and more — even when the game is closed.",
+    },
 } satisfies { [T in NotificationType]: InboxNotificationDef<T> };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/routes/app/community/leaderboards.tsx
+++ b/frontend/src/routes/app/community/leaderboards.tsx
@@ -206,6 +206,15 @@ function LeaderboardsContent() {
                         <th
                             className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
                             onClick={() =>
+                                handleSort("general.total_projects")
+                            }
+                        >
+                            Projects
+                            {getSortIndicator("general.total_projects")}
+                        </th>
+                        <th
+                            className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
+                            onClick={() =>
                                 handleSort("general.total_technologies")
                             }
                         >
@@ -609,6 +618,9 @@ function LeaderboardsContent() {
                         </td>
                         <td className="py-3 px-4 text-right font-mono">
                             {formatPower(row.general.max_power_consumption)}
+                        </td>
+                        <td className="py-3 px-4 text-right">
+                            {row.general.total_projects}
                         </td>
                         <td className="py-3 px-4 text-right">
                             {row.general.total_technologies}

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -508,6 +508,35 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/charts/resources-soc/{resolution}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Resources Soc
+         *
+         * Get resource stocks as fraction of warehouse capacity at the
+         * specified resolution.
+         *
+         *     Parameters:
+         *         resolution: Aggregation level (1/6/36/216/1296 ticks per datapoint)
+         *         start_tick: First tick to include (must be aligned to resolution)
+         *         count: Number of datapoints to retrieve
+         *
+         *     Returns values as a fraction (0-1) of the warehouse's capacity at the time of recording.
+         */
+        get: operations["get_resources_soc_api_v1_charts_resources_soc__resolution__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/charts/markets/{market_id}/clearing/{resolution}": {
         parameters: {
             query?: never;
@@ -2835,6 +2864,8 @@ export interface components {
             xp: number;
             /** Total Technologies */
             total_technologies: number;
+            /** Total Projects */
+            total_projects: number;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -3274,7 +3305,8 @@ export interface components {
                 | components["schemas"]["AchievementMilestonePowerConsumptionPayload"]
                 | components["schemas"]["AchievementMilestoneEnergyStoragePayload"]
                 | components["schemas"]["AchievementMilestoneBasePayload"]
-                | components["schemas"]["AchievementUnlockPayload"];
+                | components["schemas"]["AchievementUnlockPayload"]
+                | components["schemas"]["TutorialPushNotificationsPayload"];
         };
         /** NotificationPatchIn */
         NotificationPatchIn: {
@@ -3661,6 +3693,12 @@ export interface components {
              */
             total_technologies: number;
             /**
+             * Total Projects
+             *
+             * Total number of projects completed
+             */
+            total_projects: number;
+            /**
              * Xp
              *
              * Player experience points
@@ -3893,6 +3931,42 @@ export interface components {
              * Series
              *
              * Time series data for resource stocks, with quantities in tons
+             */
+            series: {
+                [key: string]: number[];
+            };
+        };
+        /**
+         * ResourcesSocResponse
+         *
+         * Response model for resource stocks as fraction of warehouse capacity.
+         */
+        ResourcesSocResponse: {
+            /**
+             * Start Tick
+             *
+             * The starting tick (timestamp) of the data series
+             */
+            start_tick: number;
+            /**
+             * Count
+             *
+             * Number of data points in the series
+             */
+            count: number;
+            /**
+             * Resolution
+             *
+             * Time resolution between data points in ticks
+             *
+             * @enum {string}
+             */
+            resolution: "1" | "6" | "36" | "216" | "1296";
+            /**
+             * Series
+             *
+             * Time series data for resource stocks, as a fraction (0-1) of
+             * warehouse capacity
              */
             series: {
                 [key: string]: number[];
@@ -4465,6 +4539,21 @@ export interface components {
         TestPushBody: {
             /** Endpoint */
             endpoint?: string | null;
+        };
+        /**
+         * TutorialPushNotificationsPayload
+         *
+         * Tutorial notification encouraging the player to enable browser push
+         * notifications.
+         */
+        TutorialPushNotificationsPayload: {
+            /**
+             * Type
+             *
+             * @constant
+             * @default tutorial_push_notifications
+             */
+            type: "tutorial_push_notifications";
         };
         /**
          * UserOut
@@ -5311,6 +5400,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ResourcesResponse"];
+                };
+            };
+            /** Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_resources_soc_api_v1_charts_resources_soc__resolution__get: {
+        parameters: {
+            query: {
+                start_tick: number;
+                count: number;
+            };
+            header?: never;
+            path: {
+                resolution: "1" | "6" | "36" | "216" | "1296";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourcesSocResponse"];
                 };
             };
             /** Validation Error */

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -20,13 +20,15 @@ export type InboxCategory =
     | "projects"
     | "market"
     | "events"
-    | "achievements";
+    | "achievements"
+    | "tutorials";
 
 export const INBOX_CATEGORY_LABELS: Record<InboxCategory, string> = {
     projects: "Projects",
     market: "Market",
     events: "Events",
     achievements: "Achievements",
+    tutorials: "Tutorials",
 };
 
 // ---------------------------------------------------------------------------
@@ -43,4 +45,5 @@ export const PUSH_CATEGORY_LABELS: Record<PushCategory, string> = {
     market: "Market",
     events: "Events",
     achievements: "Achievements",
+    tutorials: "Tutorials",
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a tutorial in-game inbox notification prompting players to enable browser push notifications, triggered the first time a player completes their 3rd project while having no active push subscriptions. It also exposes `total_projects` in the leaderboards and profile API, and adds a full leaderboard frontend page with sortable columns across six stat categories.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no blocking issues found; the feature is cleanly implemented and follows established patterns throughout.

All changed files follow the existing notification pipeline conventions. The trigger condition (total_projects == 3 and no push subscriptions) is correct and fires exactly once. The new notification type is properly registered in every required location (Python Literal, Pydantic union, TypeScript config, category maps). Backward compatibility is handled via .get() with defaults. No P0 or P1 issues identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/utils/projects.py | Triggers TutorialPushNotificationsPayload on the 3rd project completion when no push subscriptions exist; increments total_projects counter and correctly places the check inside the skip_notifications guard. |
| energetica/schemas/notifications.py | Adds TutorialPushNotificationsPayload (no extra fields) and registers it in PersistableNotificationPayload; correctly follows the existing pattern for new inbox notification types. |
| energetica/database/messages.py | Adds tutorial_push_notifications to the NotificationType Literal; no issues. |
| frontend/src/lib/notification-config.tsx | Adds tutorial_push_notifications entry to INBOX_NOTIFICATION_CONFIG with correct category, path (/app/settings), and message text; satisfies the TypeScript exhaustiveness check. |
| frontend/src/types/notifications.ts | Adds tutorials to InboxCategory and PushCategory label maps; complete and consistent. |
| energetica/schemas/leaderboards.py | Exposes total_projects in GeneralStats using metrics.get with a 0 default; backward-compatible. |
| energetica/schemas/players.py | Adds total_projects to ProgressionMetrics with a safe .get() default; no issues. |
| frontend/src/routes/app/community/leaderboards.tsx | New leaderboard page with sortable columns across six categories; emissions tab gated by capability; technologies category intentionally omits the network column in both headers and rows. |
| frontend/src/types/api.generated.ts | Auto-generated file updated by openapi-typescript to reflect new notification type and leaderboard fields; no manual changes needed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Engine
    participant complete_project
    participant Player
    participant Notification DB
    participant Frontend Inbox

    Engine->>complete_project: project finishes
    complete_project->>Player: increment progression_metrics["total_projects"]
    complete_project->>Player: notify(ConstructionFinishedPayload / TechnologyResearchedPayload)
    Player->>Notification DB: persist inbox entry
    Player->>Frontend Inbox: socketio invalidate ["notifications"]

    alt total_projects == 3 AND no push_subscriptions
        complete_project->>Player: notify(TutorialPushNotificationsPayload)
        Player->>Notification DB: persist inbox entry (payload={})
        Player->>Frontend Inbox: socketio invalidate ["notifications"]
        Note over Player: push loop is skipped — no subscriptions
    end

    Frontend Inbox-->>Player: renders Tip: Enable push notifications
    Note over Frontend Inbox: category=tutorials, path=/app/settings
```

<sub>Reviews (1): Last reviewed commit: ["feat: inform player about push notificat..."](https://github.com/felixvonsamson/energetica/commit/ee2446fb638115864e918e94d21b23f47483ce89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28879604)</sub>

<!-- /greptile_comment -->