### PR TITLE
Improvement/690 knowledge spillover should not affect speed

### DIFF
--- a/energetica/technology_effects.py
+++ b/energetica/technology_effects.py
@@ -392,9 +392,8 @@ def construction_time(player: Player, project_type: ProjectType) -> float:
             project_type=project_type,
         ) + player.get_level(project_type)
         duration *= const_config[project_type]["price_multiplier"] ** (0.6 * level_with_constructions)
-        # knowledge spillover and laboratory time reduction
+        # laboratory time reduction
         if isinstance(project_type, TechnologyType):
-            duration *= 0.92 ** research_prevalence(project_type, next_level(player, project_type))
             duration *= (
                 const_config["laboratory"]["time_factor"]
                 ** player.functional_facility_lvl[FunctionalFacilityType.LABORATORY]

--- a/frontend/src/components/technologies/technology-detail-dialog.tsx
+++ b/frontend/src/components/technologies/technology-detail-dialog.tsx
@@ -216,10 +216,7 @@ export function TechnologyDetailDialog<T>({
                             <div className="flex items-center justify-around">
                                 <div className="flex items-center gap-2">
                                     <Money
-                                        amount={Math.round(
-                                            technology.price *
-                                                (technology.discount ?? 1),
-                                        )}
+                                        amount={Math.round(technology.price)}
                                         long
                                         className="text-lg font-semibold"
                                     />

--- a/frontend/src/content/changelog.mdx
+++ b/frontend/src/content/changelog.mdx
@@ -12,7 +12,7 @@ import { DevelopmentBanner } from "@/components/development-banner";
 - New home page with current weather conditions, constructions and research projects under way and order of priority of facilities (see wiki for more details).
 - Facilities (power, storage and extraction) now have lifetimes and will be decommissioned automatically after this time has passed. The cost of decommissioning is 20% of the current price of this facility.
 - All power, storage and extraction facilities now have operation and maintenance costs. Renewable and storage facilities have a fixed O&M cost. Controllable and extraction facilities have 20% of their O&M that is fixed and 80% that is variable (depending on the power or resource output). Nuclear facilities have a fixed O&M fraction of 50%.
-- Modelling of knowledge spillover for technology research. The price of research gets 8% cheaper and faster to research for each other player that already researched it on the server.
+- Modelling of knowledge spillover for technology research. The price of research gets 8% cheaper for each other player that already researched it on the server.
 - SCP (self consumption priority) has been removed in the networks.
 - Implementation of notifications.
 - Values have been adjusted across the board.

--- a/frontend/src/content/wiki/technologies.mdx
+++ b/frontend/src/content/wiki/technologies.mdx
@@ -6,4 +6,4 @@ Researching technologies involves electricity consumption without direct CO<sub>
 
 ## Knowledge Spillover
 
-The Knowledge spillover effect is a feature that reduces the prices and research times of a certain level of a technology if is has already been researched by other players on the server. For each player that already researched a given level of a technology, the price and research time of this level is reduced by 8% for all players that have not yet researched it.
+The Knowledge spillover effect is a feature that reduces the price of a certain level of a technology if it has already been researched by other players on the server. For each player that already researched a given level of a technology, the price of this level is reduced by 8% for all players that have not yet researched it.


### PR DESCRIPTION
fixes #687 and #690

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related issues: it removes the knowledge spillover speed reduction from `construction_time` so that spillover only affects research price (not duration), and it fixes a double-discount bug in `technology-detail-dialog.tsx` where `technology.price` — already the discounted value from the server — was incorrectly multiplied by `technology.discount` again. Documentation in the changelog and wiki is updated to match.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are small, targeted, and consistent across backend, frontend, and documentation.

No P0 or P1 findings. The backend correctly removes the time-reduction multiplier while keeping the price discount intact. The UI fix eliminates a real double-discount bug, and the grid-view TechnologyItem component already used price directly so it was unaffected. Documentation is consistent with the code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/technology_effects.py | Removes `duration *= 0.92 ** research_prevalence(...)` from `construction_time` so knowledge spillover no longer reduces research speed; price discount via `knowledge_spillover_discount` in `price_multiplier` is unchanged. |
| frontend/src/components/technologies/technology-detail-dialog.tsx | Fixes double-discount: `technology.price` from the server already includes the spillover discount, so the previous `* (technology.discount ?? 1)` was incorrectly applying it twice; `discount` field is retained for the badge display only. |
| frontend/src/content/changelog.mdx | Changelog entry corrected to state knowledge spillover only reduces price, not research speed. |
| frontend/src/content/wiki/technologies.mdx | Wiki description updated to remove the mention of research-time reduction from knowledge spillover. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Knowledge Spillover\nresearch_prevalence] -->|0.92^n multiplier| B[price_multiplier]
    B --> C[construction_price\nalready discounted]
    C --> D[_package_project_base\nprice field]
    D --> E[Frontend: technology.price\nalready discounted]
    E --> F[Money display\nMath.round price]
    D --> G[discount field\n= 0.92^n]
    G --> H[Badge display\n−N%]

    I[construction_time] -.->|REMOVED: was 0.92^n| J((Knowledge Spillover\nno longer affects speed))
    I --> K[laboratory time_factor\nstill applied]
```

<sub>Reviews (3): Last reviewed commit: ["fix 687"](https://github.com/felixvonsamson/energetica/commit/2ff678662b5040e8bdd543139102d4545bebed60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29752913)</sub>

<!-- /greptile_comment -->