### PR TITLE
feat: replace average_revenues with cumulated gross_earnings

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -137,7 +137,7 @@ class Player(DBModel):
     progression_metrics: dict[str, float] = field(
         default_factory=lambda: {
             "xp": 0,
-            "gross_earnings": 0,
+            "operating_income": 0,
             "max_power_consumption": 0,
             "max_energy_stored": 0,
             "extracted_resources": 0,

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -137,7 +137,7 @@ class Player(DBModel):
     progression_metrics: dict[str, float] = field(
         default_factory=lambda: {
             "xp": 0,
-            "average_revenues": 0,
+            "gross_earnings": 0,
             "max_power_consumption": 0,
             "max_energy_stored": 0,
             "extracted_resources": 0,

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -169,7 +169,7 @@ def set_facilities_usage(new_values: dict, player: Player) -> None:
 def update_player_progress_values(player: Player, new_values: dict) -> None:
     # TODO (Felix): Should be moved somewhere else, e.g. player.py ?
     """Update the player progress values and checks for new unlocks and achievements."""
-    player.progression_metrics["gross_earnings"] += sum(
+    player.progression_metrics["operating_income"] += sum(
         new_values[player.id]["revenues"].values()
     ) + sum(new_values[player.id]["op_costs"].values())
     # update max power consumption

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -169,17 +169,9 @@ def set_facilities_usage(new_values: dict, player: Player) -> None:
 def update_player_progress_values(player: Player, new_values: dict) -> None:
     # TODO (Felix): Should be moved somewhere else, e.g. player.py ?
     """Update the player progress values and checks for new unlocks and achievements."""
-    # calculate moving average revenue TODO (Felix): Separate function ?
-    player.progression_metrics["average_revenues"] = (
-        player.progression_metrics["average_revenues"]
-        + 3600
-        / engine.in_game_seconds_per_tick
-        * 0.03
-        * sum(
-            [new_values[player.id]["revenues"][rev] for rev in new_values[player.id]["revenues"]]
-            + [new_values[player.id]["op_costs"][rev] for rev in new_values[player.id]["op_costs"]],
-        )
-    ) / 1.03
+    player.progression_metrics["gross_earnings"] += sum(
+        new_values[player.id]["revenues"].values()
+    ) + sum(new_values[player.id]["op_costs"].values())
     # update max power consumption
     total_demand = sum([new_values[player.id]["demand"][demand] for demand in new_values[player.id]["demand"]])
     if total_demand > player.progression_metrics["max_power_consumption"]:

--- a/energetica/schemas/leaderboards.py
+++ b/energetica/schemas/leaderboards.py
@@ -19,7 +19,7 @@ class LeaderboardsOut(BaseModel):
 class GeneralStats(BaseModel):
     network_name: Optional[str]
     max_power_consumption: float
-    average_revenues: float
+    gross_earnings: float
     xp: float
     total_technologies: int
     total_projects: int
@@ -85,7 +85,7 @@ class PlayerDetailStats(BaseModel):
         general = GeneralStats(
             network_name=player.network.name if player.network else None,
             max_power_consumption=metrics.get("max_power_consumption", 0),
-            average_revenues=metrics.get("average_revenues", 0),
+            gross_earnings=metrics.get("gross_earnings", 0),
             xp=metrics.get("xp", 0),
             total_technologies=int(metrics.get("total_technologies", 0)),
             total_projects=int(metrics.get("total_projects", 0)),

--- a/energetica/schemas/leaderboards.py
+++ b/energetica/schemas/leaderboards.py
@@ -19,7 +19,7 @@ class LeaderboardsOut(BaseModel):
 class GeneralStats(BaseModel):
     network_name: Optional[str]
     max_power_consumption: float
-    gross_earnings: float
+    operating_income: float
     xp: float
     total_technologies: int
     total_projects: int
@@ -85,7 +85,7 @@ class PlayerDetailStats(BaseModel):
         general = GeneralStats(
             network_name=player.network.name if player.network else None,
             max_power_consumption=metrics.get("max_power_consumption", 0),
-            gross_earnings=metrics.get("gross_earnings", 0),
+            operating_income=metrics.get("operating_income", 0),
             xp=metrics.get("xp", 0),
             total_technologies=int(metrics.get("total_technologies", 0)),
             total_projects=int(metrics.get("total_projects", 0)),

--- a/energetica/schemas/players.py
+++ b/energetica/schemas/players.py
@@ -156,7 +156,7 @@ class TechnologyLevels(BaseModel):
 class ProgressionMetrics(BaseModel):
     """Player progression metrics and statistics."""
 
-    gross_earnings: float = Field(description="Lifetime cumulated revenues")
+    operating_income: float = Field(description="Lifetime cumulated operating income")
     max_power_consumption: float = Field(description="Maximum power consumption in W")
     max_energy_stored: float = Field(description="Maximum energy stored in J")
     imported_energy: float = Field(description="Total imported energy in J")
@@ -213,7 +213,7 @@ class ProfileOut(BaseModel):
 
         # Always include emissions data (frontend will hide based on capabilities)
         progression_metrics = ProgressionMetrics(
-            gross_earnings=metrics.get("gross_earnings", 0),
+            operating_income=metrics.get("operating_income", 0),
             max_power_consumption=metrics.get("max_power_consumption", 0),
             max_energy_stored=metrics.get("max_energy_stored", 0),
             imported_energy=metrics.get("imported_energy", 0),

--- a/energetica/schemas/players.py
+++ b/energetica/schemas/players.py
@@ -156,7 +156,7 @@ class TechnologyLevels(BaseModel):
 class ProgressionMetrics(BaseModel):
     """Player progression metrics and statistics."""
 
-    average_revenues: float = Field(description="Average revenues per hour")
+    gross_earnings: float = Field(description="Lifetime cumulated revenues")
     max_power_consumption: float = Field(description="Maximum power consumption in W")
     max_energy_stored: float = Field(description="Maximum energy stored in J")
     imported_energy: float = Field(description="Total imported energy in J")
@@ -213,7 +213,7 @@ class ProfileOut(BaseModel):
 
         # Always include emissions data (frontend will hide based on capabilities)
         progression_metrics = ProgressionMetrics(
-            average_revenues=metrics.get("average_revenues", 0),
+            gross_earnings=metrics.get("gross_earnings", 0),
             max_power_consumption=metrics.get("max_power_consumption", 0),
             max_energy_stored=metrics.get("max_energy_stored", 0),
             imported_energy=metrics.get("imported_energy", 0),

--- a/energetica/utils/resource_market.py
+++ b/energetica/utils/resource_market.py
@@ -66,7 +66,9 @@ def purchase_resource(buyer: Player, quantity: float, sale: ResourceOnSale) -> R
         sale.player.resources[sale.resource] -= quantity
         sale.player.resources_on_sale[sale.resource] -= quantity
         buyer.progression_metrics["bought_resources"] += quantity
+        buyer.progression_metrics["operating_income"] -= total_price
         sale.player.progression_metrics["sold_resources"] += quantity
+        sale.player.progression_metrics["operating_income"] += total_price
         buyer.check_trading_achievement()
         sale.player.check_trading_achievement()
 

--- a/frontend/src/routes/app/community/leaderboards.tsx
+++ b/frontend/src/routes/app/community/leaderboards.tsx
@@ -4,7 +4,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { GameLayout } from "@/components/layout/game-layout";
-import { PageCard, CardContent, CashFlow } from "@/components/ui";
+import { PageCard, CardContent, Money } from "@/components/ui";
 import { useHasCapability } from "@/hooks/use-capabilities";
 import { useLeaderboards } from "@/hooks/use-leaderboards";
 import { formatPower, formatEnergy, formatMass } from "@/lib/format-utils";
@@ -188,11 +188,11 @@ function LeaderboardsContent() {
                         <th
                             className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
                             onClick={() =>
-                                handleSort("general.average_revenues")
+                                handleSort("general.gross_earnings")
                             }
                         >
-                            Revenues/h
-                            {getSortIndicator("general.average_revenues")}
+                            Gross Earnings
+                            {getSortIndicator("general.gross_earnings")}
                         </th>
                         <th
                             className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
@@ -612,9 +612,7 @@ function LeaderboardsContent() {
                     <>
                         {commonCells}
                         <td className="py-3 px-4 text-right">
-                            <CashFlow
-                                amountPerTick={row.general.average_revenues}
-                            />
+                            <Money amount={row.general.gross_earnings} />
                         </td>
                         <td className="py-3 px-4 text-right font-mono">
                             {formatPower(row.general.max_power_consumption)}

--- a/frontend/src/routes/app/community/leaderboards.tsx
+++ b/frontend/src/routes/app/community/leaderboards.tsx
@@ -188,11 +188,11 @@ function LeaderboardsContent() {
                         <th
                             className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
                             onClick={() =>
-                                handleSort("general.gross_earnings")
+                                handleSort("general.operating_income")
                             }
                         >
-                            Gross Earnings
-                            {getSortIndicator("general.gross_earnings")}
+                            Operating Income
+                            {getSortIndicator("general.operating_income")}
                         </th>
                         <th
                             className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
@@ -612,7 +612,7 @@ function LeaderboardsContent() {
                     <>
                         {commonCells}
                         <td className="py-3 px-4 text-right">
-                            <Money amount={row.general.gross_earnings} />
+                            <Money amount={row.general.operating_income} />
                         </td>
                         <td className="py-3 px-4 text-right font-mono">
                             {formatPower(row.general.max_power_consumption)}

--- a/frontend/src/routes/app/community/leaderboards.tsx
+++ b/frontend/src/routes/app/community/leaderboards.tsx
@@ -4,12 +4,8 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { GameLayout } from "@/components/layout/game-layout";
-<<<<<<< feat/683-change-revenues-to-cumulated-revenues
 import { PageCard, CardContent, Money } from "@/components/ui";
-=======
-import { PageCard, CardContent, CashFlow } from "@/components/ui";
 import { PlayerName } from "@/components/ui/player-name";
->>>>>>> main
 import { useHasCapability } from "@/hooks/use-capabilities";
 import { useLeaderboards } from "@/hooks/use-leaderboards";
 import { usePlayerMap } from "@/hooks/use-players";

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2858,8 +2858,8 @@ export interface components {
             network_name: string | null;
             /** Max Power Consumption */
             max_power_consumption: number;
-            /** Average Revenues */
-            average_revenues: number;
+            /** Gross Earnings */
+            gross_earnings: number;
             /** Xp */
             xp: number;
             /** Total Technologies */
@@ -3639,11 +3639,11 @@ export interface components {
          */
         ProgressionMetrics: {
             /**
-             * Average Revenues
+             * Gross Earnings
              *
-             * Average revenues per hour
+             * Lifetime cumulated revenues
              */
-            average_revenues: number;
+            gross_earnings: number;
             /**
              * Max Power Consumption
              *

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2858,8 +2858,8 @@ export interface components {
             network_name: string | null;
             /** Max Power Consumption */
             max_power_consumption: number;
-            /** Gross Earnings */
-            gross_earnings: number;
+            /** Operating Income */
+            operating_income: number;
             /** Xp */
             xp: number;
             /** Total Technologies */
@@ -3639,11 +3639,11 @@ export interface components {
          */
         ProgressionMetrics: {
             /**
-             * Gross Earnings
+             * Operating Income
              *
-             * Lifetime cumulated revenues
+             * Lifetime cumulated operating income
              */
-            gross_earnings: number;
+            operating_income: number;
             /**
              * Max Power Consumption
              *


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the exponential moving-average `average_revenues` metric with a cumulative `gross_earnings` counter across the backend models, schemas, and frontend leaderboard UI. The change is clean and consistent across all layers, but the pickle-based persistence layer needs a one-line backward-compatibility guard.

- **P1 – `KeyError` on first tick after deploy**: existing players loaded from pickle will not have `gross_earnings` in their `progression_metrics` dict; the `+=` in `production_update.py` will raise `KeyError`. The `__setstate__` migration block in `player.py` is the established fix point.

<h3>Confidence Score: 4/5</h3>

Not safe to merge without a `__setstate__` migration — existing pickled players will raise `KeyError` on the first production tick after restart.

One clear P1 defect: the renamed dict key inside `progression_metrics` is not migrated in `__setstate__`, which will crash the production update loop for all pre-existing players after the first server restart with this code.

energetica/database/player.py — `__setstate__` must add a migration for the `gross_earnings` key.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| energetica/database/player.py | Renames `average_revenues` to `gross_earnings` in the default `progression_metrics` factory, but the `__setstate__` backward-compat block is not updated — existing pickled players will raise `KeyError` on the first production tick after deploy. |
| energetica/production_update.py | Replaces the exponential moving-average revenue calculation with a simple cumulative sum of revenues + op_costs; straightforward change, though `op_costs` values are negative so the metric is net, not gross. |
| energetica/schemas/leaderboards.py | Renames `average_revenues` to `gross_earnings` in `GeneralStats` schema with safe `.get("gross_earnings", 0)` fallback — no issues. |
| energetica/schemas/players.py | Updates `ProgressionMetrics` field from `average_revenues` to `gross_earnings` with an updated description; uses safe `.get()` default — no issues. |
| frontend/src/routes/app/community/leaderboards.tsx | Switches column header, sort key, and cell renderer from `average_revenues`/`CashFlow` to `gross_earnings`/`Money` — consistent with backend changes. |
| frontend/src/types/api.generated.ts | Auto-generated type update renaming `average_revenues` to `gross_earnings` in `GeneralStats` and `ProgressionMetrics` interfaces — straightforward and consistent. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Production tick fires] --> B[update_player_progress_values]
    B --> C{Player loaded\nfrom pickle?}
    C -- New player --> D[progression_metrics has\n'gross_earnings' key ✓]
    C -- Existing player\nno migration --> E[progression_metrics has\n'average_revenues' key only]
    D --> F["gross_earnings += revenues + op_costs ✓"]
    E --> G["gross_earnings += ... ❌ KeyError"]
    G --> H[Production update crashes]
    F --> I[Metric persisted correctly]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `energetica/database/player.py`, line 171-193 ([link](https://github.com/felixvonsamson/energetica/blob/b26d99abf9fa8d62f5c65a1c6ff99a8b15e8300c/energetica/database/player.py#L171-L193)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing backward-compat migration for `gross_earnings` key**

   `__setstate__` already migrates new top-level attributes on unpickling (e.g. `renewable_statuses`), but this PR doesn't add an equivalent guard for the renamed key inside `progression_metrics`. When the server restarts with this code and deserializes any existing player whose pickle still carries `average_revenues` instead of `gross_earnings`, the first production tick will hit:

   ```
   player.progression_metrics["gross_earnings"] += ...   # KeyError
   ```

   The fix is to add the migration in `__setstate__`, matching the established pattern:

   ```python
   # inside __setstate__, after self.__dict__.update(state)
   if "gross_earnings" not in self.progression_metrics:
       self.progression_metrics["gross_earnings"] = 0
       self.progression_metrics.pop("average_revenues", None)
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat: replace average\_revenues with cumu..."](https://github.com/felixvonsamson/energetica/commit/b26d99abf9fa8d62f5c65a1c6ff99a8b15e8300c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28945283)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->