### PR TITLE
fix: return empty market data instead of 404 for missing pickle files

### DIFF
--- a/energetica/routers/charts.py
+++ b/energetica/routers/charts.py
@@ -724,9 +724,13 @@ def get_market_data(
     # Load market data from pickle file
     market_file_path = Path(f"instance/data/networks/{market_id}/charts/market_t{tick}.pck")
     if not market_file_path.is_file():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Market data not found for tick {tick}",
+        empty_orders = MarketOrderData(player_id=[], capacity=[], price=[], facility=[], cumul_capacities=[])
+        return MarketOrdersDataResponse(
+            tick=tick,
+            capacities=empty_orders,
+            demands=empty_orders,
+            market_price=0.0,
+            market_quantity=0.0,
         )
 
     try:

--- a/frontend/src/hooks/use-charts.ts
+++ b/frontend/src/hooks/use-charts.ts
@@ -453,7 +453,21 @@ export function useMarketData({
     const query = useQuery<MarketOrdersDataResponse>({
         queryKey: queryKeys.charts.marketOrderData(marketId, tick),
         queryFn: () => chartsApi.getMarketData(marketId, tick),
-        staleTime: Infinity, // Historical market data never changes
+        // On the happy path this query always resolves with real order data and
+        // Infinity is correct — historical ticks are immutable.
+        //
+        // Workaround: the backend returns an empty payload when the game engine
+        // hasn't written the per-tick pickle file yet (race condition) or for
+        // ticks predating market creation. Those responses must not be cached
+        // forever, so we use a short staleTime to allow a retry after a brief
+        // window rather than treating them as permanent.
+        staleTime: (query) => {
+            const data = query.state.data as MarketOrdersDataResponse | undefined;
+            if (!data || data.capacities.price.length === 0) {
+                return 30_000;
+            }
+            return Infinity;
+        },
     });
 
     // If data is loading, try to find the closest cached tick


### PR DESCRIPTION
## Summary

- `GET /charts/markets/{market_id}/market/{tick}` was returning 404 when the per-tick pickle file didn't exist (ticks predating market creation, or race condition during game engine writes), causing the supply/demand chart to show "Failed to load market data"
- Backend now returns an empty `MarketOrdersDataResponse` (zero orders, zero price/quantity) for missing files — the chart already handles this case and shows "No orders for this tick"
- Frontend `useMarketData` hook updated to not cache empty responses with `staleTime: Infinity`; uses 30s instead so race-condition ticks are retried without hammering the server

## Test plan

- [ ] Open the market supply/demand chart for a recently-created market and confirm no 404 errors in network tab
- [ ] Verify ticks before market creation show "No orders for this tick" rather than an error
- [ ] Verify ticks with real orders still render correctly and are cached permanently (no unnecessary refetches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 404 error returned by `GET /charts/markets/{market_id}/market/{tick}` when the per-tick pickle file is missing, replacing it with an empty `MarketOrdersDataResponse` (zero orders, zero price/quantity). The frontend `useMarketData` hook now sets `staleTime` dynamically — `Infinity` for ticks with real orders, and 30 s for empty responses so race-condition ticks are retried automatically.

<h3>Confidence Score: 5/5</h3>

Safe to merge — clean fix with no P1+ issues found.

Both changes are minimal and targeted. The backend empty-response path uses the same valid response schema as the success path. The frontend dynamic staleTime is correct React Query v5 API usage. Existing error handling (corrupt file → 500, non-existent market → 404, future tick → 400) is fully preserved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/routers/charts.py | Replaces HTTPException 404 with an empty MarketOrdersDataResponse when the pickle file is missing; error path for corrupt files is preserved. |
| frontend/src/hooks/use-charts.ts | Dynamic staleTime function correctly caches empty responses for 30 s and real data indefinitely; valid React Query v5 API. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FE as Frontend (useMarketData)
    participant BE as Backend (/charts/markets/.../market/{tick})
    participant FS as Filesystem (pickle file)

    FE->>BE: GET market data for tick T
    BE->>FS: Check market_t{T}.pck exists?
    alt File missing (pre-market or race condition)
        FS-->>BE: Not found
        BE-->>FE: 200 OK – empty MarketOrdersDataResponse (price/qty = 0)
        FE->>FE: staleTime = 30 s (retry allowed)
        FE->>FE: Chart shows "No orders for this tick"
    else File exists
        FS-->>BE: File data
        BE-->>FE: 200 OK – full MarketOrdersDataResponse
        FE->>FE: staleTime = Infinity (permanent cache)
        FE->>FE: Chart renders supply/demand curve
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix: return empty market data instead of..."](https://github.com/felixvonsamson/energetica/commit/a3e7cc57ddc840ed80c8b99ec71eea1963bbee03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29896462)</sub>

<!-- /greptile_comment -->