### PR TITLE
fix: correct multiple bugs in vps-setup.sh and deploy.sh

### DIFF
--- a/frontend/src/types/app-routes.ts
+++ b/frontend/src/types/app-routes.ts
@@ -17,6 +17,7 @@ export type AppRoute =
     | '/app/community/map'
     | '/app/community/messages'
     | '/app/community/resource-market'
+    | '/app/dashboard/quiz'
     | '/app/facilities/extraction'
     | '/app/facilities/functional'
     | '/app/facilities/manage'

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,11 +13,11 @@ set -e
 #   --rm_instance        Remove the instance folder on the server before deploying (DESTRUCTIVE)
 #
 # Environment variables (skip interactive prompts):
-#   DEPLOY_HOST          SSH host alias (default: energetica-game-deploy)
+#   DEPLOY_HOST          SSH host alias (e.g. energetica-game or energetica-edu)
 #   DEPLOY_USER          SSH user (default: deploy)
 #   DEPLOY_DOMAIN        Domain name (e.g. energetica-game.org)
 
-REMOTE_HOST="${DEPLOY_HOST:-energetica-game-deploy}"
+REMOTE_HOST="${DEPLOY_HOST:-}"
 REMOTE_USER="${DEPLOY_USER:-deploy}"
 REMOTE_PATH="/var/www/energetica"
 DOMAIN="${DEPLOY_DOMAIN:-}"
@@ -84,13 +84,23 @@ log_info() {
     echo -e "${BLUE}ℹ $1${NC}"
 }
 
-# Prompt for domain if not set via environment variable
-if [ -z "$DOMAIN" ]; then
-    read -r -p "Enter the domain name for this server (e.g. energetica-game.org): " DOMAIN
-    if [ -z "$DOMAIN" ]; then
-        echo -e "${RED}ERROR: Domain name is required${NC}"
-        exit 1
-    fi
+# Select target server if not provided via environment variables
+if [ -z "$REMOTE_HOST" ] || [ -z "$DOMAIN" ]; then
+    echo ""
+    echo -e "${BLUE}Select deployment target:${NC}"
+    echo ""
+    PS3="Target: "
+    select CHOICE in \
+        "energetica-game  →  energetica-game.org" \
+        "energetica-edu   →  energetica-edu.org"; do
+        case $REPLY in
+            1) REMOTE_HOST="${DEPLOY_HOST:-energetica-game}"; DOMAIN="${DEPLOY_DOMAIN:-energetica-game.org}"; break ;;
+            2) REMOTE_HOST="${DEPLOY_HOST:-energetica-edu}";  DOMAIN="${DEPLOY_DOMAIN:-energetica-edu.org}";  break ;;
+            *) echo -e "${RED}Invalid selection. Please try again.${NC}" ;;
+        esac
+    done
+    echo ""
+    log_success "Target: $REMOTE_HOST ($DOMAIN)"
 fi
 
 # Verify SSH host is reachable

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -120,7 +120,7 @@ main() {
     if [ "$SKIP_FRONTEND_BUILD" = false ]; then
         log_step "Building frontend..."
         cd frontend
-        npm run build
+        bun run build
         BUILD_EXIT_CODE=$?
         cd ..
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,10 +11,16 @@ set -e
 #   --skip-backend       Skip git sync and service restart (frontend-only deployment)
 #   --skip-frontend-build Skip building frontend locally (for backend-only changes)
 #   --rm_instance        Remove the instance folder on the server before deploying (DESTRUCTIVE)
+#
+# Environment variables (skip interactive prompts):
+#   DEPLOY_HOST          SSH host alias (default: energetica-game-deploy)
+#   DEPLOY_USER          SSH user (default: deploy)
+#   DEPLOY_DOMAIN        Domain name (e.g. energetica-game.org)
 
 REMOTE_HOST="${DEPLOY_HOST:-energetica-game-deploy}"
 REMOTE_USER="${DEPLOY_USER:-deploy}"
 REMOTE_PATH="/var/www/energetica"
+DOMAIN="${DEPLOY_DOMAIN:-}"
 LOCAL_BUILT_FRONTEND="./energetica/static/react"
 ALLOW_DIRTY=false
 AUTO_CONFIRM=false
@@ -77,6 +83,15 @@ log_error() {
 log_info() {
     echo -e "${BLUE}ℹ $1${NC}"
 }
+
+# Prompt for domain if not set via environment variable
+if [ -z "$DOMAIN" ]; then
+    read -r -p "Enter the domain name for this server (e.g. energetica-game.org): " DOMAIN
+    if [ -z "$DOMAIN" ]; then
+        echo -e "${RED}ERROR: Domain name is required${NC}"
+        exit 1
+    fi
+fi
 
 # Verify SSH host is reachable
 if ! ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new "${REMOTE_USER}@${REMOTE_HOST}" "exit" 2>/dev/null; then
@@ -150,7 +165,7 @@ main() {
     # Step 3: Confirm deployment
     log_step "Deployment summary:"
     echo "  Repository:    ${CURRENT_BRANCH} (${CURRENT_COMMIT})"
-    echo "  Domain:        https://energetica-game.org"
+    echo "  Domain:        https://$DOMAIN"
     echo "  Remote:        ${REMOTE_HOST}:${REMOTE_PATH}"
     echo ""
     echo "This will:"
@@ -279,7 +294,7 @@ main() {
     echo -e "${GREEN}║   ✓ Deployment Complete!               ║${NC}"
     echo -e "${BLUE}╚════════════════════════════════════════╝${NC}"
     echo ""
-    log_info "Site: https://energetica-game.org"
+    log_info "Site: https://$DOMAIN"
     log_info "Logs: ssh ${REMOTE_USER}@${REMOTE_HOST} 'sudo journalctl -u energetica -f'"
     log_info "To rollback: ./scripts/rollback.sh"
     echo ""

--- a/scripts/vps-setup.sh
+++ b/scripts/vps-setup.sh
@@ -238,6 +238,12 @@ EOF
 
 log_success "Systemd service file created"
 
+log_step "Creating instance directory..."
+mkdir -p "$APP_PATH/instance"
+chown "$APP_USER:$APP_USER" "$APP_PATH/instance"
+chmod 770 "$APP_PATH/instance"
+log_success "Instance directory created"
+
 log_step "Enabling and starting service..."
 systemctl daemon-reload
 systemctl enable energetica

--- a/scripts/vps-setup.sh
+++ b/scripts/vps-setup.sh
@@ -287,6 +287,7 @@ else
         exit 1
     fi
 
+    mkdir -p /var/www/html
     certbot certonly --webroot -w /var/www/html -d "$DOMAIN"
     log_success "SSL certificate obtained"
 fi

--- a/scripts/vps-setup.sh
+++ b/scripts/vps-setup.sh
@@ -69,11 +69,6 @@ log_step "Installing Python and build tools..."
 apt install -y python3 python3-venv python3-dev build-essential
 log_success "Python dependencies installed"
 
-log_step "Installing Node.js (for rollback frontend rebuilds)..."
-curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-apt install -y nodejs
-log_success "Node.js installed"
-
 log_step "Installing certbot and Let's Encrypt..."
 apt install -y certbot python3-certbot-apache
 log_success "Certbot installed"

--- a/scripts/vps-setup.sh
+++ b/scripts/vps-setup.sh
@@ -290,6 +290,15 @@ else
     mkdir -p /var/www/html
     certbot certonly --webroot -w /var/www/html -d "$DOMAIN"
     log_success "SSL certificate obtained"
+
+    # Ensure Apache is reloaded after every future auto-renewal
+    mkdir -p /etc/letsencrypt/renewal-hooks/deploy
+    cat > /etc/letsencrypt/renewal-hooks/deploy/reload-apache.sh << 'HOOK'
+#!/bin/bash
+systemctl reload apache2
+HOOK
+    chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-apache.sh
+    log_success "Certbot deploy hook installed"
 fi
 
 # Step 10: Update Apache Virtual Host with full HTTPS configuration

--- a/scripts/vps-setup.sh
+++ b/scripts/vps-setup.sh
@@ -45,7 +45,7 @@ fi
 log_section "ENERGETICA VPS SETUP"
 
 # Prompt for domain
-read -p "Enter the domain name for this server (e.g. energetica-game.org): " DOMAIN
+read -r -p "Enter the domain name for this server (e.g. energetica-game.org): " DOMAIN
 if [ -z "$DOMAIN" ]; then
     echo -e "${RED}ERROR: Domain name is required${NC}"
     exit 1

--- a/scripts/vps-setup.sh
+++ b/scripts/vps-setup.sh
@@ -3,10 +3,9 @@ set -e
 
 # Energetica VPS One-Time Setup Script
 # Run this on your VPS to set up Apache, Let's Encrypt, and the FastAPI backend
-# Usage: bash vps-setup.sh
+# Usage: sudo bash vps-setup.sh
 
 # Configuration
-DOMAIN="energetica-game.org"
 APP_PATH="/var/www/energetica"
 DEPLOY_USER="deploy"
 APP_USER="www-data"
@@ -26,6 +25,10 @@ log_success() {
     echo -e "${GREEN}✓ $1${NC}"
 }
 
+log_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
 log_section() {
     echo ""
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -40,6 +43,14 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 log_section "ENERGETICA VPS SETUP"
+
+# Prompt for domain
+read -p "Enter the domain name for this server (e.g. energetica-game.org): " DOMAIN
+if [ -z "$DOMAIN" ]; then
+    echo -e "${RED}ERROR: Domain name is required${NC}"
+    exit 1
+fi
+log_success "Domain set to: $DOMAIN"
 
 # Step 1: Update system
 log_step "Updating system packages..."
@@ -96,28 +107,42 @@ else
 fi
 
 log_step "Configuring passwordless sudo for deploy user..."
-# Use sudoers.d for cleaner, safer configuration
 SUDOERS_FILE="/etc/sudoers.d/energetica-deploy"
 
-# Check if already configured
 if [ -f "$SUDOERS_FILE" ]; then
     log_success "Sudo configuration already exists"
 else
-    # Create sudoers.d entry with minimal, specific permissions
-    # Allow: git pull as www-data, and service management
     cat > "$SUDOERS_FILE" << EOF
-    $DEPLOY_USER ALL=(www-data) NOPASSWD: /usr/bin/git -C $APP_PATH pull origin *, /bin/rm -r $APP_PATH/instance
-    $DEPLOY_USER ALL=(ALL) NOPASSWD: /bin/systemctl restart energetica, /bin/systemctl status energetica, /bin/systemctl is-active *, /usr/bin/journalctl -u energetica*
-    EOF
+$DEPLOY_USER ALL=(www-data) NOPASSWD: /usr/bin/git -C $APP_PATH fetch origin *, /usr/bin/git -C $APP_PATH reset --hard origin/*, /bin/rm -r $APP_PATH/instance
+$DEPLOY_USER ALL=(ALL) NOPASSWD: /bin/systemctl restart energetica, /bin/systemctl status energetica, /bin/systemctl is-active *, /usr/bin/journalctl -u energetica*
+EOF
     chmod 440 "$SUDOERS_FILE"
 
-    # Validate sudoers syntax
     if visudo -c -f "$SUDOERS_FILE" 2>/dev/null; then
         log_success "Passwordless sudo configured (git as www-data, service restart)"
     else
         log_error "Failed to configure sudoers - invalid syntax"
         exit 1
     fi
+fi
+
+# Step 4b: Set up SSH access for deploy user
+log_section "SETTING UP SSH ACCESS FOR DEPLOY USER"
+
+DEPLOY_HOME=$(getent passwd "$DEPLOY_USER" | cut -d: -f6)
+mkdir -p "$DEPLOY_HOME/.ssh"
+chmod 700 "$DEPLOY_HOME/.ssh"
+chown "$DEPLOY_USER:$DEPLOY_USER" "$DEPLOY_HOME/.ssh"
+
+log_step "Adding SSH public key for deploy user..."
+read -r -p "Paste your public SSH key for the deploy user (or press Enter to skip): " SSH_PUBLIC_KEY
+if [ -n "$SSH_PUBLIC_KEY" ]; then
+    echo "$SSH_PUBLIC_KEY" >> "$DEPLOY_HOME/.ssh/authorized_keys"
+    chmod 600 "$DEPLOY_HOME/.ssh/authorized_keys"
+    chown "$DEPLOY_USER:$DEPLOY_USER" "$DEPLOY_HOME/.ssh/authorized_keys"
+    log_success "SSH key added for deploy user"
+else
+    log_success "Skipped — add manually: echo 'your-key' >> $DEPLOY_HOME/.ssh/authorized_keys"
 fi
 
 # Step 5: Set up application directory
@@ -230,10 +255,23 @@ if ! systemctl is-active --quiet energetica; then
     exit 1
 fi
 
-# Step 8: Set up SSL with Let's Encrypt
+# Step 8: Create initial Apache Virtual Host (HTTP only, needed for certbot verification)
+log_section "SETTING UP APACHE VIRTUAL HOST"
+
+log_step "Creating temporary HTTP vhost for domain verification..."
+cat > /etc/apache2/sites-available/energetica.conf << EOF
+<VirtualHost *:80>
+    ServerName $DOMAIN
+    DocumentRoot /var/www/html
+</VirtualHost>
+EOF
+a2ensite energetica 2>/dev/null || true
+systemctl reload apache2
+log_success "HTTP vhost active"
+
+# Step 9: Set up SSL with Let's Encrypt
 log_section "SETTING UP SSL WITH LET'S ENCRYPT"
 
-# Check if certificate already exists
 if [ -f "/etc/letsencrypt/live/$DOMAIN/fullchain.pem" ]; then
     log_success "SSL certificate already exists for $DOMAIN - skipping setup"
 else
@@ -242,18 +280,18 @@ else
     read -p "Is $DOMAIN pointing to this server? (y/n) " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "Please configure your DNS first, then run: sudo certbot --apache -d $DOMAIN"
+        echo "Please configure your DNS first, then run: sudo certbot certonly --webroot -w /var/www/html -d $DOMAIN"
         exit 1
     fi
 
-    certbot --apache -d "$DOMAIN"
+    certbot certonly --webroot -w /var/www/html -d "$DOMAIN"
     log_success "SSL certificate obtained"
 fi
 
-# Step 9: Create Apache Virtual Host
-log_section "SETTING UP APACHE VIRTUAL HOST"
+# Step 10: Update Apache Virtual Host with full HTTPS configuration
+log_section "CONFIGURING APACHE VIRTUAL HOST WITH SSL"
 
-log_step "Creating Apache configuration..."
+log_step "Creating full Apache configuration..."
 cat > /etc/apache2/sites-available/energetica.conf << EOF
 <VirtualHost *:80>
     ServerName $DOMAIN
@@ -267,7 +305,7 @@ cat > /etc/apache2/sites-available/energetica.conf << EOF
 <VirtualHost *:443>
     ServerName $DOMAIN
 
-    # SSL Configuration (auto-managed by certbot)
+    # SSL Configuration (managed by certbot)
     SSLEngine on
     SSLCertificateFile /etc/letsencrypt/live/$DOMAIN/fullchain.pem
     SSLCertificateKeyFile /etc/letsencrypt/live/$DOMAIN/privkey.pem
@@ -318,12 +356,10 @@ cat > /etc/apache2/sites-available/energetica.conf << EOF
 </VirtualHost>
 EOF
 
-log_success "Apache configuration created"
-
 log_step "Enabling site and testing configuration..."
 a2ensite energetica 2>/dev/null || true
 
-# Disable the auto-generated Let's Encrypt default config to avoid conflicts
+# Disable any auto-generated Let's Encrypt config to avoid conflicts
 log_step "Disabling default Let's Encrypt config..."
 a2dissite 000-default-le-ssl 2>/dev/null || true
 
@@ -331,7 +367,7 @@ apache2ctl configtest
 systemctl reload apache2
 log_success "Apache configuration applied"
 
-# Step 10: Set up Firewall
+# Step 11: Set up Firewall
 log_section "SETTING UP FIREWALL"
 
 log_step "Configuring firewall..."
@@ -343,7 +379,7 @@ ufw allow 80/tcp      # HTTP
 ufw allow 443/tcp     # HTTPS
 log_success "Firewall configured"
 
-# Step 11: Set up directory permissions
+# Step 12: Set up directory permissions
 log_section "SETTING UP DIRECTORY PERMISSIONS"
 
 log_step "Setting www-data as owner with www-data group, deploy as member..."
@@ -353,7 +389,7 @@ find "$APP_PATH" -type d -exec chmod 2770 {} \;
 find "$APP_PATH" -type f -exec chmod 660 {} \;
 log_success "Ownership and permissions configured (www-data owner, group write enabled for deploy user)"
 
-# Step 12: Verify setup
+# Step 13: Verify setup
 log_section "VERIFYING SETUP"
 
 log_step "Checking services..."
@@ -378,7 +414,7 @@ echo ""
 echo "Your Energetica server is now configured!"
 echo ""
 echo "Next steps:"
-echo "1. From your local machine, build the frontend: cd frontend && npm run build"
+echo "1. From your local machine, build the frontend: cd frontend && bun run build"
 echo "2. Deploy with: ./scripts/deploy.sh"
 echo ""
 echo "Useful commands:"

--- a/scripts/vps-setup.sh
+++ b/scripts/vps-setup.sh
@@ -132,7 +132,9 @@ chown "$DEPLOY_USER:$DEPLOY_USER" "$DEPLOY_HOME/.ssh"
 log_step "Adding SSH public key for deploy user..."
 read -r -p "Paste your public SSH key for the deploy user (or press Enter to skip): " SSH_PUBLIC_KEY
 if [ -n "$SSH_PUBLIC_KEY" ]; then
-    echo "$SSH_PUBLIC_KEY" >> "$DEPLOY_HOME/.ssh/authorized_keys"
+    if ! grep -qF "$SSH_PUBLIC_KEY" "$DEPLOY_HOME/.ssh/authorized_keys" 2>/dev/null; then
+        echo "$SSH_PUBLIC_KEY" >> "$DEPLOY_HOME/.ssh/authorized_keys"
+    fi
     chmod 600 "$DEPLOY_HOME/.ssh/authorized_keys"
     chown "$DEPLOY_USER:$DEPLOY_USER" "$DEPLOY_HOME/.ssh/authorized_keys"
     log_success "SSH key added for deploy user"

--- a/scripts/vps-setup.sh
+++ b/scripts/vps-setup.sh
@@ -291,9 +291,17 @@ cat > /etc/apache2/sites-available/energetica.conf << EOF
 <VirtualHost *:80>
     ServerName $DOMAIN
 
-    # Redirect all HTTP to HTTPS
+    # Serve certbot renewal challenges directly — must not be redirected
+    Alias /.well-known/acme-challenge/ /var/www/html/.well-known/acme-challenge/
+    <Directory "/var/www/html/.well-known/acme-challenge/">
+        Options None
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+    # Redirect all other HTTP to HTTPS
     RewriteEngine On
-    RewriteCond %{HTTPS} off
+    RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/
     RewriteRule ^(.*)$ https://%{HTTP_HOST}\$1 [R=301,L]
 </VirtualHost>
 


### PR DESCRIPTION
## Summary

Several bugs in the deployment scripts were found and fixed while preparing for a fresh VPS setup.

### `scripts/vps-setup.sh`

- **Domain is now prompted interactively** instead of being hardcoded as `energetica-game.org`
- **Added missing `log_error` function** — it was called in three places but never defined; with `set -e` this caused a silent "command not found" exit instead of the intended error message
- **Fixed broken sudoers heredoc** — the closing `EOF` was indented with spaces, which bash heredoc syntax does not strip, so the block was never closed and the sudoers file would have contained the entire rest of the script
- **Fixed sudoers commands to match `deploy.sh`** — the allowed command was `git pull origin *` but `deploy.sh` actually runs `git fetch origin <branch>` followed by `git reset --hard origin/<branch>`; deployments would have failed with a permission denied error
- **Added SSH key setup step** for the `deploy` user — the script created the user but never set up `~deploy/.ssh/authorized_keys`, making it impossible to connect as that user after setup
- **Fixed SSL/Apache ordering** — `certbot` ran before any Apache vhost existed for the domain; restructured into three steps: create a minimal HTTP vhost → `certbot certonly --webroot` to obtain the cert → replace with the full HTTP+HTTPS vhost

### `scripts/deploy.sh`

- **Domain is now prompted interactively** instead of being hardcoded; also respects a `DEPLOY_DOMAIN` env var to skip the prompt in scripted/CI runs (consistent with the existing `DEPLOY_HOST` and `DEPLOY_USER` env vars)

## Test plan

- [ ] Run `vps-setup.sh` on a fresh VPS and verify the domain prompt appears at the start
- [ ] Verify certbot obtains the cert successfully with the new ordering
- [ ] Run `deploy.sh` and verify the domain prompt appears before the SSH check
- [ ] Verify `DEPLOY_DOMAIN=example.com ./scripts/deploy.sh` skips the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly addresses a comprehensive set of real bugs in the deployment scripts: missing `log_error` definition, broken sudoers heredoc indentation, mismatched sudoers commands vs. `deploy.sh` invocations, missing SSH key setup for the deploy user, wrong SSL/Apache ordering, and hardcoded domain names. It also switches the frontend build from `npm` to `bun`.

- **P1 — venv permissions broken after setup (`vps-setup.sh` lines 409–410):** `find \"$APP_PATH\" -type f -exec chmod 660 {} \\;` strips the execute bit from every file in the app directory, including `.venv/bin/python`. The service survives the current boot (process already running), but the first `systemctl restart energetica` — triggered by every subsequent deploy — will fail with a permission denied error because the interpreter is no longer executable.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the chmod sweep in Step 12 breaks every post-setup service restart.

A single P1 finding caps the score at 4, but this one silently breaks the primary deployment path (every deploy.sh run restarts the service, which will fail), warranting a lower score.

scripts/vps-setup.sh — specifically the Step 12 permission sweep around lines 407–410.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/vps-setup.sh | Fixes multiple real bugs (log_error, heredoc, sudoers commands, SSH setup, SSL ordering, ACME exception); introduces a new P1: the final chmod sweep removes execute bits from .venv/bin executables, breaking every subsequent service restart. |
| scripts/deploy.sh | Replaces hardcoded domain/host with an interactive select menu and env-var overrides; switches frontend build from npm to bun; changes look correct. |
| frontend/src/types/app-routes.ts | Adds '/app/dashboard/quiz' to the AppRoute union type — straightforward, no issues. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[vps-setup.sh start] --> B[Prompt for DOMAIN]
    B --> C[Install deps / Apache / certbot]
    C --> D[Create deploy user + sudoers]
    D --> E[Setup SSH authorized_keys]
    E --> F[Clone repo + Python venv]
    F --> G[Start energetica service]
    G --> H[Create temp HTTP vhost - reload Apache]
    H --> I{Cert exists?}
    I -- No --> J[certbot certonly --webroot]
    J --> K[Install renewal deploy hook]
    I -- Yes --> L[Skip certbot]
    K --> M[Write full HTTP+HTTPS vhost - reload Apache]
    L --> M
    M --> N[Setup firewall UFW]
    N --> O[chmod 660 all files - P1: strips execute from .venv/bin/python]
    O --> P[Verify services]
    P --> Q[Setup complete]
    style O fill:#ff6b6b,color:#fff
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `scripts/deploy.sh`, line 123 ([link](https://github.com/felixvonsamson/energetica/blob/b2a95da828677e80f3cd31648ed31f108abac4ff/scripts/deploy.sh#L123)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`npm run build` mismatches project's bun setup**

   `deploy.sh` calls `npm run build` to compile the frontend, but the `vps-setup.sh` instructions (updated in this same PR, line 417) now say `bun run build`, and `frontend/bun.lock` confirms the project uses bun as its package manager. If npm isn't installed (or produces a different dependency tree than bun), the frontend build step will fail or generate incorrect output on the deploying developer's machine.

2. `scripts/vps-setup.sh`, line 295-303 ([link](https://github.com/felixvonsamson/energetica/blob/0a687c44f87a93aebb2999051ad8029ab0599911/scripts/vps-setup.sh#L295-L303)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **HTTP redirect blocks Let's Encrypt auto-renewal**

   The final HTTP vhost unconditionally redirects every request (including `/.well-known/acme-challenge/`) to HTTPS. Certbot's webroot renewal mechanism places a token file in `/var/www/html/.well-known/acme-challenge/` and expects an HTTP 200 from the challenge URL — a 301 redirect causes the ACME validation to fail. The cert will stop renewing after ~60 days (when certbot first starts retrying) and expire at 90 days, taking the site offline.

   Add an exception for the ACME challenge path before the redirect rule:

3. `scripts/vps-setup.sh`, line 409-410 ([link](https://github.com/felixvonsamson/energetica/blob/cb62a15b1a6280c8ccac8ac5773b64d73b59d807/scripts/vps-setup.sh#L409-L410)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`chmod 660` strips execute bits from the Python venv**

   `find "$APP_PATH" -type f -exec chmod 660 {} \;` removes the execute bit from every file under `$APP_PATH`, including `.venv/bin/python` and all other venv executables. The service is already running at this point so the current process is unaffected, but the first subsequent `systemctl restart energetica` (triggered by every deploy) will fail with `EACCES` because `/var/www/energetica/.venv/bin/python` is no longer executable by any user.

   Either exclude the venv from the permission sweep, or restore execute bits afterwards:

   ```bash
   find "$APP_PATH" -type f -exec chmod 660 {} \;
   # Restore execute bits for venv scripts/binaries
   find "$APP_PATH/.venv/bin" -type f -exec chmod 770 {} \;
   find "$APP_PATH" -name "*.sh" -exec chmod 770 {} \;
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["greptile fix"](https://github.com/felixvonsamson/energetica/commit/cb62a15b1a6280c8ccac8ac5773b64d73b59d807) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29668709)</sub>

<!-- /greptile_comment -->