### PR TITLE
Fix/688 chat UI improvements

### DIFF
--- a/energetica/routers/chats.py
+++ b/energetica/routers/chats.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 import energetica.utils.chat
 from energetica.database.messages import Chat
@@ -29,12 +29,24 @@ def get_chat_list(player: Annotated[Player, Depends(get_settled_player)]) -> Cha
 def get_chat_messages(
     player: Annotated[Player, Depends(get_settled_player)],
     chat_id: int,
+    before: int | None = Query(None),
+    limit: int = Query(50),
 ) -> MessageListOut:
-    """Get the messages for a chat."""
+    """Get the messages for a chat, newest `limit` messages or those before `before` message id."""
     chat = Chat.getitem(chat_id, error=HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found"))
     if player not in chat.participants:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not a participant in this chat")
-    return MessageListOut(messages=[MessageOut.from_message(message) for message in chat.messages])
+    messages = chat.messages
+    if before is not None:
+        before_index = next((i for i, m in enumerate(messages) if m.id == before), None)
+        if before_index is None:
+            return MessageListOut(messages=[], has_more=False)
+        messages = messages[:before_index]
+    has_more = len(messages) > limit
+    return MessageListOut(
+        messages=[MessageOut.from_message(m) for m in messages[-limit:]],
+        has_more=has_more,
+    )
 
 
 @router.post("/{chat_id}/messages")

--- a/energetica/routers/chats.py
+++ b/energetica/routers/chats.py
@@ -30,7 +30,7 @@ def get_chat_messages(
     player: Annotated[Player, Depends(get_settled_player)],
     chat_id: int,
     before: int | None = Query(None),
-    limit: int = Query(50),
+    limit: int = Query(50, ge=1, le=200),
 ) -> MessageListOut:
     """Get the messages for a chat, newest `limit` messages or those before `before` message id."""
     chat = Chat.getitem(chat_id, error=HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found"))

--- a/energetica/schemas/chats.py
+++ b/energetica/schemas/chats.py
@@ -58,6 +58,7 @@ class MessageListOut(BaseModel):
     """Response model for the message list."""
 
     messages: list[MessageOut]
+    has_more: bool
 
 
 class MessageCreate(BaseModel):

--- a/energetica/utils/misc.py
+++ b/energetica/utils/misc.py
@@ -215,6 +215,7 @@ def send_new_message_sio(message: Message, chat: Chat) -> None:
         player.emit(
             "display_new_message",
             {
+                "id": message.id,
                 "time": message.timestamp.isoformat(),
                 "player_id": message.player.id,
                 "text": message.text,

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -12,6 +12,10 @@ interface ChatWindowProps {
     selectedChatId: number | null;
     isMessagesLoading: boolean;
     messages: Message[];
+    hasMore: boolean;
+    isLoadingMore: boolean;
+    onLoadMore: () => void;
+    onSend: (text: string, playerId: number) => Promise<void>;
     isDialogOpen: boolean;
     onBackClick?: () => void;
     showBackButton?: boolean;
@@ -22,6 +26,10 @@ export function ChatWindow({
     selectedChatId,
     isMessagesLoading,
     messages,
+    hasMore,
+    isLoadingMore,
+    onLoadMore,
+    onSend,
     isDialogOpen,
     onBackClick,
     showBackButton,
@@ -38,7 +46,7 @@ export function ChatWindow({
     return (
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
             <div className="flex-1 flex flex-col overflow-hidden bg-card rounded-lg text-foreground">
-                {/* Chat Header - sticky to stay visible when scrolling */}
+                {/* Chat Header */}
                 <div className="shrink-0 border-b border-border pb-4 mb-4 px-6 pt-6">
                     <div className="flex items-center gap-3">
                         {showBackButton && (
@@ -64,18 +72,19 @@ export function ChatWindow({
 
                 {/* Scrollable content area */}
                 <div className="flex-1 flex flex-col min-h-0 overflow-hidden px-6 pb-6">
-                    {/* Messages Container */}
                     <MessageContainer
                         isLoading={isMessagesLoading}
                         messages={messages}
                         selectedChatId={selectedChatId}
                         isGroupChat={selectedChat?.is_group ?? false}
+                        hasMore={hasMore}
+                        isLoadingMore={isLoadingMore}
+                        onLoadMore={onLoadMore}
                     />
 
-                    {/* Message Input - stays at bottom */}
                     {selectedChatId && (
                         <MessageInput
-                            chatId={selectedChatId}
+                            onSend={onSend}
                             isDisabled={!selectedChat}
                             isDialogOpen={isDialogOpen}
                         />

--- a/frontend/src/components/chat/message-container.tsx
+++ b/frontend/src/components/chat/message-container.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 import { PlayerName } from "@/components/ui/player-name";
 import { useAuth } from "@/hooks/use-auth";
@@ -12,6 +12,9 @@ interface MessageContainerProps {
     messages: Message[];
     selectedChatId: number | null;
     isGroupChat: boolean;
+    hasMore: boolean;
+    isLoadingMore: boolean;
+    onLoadMore: () => void;
 }
 
 interface MessageGroup {
@@ -25,12 +28,17 @@ export function MessageContainer({
     messages,
     selectedChatId,
     isGroupChat,
+    hasMore,
+    isLoadingMore,
+    onLoadMore,
 }: MessageContainerProps) {
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const isNearBottomRef = useRef(true);
     const prevChatIdRef = useRef<number | null>(selectedChatId);
     const initialScrollDoneRef = useRef(false);
+    // Scroll height before "load more" prepend — used to restore scroll position
+    const prevScrollHeightRef = useRef(0);
     const playerMap = usePlayerMap();
     const { user } = useAuth();
 
@@ -40,6 +48,19 @@ export function MessageContainer({
         isNearBottomRef.current =
             el.scrollHeight - el.scrollTop - el.clientHeight < 100;
     };
+
+    // Capture scroll height before messages are prepended (when isLoadingMore goes true)
+    // then restore position after the new messages land in the DOM.
+    useLayoutEffect(() => {
+        const el = scrollContainerRef.current;
+        if (!el) return;
+        if (isLoadingMore) {
+            prevScrollHeightRef.current = el.scrollHeight;
+        } else if (prevScrollHeightRef.current > 0) {
+            el.scrollTop += el.scrollHeight - prevScrollHeightRef.current;
+            prevScrollHeightRef.current = 0;
+        }
+    }, [isLoadingMore]);
 
     useEffect(() => {
         const chatChanged = selectedChatId !== prevChatIdRef.current;
@@ -68,14 +89,13 @@ export function MessageContainer({
         }
     }, [messages, selectedChatId, user?.player_id]);
 
-    // Group messages by sender and time proximity (5 minutes threshold)
     const groupMessages = (messages: Message[]): MessageGroup[] => {
         const groups: MessageGroup[] = [];
-        const TIME_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+        const TIME_THRESHOLD_MS = 5 * 60 * 1000;
 
         for (let i = 0; i < messages.length; i++) {
             const currentMessage = messages[i];
-            if (!currentMessage) continue; // Skip if undefined (shouldn't happen)
+            if (!currentMessage) continue;
 
             const previousMessage = i > 0 ? messages[i - 1] : null;
 
@@ -103,8 +123,6 @@ export function MessageContainer({
         return groups;
     };
 
-    const messageGroups = groupMessages(messages);
-
     if (!selectedChatId) {
         return (
             <div className="flex-1 flex items-center justify-center text-muted-foreground">
@@ -129,22 +147,34 @@ export function MessageContainer({
         );
     }
 
+    const messageGroups = groupMessages(messages);
+
     return (
         <div
             ref={scrollContainerRef}
             className="flex-1 overflow-y-auto space-y-4 mb-4 pr-2"
             onScroll={handleScroll}
         >
+            {/* Load more button */}
+            {hasMore && (
+                <div className="flex justify-center pt-2 pb-1">
+                    <button
+                        onClick={onLoadMore}
+                        disabled={isLoadingMore}
+                        className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors"
+                    >
+                        {isLoadingMore ? "Loading…" : "Load older messages"}
+                    </button>
+                </div>
+            )}
+
             {messageGroups.map((group) => {
                 const isOwnMessage = group.playerId === user?.player_id;
                 const showPlayerName = isGroupChat && !isOwnMessage;
                 const firstMessage = group.messages[0];
                 const player = playerMap[group.playerId];
 
-                // Skip groups without messages (shouldn't happen but type-safety)
-                if (!firstMessage) {
-                    return null;
-                }
+                if (!firstMessage) return null;
 
                 return (
                     <div
@@ -154,7 +184,6 @@ export function MessageContainer({
                             isOwnMessage ? "items-end" : "items-start",
                         )}
                     >
-                        {/* Show player name and timestamp only for the first message in the group */}
                         {group.showTimestamp && (
                             <div className="text-sm text-muted-foreground mb-1 px-1 inline-flex items-center gap-1">
                                 {showPlayerName && player && (
@@ -164,7 +193,6 @@ export function MessageContainer({
                             </div>
                         )}
 
-                        {/* Render all messages in the group */}
                         <div
                             className={cn(
                                 "w-full space-y-1 flex flex-col",

--- a/frontend/src/components/chat/message-container.tsx
+++ b/frontend/src/components/chat/message-container.tsx
@@ -161,7 +161,7 @@ export function MessageContainer({
                     <button
                         onClick={onLoadMore}
                         disabled={isLoadingMore}
-                        className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors"
+                        className="text-sm px-3 py-1 rounded-full border border-border-subtle bg-surface-overlay text-fg-base hover:bg-surface-sunken disabled:opacity-50 transition-colors cursor-pointer"
                     >
                         {isLoadingMore ? "Loading…" : "Load older messages"}
                     </button>

--- a/frontend/src/components/chat/message-container.tsx
+++ b/frontend/src/components/chat/message-container.tsx
@@ -27,13 +27,46 @@ export function MessageContainer({
     isGroupChat,
 }: MessageContainerProps) {
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const isNearBottomRef = useRef(true);
+    const prevChatIdRef = useRef<number | null>(selectedChatId);
+    const initialScrollDoneRef = useRef(false);
     const playerMap = usePlayerMap();
     const { user } = useAuth();
 
-    // Auto-scroll to bottom when messages change
+    const handleScroll = () => {
+        const el = scrollContainerRef.current;
+        if (!el) return;
+        isNearBottomRef.current =
+            el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+    };
+
     useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, [messages]);
+        const chatChanged = selectedChatId !== prevChatIdRef.current;
+        prevChatIdRef.current = selectedChatId;
+
+        if (chatChanged) {
+            isNearBottomRef.current = true;
+            initialScrollDoneRef.current = false;
+            const el = scrollContainerRef.current;
+            if (el) el.scrollTop = el.scrollHeight;
+            return;
+        }
+
+        if (!initialScrollDoneRef.current && messages.length > 0) {
+            initialScrollDoneRef.current = true;
+            const el = scrollContainerRef.current;
+            if (el) el.scrollTop = el.scrollHeight;
+            return;
+        }
+
+        const lastMessage = messages[messages.length - 1];
+        const isOwnMessage = lastMessage?.player_id === user?.player_id;
+
+        if (isNearBottomRef.current || isOwnMessage) {
+            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+        }
+    }, [messages, selectedChatId, user?.player_id]);
 
     // Group messages by sender and time proximity (5 minutes threshold)
     const groupMessages = (messages: Message[]): MessageGroup[] => {
@@ -97,7 +130,11 @@ export function MessageContainer({
     }
 
     return (
-        <div className="flex-1 overflow-y-auto space-y-4 mb-4 pr-2">
+        <div
+            ref={scrollContainerRef}
+            className="flex-1 overflow-y-auto space-y-4 mb-4 pr-2"
+            onScroll={handleScroll}
+        >
             {messageGroups.map((group) => {
                 const isOwnMessage = group.playerId === user?.player_id;
                 const showPlayerName = isGroupChat && !isOwnMessage;

--- a/frontend/src/components/chat/message-input.tsx
+++ b/frontend/src/components/chat/message-input.tsx
@@ -1,26 +1,21 @@
 import { useState, useRef, useEffect, useCallback } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui";
 import { useAuth } from "@/hooks/use-auth";
-import { useSendMessage } from "@/hooks/use-chats";
+import { resolveErrorMessage } from "@/lib/game-messages";
 
 interface MessageInputProps {
-    chatId: number;
+    onSend: (text: string, playerId: number) => Promise<void>;
     isDisabled: boolean;
     isDialogOpen: boolean;
 }
 
-export function MessageInput({
-    chatId,
-    isDisabled,
-    isDialogOpen,
-}: MessageInputProps) {
+export function MessageInput({ onSend, isDisabled, isDialogOpen }: MessageInputProps) {
     const [message, setMessage] = useState("");
     const inputRef = useRef<HTMLTextAreaElement>(null);
-    const { mutate: sendMessage } = useSendMessage();
     const { user } = useAuth();
 
-    // Auto-resize textarea as content changes
     const adjustHeight = useCallback(() => {
         const textarea = inputRef.current;
         if (textarea) {
@@ -29,38 +24,27 @@ export function MessageInput({
         }
     }, []);
 
-    const handleSend = () => {
+    const handleSend = async () => {
         if (!message.trim() || !user?.player_id) return;
         const messageText = message;
-
-        // Clear input immediately (optimistic)
         setMessage("");
         if (inputRef.current) {
             inputRef.current.style.height = "auto";
             inputRef.current.focus();
         }
-
-        sendMessage(
-            {
-                chatId,
-                data: { new_message: messageText },
-                playerId: user!.player_id!,
-            },
-            {
-                onError: () => {
-                    // Restore message text if the request fails
-                    setMessage(messageText);
-                },
-            },
-        );
+        try {
+            await onSend(messageText, user.player_id);
+        } catch (err) {
+            setMessage(messageText);
+            toast.error(resolveErrorMessage(err));
+        }
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
-            handleSend();
+            void handleSend();
         }
-        // Shift+Enter will naturally insert a new line in textarea
     };
 
     useEffect(() => {
@@ -89,7 +73,7 @@ export function MessageInput({
                 className="flex-1 px-3 py-2 rounded-lg border border-input bg-card focus:outline-none focus:ring-2 focus:ring-inset focus:ring-pine dark:focus:ring-brand-green disabled:opacity-50 min-w-0 resize-none max-h-32 overflow-y-auto"
             />
             <Button
-                onClick={handleSend}
+                onClick={() => void handleSend()}
                 disabled={isDisabled || !message.trim()}
                 aria-label="Send message"
                 className="max-h-12"

--- a/frontend/src/components/layout/game-layout.tsx
+++ b/frontend/src/components/layout/game-layout.tsx
@@ -43,7 +43,7 @@ export function GameLayout({ children }: GameLayoutProps) {
                             className="flex-1 overflow-auto min-w-0"
                             onScroll={handleScroll}
                         >
-                            <div className="max-w-[1400px] mx-auto">
+                            <div className="max-w-[1400px] mx-auto h-full">
                                 {children}
                             </div>
                         </main>

--- a/frontend/src/hooks/use-chats.ts
+++ b/frontend/src/hooks/use-chats.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { chatsApi } from "@/lib/api/chats";

--- a/frontend/src/hooks/use-chats.ts
+++ b/frontend/src/hooks/use-chats.ts
@@ -41,14 +41,25 @@ export function useChatMessages(chatId: number | null) {
             setHasMore(false);
             return;
         }
+        let cancelled = false;
         setIsLoading(true);
         chatsApi
             .getChatMessages(chatId)
             .then((data) => {
-                setMessages(data.messages);
-                setHasMore(data.has_more);
+                if (!cancelled) {
+                    setMessages(data.messages);
+                    setHasMore(data.has_more);
+                }
             })
-            .finally(() => setIsLoading(false));
+            .catch(() => {
+                if (!cancelled) toast.error("Failed to load messages");
+            })
+            .finally(() => {
+                if (!cancelled) setIsLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
     }, [chatId]);
 
     const loadMore = useCallback(async () => {
@@ -60,6 +71,8 @@ export function useChatMessages(chatId: number | null) {
             const data = await chatsApi.getChatMessages(chatId, oldestId);
             setMessages((prev) => [...data.messages, ...prev]);
             setHasMore(data.has_more);
+        } catch {
+            toast.error("Failed to load older messages");
         } finally {
             setIsLoadingMore(false);
         }

--- a/frontend/src/hooks/use-chats.ts
+++ b/frontend/src/hooks/use-chats.ts
@@ -1,17 +1,4 @@
-/**
- * Hooks for fetching and managing chats and messages.
- *
- * This module demonstrates best practices for React Query hooks:
- *
- * - Proper type extraction from API schemas
- * - Consistent error handling
- * - Automatic cache invalidation
- * - Explicit variable naming (no unused params)
- *
- * All types are imported from @/types/chats to keep chat-related definitions in
- * one place and stay synchronized with the OpenAPI schema.
- */
-
+import { useCallback, useEffect, useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -19,179 +6,107 @@ import { chatsApi } from "@/lib/api/chats";
 import { resolveErrorMessage } from "@/lib/game-messages";
 import { queryKeys, queryClient } from "@/lib/query-client";
 import type {
-    ChatMessagesResponse,
     CreateChatRequest,
     CreateChatResponse,
     Message,
-    SendMessageRequest,
     OpenChatResponse,
 } from "@/types/chats";
 
-/**
- * Get the list of all chats for the current user.
- *
- * Includes unread message counts and last opened chat ID. Updates every 30
- * seconds since new messages arrive via WebSocket but chat metadata changes
- * less frequently.
- *
- * @example
- *     const { data: chats, isLoading, error } = useChatList();
- *     if (chats) {
- *         chats.chats.forEach((chat) => console.log(chat.display_name));
- *     }
- *
- * @returns Query result with typed chat list data
- */
 export function useChatList() {
     return useQuery({
         queryKey: queryKeys.chats.list,
         queryFn: chatsApi.getChatList,
-        staleTime: 30 * 1000, // 30 seconds - chats update when messages arrive
-        gcTime: 5 * 60 * 1000, // 5 minutes - keep for offline access
+        staleTime: 30 * 1000,
+        gcTime: 5 * 60 * 1000,
         refetchOnWindowFocus: true,
     });
 }
 
 /**
- * Get all messages in a specific chat.
+ * Manages all message state for a single chat: initial load, paginated history,
+ * optimistic sends, and real-time additions from WebSocket events.
  *
- * Query is disabled (won't fetch) until a valid chatId is provided. This
- * prevents unnecessary API calls while the user is selecting a chat.
- *
- * @example
- *     const { data: messages } = useChatMessages(selectedChatId);
- *     if (messages) {
- *         console.log(`Got ${messages.messages.length} messages`);
- *     }
- *
- * @param chatId - The ID of the chat to fetch messages for, or null to disable
- * @returns Query result with typed message data
+ * Uses local state instead of React Query so that loading older pages doesn't
+ * blow away already-loaded message history.
  */
 export function useChatMessages(chatId: number | null) {
-    return useQuery({
-        queryKey: queryKeys.chats.messages(chatId || 0),
-        queryFn: () => chatsApi.getChatMessages(chatId!),
-        staleTime: 10 * 1000, // 10 seconds - messages update frequently
-        gcTime: 5 * 60 * 1000, // 5 minutes
-        refetchOnWindowFocus: true,
-        enabled: chatId !== null, // Don't fetch if no chat selected
-    });
-}
+    const [messages, setMessages] = useState<Message[]>([]);
+    const [hasMore, setHasMore] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
 
-/**
- * Send a new message to a chat.
- *
- * Automatically refreshes both the message list for this chat and the chat list
- * (since unread counts may change). The mutation properly types both the
- * request and response.
- *
- * @example
- *     const { mutate: sendMessage, isPending } = useSendMessage();
- *     const handleSend = (text: string) => {
- *         sendMessage({
- *             chatId: 123,
- *             data: { text },
- *         });
- *     };
- *
- * @returns Mutation hook for sending messages
- */
-export function useSendMessage() {
-    return useMutation({
-        mutationFn: ({
-            chatId,
-            data,
-        }: {
-            chatId: number;
-            data: SendMessageRequest;
-            playerId: number;
-        }): ReturnType<typeof chatsApi.sendMessage> =>
-            chatsApi.sendMessage(chatId, data),
-        onMutate: async ({ chatId, data, playerId }) => {
-            // Cancel in-flight refetches so they don't overwrite the optimistic update
-            await queryClient.cancelQueries({
-                queryKey: queryKeys.chats.messages(chatId),
-            });
+    useEffect(() => {
+        if (chatId === null) {
+            setMessages([]);
+            setHasMore(false);
+            return;
+        }
+        setIsLoading(true);
+        chatsApi
+            .getChatMessages(chatId)
+            .then((data) => {
+                setMessages(data.messages);
+                setHasMore(data.has_more);
+            })
+            .finally(() => setIsLoading(false));
+    }, [chatId]);
 
-            const previousMessages =
-                queryClient.getQueryData<ChatMessagesResponse>(
-                    queryKeys.chats.messages(chatId),
+    const loadMore = useCallback(async () => {
+        if (!chatId || !hasMore || isLoadingMore || messages.length === 0) return;
+        const oldestId = messages[0]?.id;
+        if (oldestId === undefined) return;
+        setIsLoadingMore(true);
+        try {
+            const data = await chatsApi.getChatMessages(chatId, oldestId);
+            setMessages((prev) => [...data.messages, ...prev]);
+            setHasMore(data.has_more);
+        } finally {
+            setIsLoadingMore(false);
+        }
+    }, [chatId, hasMore, isLoadingMore, messages]);
+
+    const addMessage = useCallback((message: Message) => {
+        setMessages((prev) => [...prev, message]);
+    }, []);
+
+    /** Send a message with optimistic UI. Throws on error so the caller can restore input. */
+    const sendMessage = useCallback(
+        async (text: string, playerId: number): Promise<void> => {
+            if (!chatId) return;
+            const tempId = -Date.now();
+            setMessages((prev) => [
+                ...prev,
+                {
+                    id: tempId,
+                    player_id: playerId,
+                    text,
+                    timestamp: new Date().toISOString(),
+                },
+            ]);
+            try {
+                const realMessage = await chatsApi.sendMessage(chatId, {
+                    new_message: text,
+                });
+                setMessages((prev) =>
+                    prev.map((m) => (m.id === tempId ? realMessage : m)),
                 );
-
-            // Optimistic message — negative ID flags it as pending
-            const optimisticMessage: Message = {
-                id: -Date.now(),
-                player_id: playerId,
-                text: data.new_message,
-                timestamp: new Date().toISOString(),
-            };
-
-            queryClient.setQueryData<ChatMessagesResponse>(
-                queryKeys.chats.messages(chatId),
-                (old) =>
-                    old
-                        ? {
-                              ...old,
-                              messages: [...old.messages, optimisticMessage],
-                          }
-                        : old,
-            );
-
-            return { previousMessages };
-        },
-        onError: (err, { chatId }, context) => {
-            if (context?.previousMessages !== undefined) {
-                queryClient.setQueryData(
-                    queryKeys.chats.messages(chatId),
-                    context.previousMessages,
-                );
+                queryClient.invalidateQueries({ queryKey: queryKeys.chats.list });
+            } catch (err) {
+                setMessages((prev) => prev.filter((m) => m.id !== tempId));
+                throw err;
             }
-            toast.error(resolveErrorMessage(err));
         },
-        onSettled: (_response, _err, { chatId }) => {
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.chats.messages(chatId),
-            });
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.chats.list,
-            });
-        },
-    });
+        [chatId],
+    );
+
+    return { messages, hasMore, isLoading, isLoadingMore, loadMore, addMessage, sendMessage };
 }
 
-/**
- * Create a new group chat.
- *
- * Properly typed with the creation request and response types extracted from
- * the API schema. Automatically invalidates the chat list to show the new
- * chat.
- *
- * @example
- *     const { mutate: createChat } = useCreateGroupChat();
- *     const handleCreate = () => {
- *         createChat(
- *             {
- *                 group_chat_name: "Engineering",
- *                 group_member_ids: [1, 2, 3],
- *             },
- *             {
- *                 onSuccess: (newChat) => {
- *                     console.log(`Created chat: ${newChat.id}`);
- *                 },
- *             },
- *         );
- *     };
- *
- * @returns Mutation hook for creating group chats
- */
 export function useCreateGroupChat() {
     return useMutation<CreateChatResponse, Error, CreateChatRequest>({
         mutationFn: chatsApi.createGroupChat,
         onSuccess: () => {
-            // Invalidate chat list to show the new chat
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.chats.list,
-            });
+            queryClient.invalidateQueries({ queryKey: queryKeys.chats.list });
         },
         onError: (error) => {
             toast.error(resolveErrorMessage(error));
@@ -199,27 +114,12 @@ export function useCreateGroupChat() {
     });
 }
 
-/**
- * Mark a chat as opened by the current user.
- *
- * Updates the "last opened chat" timestamp on the server. Automatically
- * invalidates the chat list to reflect the updated metadata.
- *
- * @example
- *     const { mutate: openChat } = useOpenChat();
- *     openChat(chatId); // Mark as opened
- *
- * @returns Mutation hook for opening chats
- */
 export function useOpenChat() {
     return useMutation<OpenChatResponse, Error, number>({
         mutationFn: (chatId: number): Promise<OpenChatResponse> =>
             chatsApi.openChat(chatId),
         onSuccess: () => {
-            // Invalidate the chat list to update last opened chat ID
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.chats.list,
-            });
+            queryClient.invalidateQueries({ queryKey: queryKeys.chats.list });
         },
     });
 }

--- a/frontend/src/hooks/use-messages-page.ts
+++ b/frontend/src/hooks/use-messages-page.ts
@@ -2,8 +2,8 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useRef, useEffect, useCallback, useState } from "react";
 
 import { useSocketEvent } from "@/contexts/socket-context";
-import { useChatList, useChatMessages, useOpenChat } from "@/hooks/use-chats";
 import { useAuth } from "@/hooks/use-auth";
+import { useChatList, useChatMessages, useOpenChat } from "@/hooks/use-chats";
 import { useSettings, useUpdateSettings } from "@/hooks/use-settings";
 import type { Message } from "@/types/chats";
 

--- a/frontend/src/hooks/use-messages-page.ts
+++ b/frontend/src/hooks/use-messages-page.ts
@@ -3,10 +3,11 @@ import { useRef, useEffect, useCallback, useState } from "react";
 
 import { useSocketEvent } from "@/contexts/socket-context";
 import { useChatList, useChatMessages, useOpenChat } from "@/hooks/use-chats";
+import { useAuth } from "@/hooks/use-auth";
 import { useSettings, useUpdateSettings } from "@/hooks/use-settings";
+import type { Message } from "@/types/chats";
 
 export function useMessagesPage() {
-    // Get URL search parameters
     const { selectedChatId, showDisclaimer } = useSearch({
         from: "/app/community/messages",
     });
@@ -14,27 +15,33 @@ export function useMessagesPage() {
         from: "/app/community/messages",
     });
 
-    // Local state for dialogs
     const [showNewChatDialog, setShowNewChatDialog] = useState(false);
     const [showGroupChatDialog, setShowGroupChatDialog] = useState(false);
 
     const selectedChatIdRef = useRef<number | null>(selectedChatId ?? null);
 
     const { data: chatListData, isLoading: isChatListLoading } = useChatList();
-    const { data: chatMessagesData, isLoading: isChatMessagesLoading } =
-        useChatMessages(selectedChatId ?? null);
+    const {
+        messages,
+        hasMore,
+        isLoading: isChatMessagesLoading,
+        isLoadingMore,
+        loadMore,
+        addMessage,
+        sendMessage,
+    } = useChatMessages(selectedChatId ?? null);
     const { data: settingsData } = useSettings();
     const { mutate: updateSettings } = useUpdateSettings();
     const { mutate: openChat } = useOpenChat();
+    const { user } = useAuth();
 
-    // Keep ref in sync with selected chat ID
     useEffect(() => {
         selectedChatIdRef.current = selectedChatId ?? null;
     }, [selectedChatId]);
 
-    // When a message is received, mark the chat as opened if it's the selected chat
     const handleNewMessage = useCallback(
         (data: {
+            id: number;
             time: string;
             player_id: number;
             text: string;
@@ -42,14 +49,22 @@ export function useMessagesPage() {
         }) => {
             if (data.chat_id === selectedChatIdRef.current) {
                 openChat(data.chat_id);
+                // Own messages are already handled by the optimistic send flow
+                if (data.player_id !== user?.player_id) {
+                    addMessage({
+                        id: data.id,
+                        player_id: data.player_id,
+                        text: data.text,
+                        timestamp: data.time,
+                    } satisfies Message);
+                }
             }
         },
-        [openChat],
+        [openChat, addMessage, user?.player_id],
     );
 
     useSocketEvent("display_new_message", handleNewMessage);
 
-    // Auto-select first chat if available and mark it as opened
     useEffect(() => {
         if (
             !selectedChatId &&
@@ -71,7 +86,6 @@ export function useMessagesPage() {
         (chat) => chat.id === selectedChatId,
     );
 
-    // Determine if disclaimer should be shown
     const shouldShowDisclaimer =
         showDisclaimer === false
             ? false
@@ -100,8 +114,12 @@ export function useMessagesPage() {
         setShowGroupChatDialog,
         isChatListLoading,
         isChatMessagesLoading,
+        isLoadingMore,
         chatListData,
-        chatMessagesData,
+        messages,
+        hasMore,
+        loadMore,
+        sendMessage,
         selectedChat,
         openChat,
     };

--- a/frontend/src/lib/api/chats.ts
+++ b/frontend/src/lib/api/chats.ts
@@ -8,10 +8,11 @@ export const chatsApi = {
     getChatList: () =>
         apiClient.get<ApiResponse<"/api/v1/chats", "get">>("/chats"),
 
-    /** Get all messages in a specific chat. */
-    getChatMessages: (chatId: number) =>
+    /** Get messages for a chat. Fetches the latest 50, or 50 before `before` message id. */
+    getChatMessages: (chatId: number, before?: number) =>
         apiClient.get<ApiResponse<"/api/v1/chats/{chat_id}/messages", "get">>(
             `/chats/${chatId}/messages`,
+            before !== undefined ? { params: { before } } : undefined,
         ),
 
     /** Send a new message to a chat. */

--- a/frontend/src/routes/app/community/messages.tsx
+++ b/frontend/src/routes/app/community/messages.tsx
@@ -96,8 +96,12 @@ function MessagesContent() {
         setShowGroupChatDialog,
         isChatListLoading,
         isChatMessagesLoading,
+        isLoadingMore,
         chatListData,
-        chatMessagesData,
+        messages,
+        hasMore,
+        loadMore,
+        sendMessage,
         selectedChat,
         openChat,
     } = useMessagesPage();
@@ -160,7 +164,11 @@ function MessagesContent() {
                         selectedChat={selectedChat}
                         selectedChatId={selectedChatId}
                         isMessagesLoading={isChatMessagesLoading}
-                        messages={chatMessagesData?.messages || []}
+                        messages={messages}
+                        hasMore={hasMore}
+                        isLoadingMore={isLoadingMore}
+                        onLoadMore={loadMore}
+                        onSend={sendMessage}
                         isDialogOpen={showNewChatDialog || showGroupChatDialog}
                         onBackClick={handleBackToList}
                         showBackButton={showMobileChatView && isMobile}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -81,6 +81,7 @@
     --color-surface-page:    var(--surface-page);
     --color-surface-card:    var(--surface-card);
     --color-surface-raised:  var(--surface-raised);
+    --color-surface-overlay: var(--surface-overlay);
     --color-surface-sunken:  var(--surface-sunken);
     --color-surface-topbar:  var(--surface-topbar);
 
@@ -167,6 +168,7 @@
         --surface-page:   var(--color-pine-200);   /* app background */
         --surface-card:   var(--color-bone-100);   /* cards, panels */
         --surface-raised: var(--color-bone-50);    /* popovers, dropdowns (above card) */
+        --surface-overlay: var(--color-bone-50);   /* lightest bone surface, interactive elements */
         --surface-sunken: var(--color-bone-150);   /* table rows, inset areas (below card) */
         --surface-topbar: var(--color-pine-100);   /* top navigation bar */
 
@@ -322,6 +324,7 @@
         --surface-page:   #0a0a0a;
         --surface-card:   #2d2d2d;
         --surface-raised: #383838;   /* above card: popovers, dropdowns */
+        --surface-overlay: #454545;  /* lightest surface, interactive elements */
         --surface-sunken: #1e1e1e;   /* below card: table rows, inset areas */
         --surface-topbar: var(--color-pine-900);
 
@@ -333,7 +336,7 @@
         --hyperlink:      var(--color-blue-400);        /* links */
 
         /* Borders */
-        --border-subtle:  #2a2a2a;
+        --border-subtle:  #525252;
         --border-brand:   var(--color-pine-700);   /* brand-coloured input/widget borders */
         /* --border (default) is already defined above */
 

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -751,7 +751,8 @@ export interface paths {
         /**
          * Get Chat Messages
          *
-         * Get the messages for a chat.
+         * Get the messages for a chat, newest `limit` messages or those before
+         * `before` message id.
          */
         get: operations["get_chat_messages_api_v1_chats__chat_id__messages_get"];
         put?: never;
@@ -3179,6 +3180,8 @@ export interface components {
         MessageListOut: {
             /** Messages */
             messages: components["schemas"]["MessageOut"][];
+            /** Has More */
+            has_more: boolean;
         };
         /**
          * MessageOut
@@ -5732,7 +5735,10 @@ export interface operations {
     };
     get_chat_messages_api_v1_chats__chat_id__messages_get: {
         parameters: {
-            query?: never;
+            query?: {
+                before?: number | null;
+                limit?: number;
+            };
             header?: never;
             path: {
                 chat_id: number;


### PR DESCRIPTION
- The card containing the chats is not constrained to the available space and the chat is scollable inside it
- The chats now only scrolls to the bottom when the new messages is the players one and not on every new message
- Backend is now sending only the 50 last messages and players have a button to load more messages seamlessly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements three chat UI improvements: constraining the chat card to available viewport height with internal scrolling, limiting the initial message fetch to the 50 most recent messages with a "Load older messages" button for paginated history, and restricting auto-scroll-to-bottom to only the user's own new messages (rather than every incoming message). The backend, API types, hooks, and components are all updated consistently.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 issues found; only a minor P2 performance suggestion.

All three features (layout constraint, paginated history, smart auto-scroll) are implemented correctly. Stale-fetch cancellation, optimistic send + rollback, WebSocket deduplication, and scroll position restoration are all handled properly. The single finding is a P2 callback recreation pattern that has no correctness impact.

frontend/src/hooks/use-chats.ts — minor `loadMore` dep-array optimization.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/hooks/use-chats.ts | Replaced React Query message cache with local state to support paginated history; includes stale-fetch cancellation, optimistic sends, `loadMore`, and `addMessage`. Minor: `loadMore` captures the full `messages` array in deps. |
| frontend/src/components/chat/message-container.tsx | Smart auto-scroll (near-bottom / own-message), `useLayoutEffect`-based scroll restoration on prepend, and a "Load older messages" button. Logic is sound. |
| frontend/src/hooks/use-messages-page.ts | Wires new pagination/send API; WebSocket handler correctly skips own messages to avoid double-rendering optimistic sends. |
| energetica/routers/chats.py | Adds cursor-based `before`/`limit` pagination; limit is properly capped at 200 via FastAPI Query validation. |
| frontend/src/components/chat/message-input.tsx | Decoupled from `useSendMessage`; now accepts an `onSend` callback, with proper async error handling and input restoration. |
| frontend/src/lib/api/chats.ts | Adds optional `before` query param to `getChatMessages`; correct conditional params object. |
| energetica/schemas/chats.py | Adds `has_more: bool` field to `MessageListOut` to support pagination. |
| energetica/utils/misc.py | Adds `id` to the `display_new_message` WebSocket payload so the frontend can deduplicate messages. |
| frontend/src/styles/global.css | Adds `--surface-overlay` CSS token in both light and dark themes; also corrects `--border-subtle` dark-mode contrast. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant MC as MessageContainer
    participant H as useChatMessages
    participant API as chatsApi
    participant WS as WebSocket

    U->>H: select chat (chatId changes)
    H->>API: getChatMessages(chatId)
    API-->>H: { messages[0..49], has_more }
    H-->>MC: messages, hasMore=true
    MC->>MC: scrollTop = scrollHeight (initial)

    U->>MC: click "Load older messages"
    MC->>H: loadMore()
    H->>H: setIsLoadingMore(true)
    Note over MC: useLayoutEffect saves scrollHeight
    H->>API: getChatMessages(chatId, before=messages[0].id)
    API-->>H: { older messages, has_more }
    H->>H: setMessages([older..., ...prev]) + setIsLoadingMore(false)
    Note over MC: useLayoutEffect restores scroll position

    U->>MC: type & send message
    MC->>H: sendMessage(text, playerId)
    H->>MC: optimistic message (id=-Date.now())
    H->>API: POST /chats/{id}/messages
    API-->>H: realMessage
    H->>MC: replace optimistic with realMessage

    WS-->>H: display_new_message (own player_id)
    Note over H: skipped — already handled optimistically

    WS-->>H: display_new_message (other player_id)
    H->>MC: addMessage(...)
    Note over MC: scroll only if near bottom
```

<sub>Reviews (2): Last reviewed commit: ["fix liniting"](https://github.com/felixvonsamson/energetica/commit/b166194886d6e0a89ab7b0a7616ea7101796cd89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29752508)</sub>

<!-- /greptile_comment -->