### PR TITLE
feat: allow market overview access without market membership

### DIFF
--- a/frontend/src/routes/app/overviews/electricity-markets.tsx
+++ b/frontend/src/routes/app/overviews/electricity-markets.tsx
@@ -134,8 +134,9 @@ function MarketsOverviewContent() {
     const playerMarket = useElectricityMarketForPlayer(playerId);
     const { data: marketsData } = useElectricityMarkets();
 
-    // Determine which market to show
-    const selectedMarketId = searchMarketId ?? playerMarket?.id;
+    // Determine which market to show: URL param > player's market > first available market
+    const selectedMarketId =
+        searchMarketId ?? playerMarket?.id ?? marketsData?.electricity_markets[0]?.id;
 
     // Find the selected market name
     const selectedMarket = useMemo(() => {
@@ -184,27 +185,33 @@ function MarketsOverviewContent() {
               }`
     }`;
 
-    // Show message if player is not in a market and none selected
-    if (!selectedMarketId) {
+    // Still loading
+    if (!marketsData) return null;
+
+    // No markets exist yet
+    if (!marketsData.electricity_markets.length) {
         return (
             <div className="py-4 md:p-8">
                 <PageCard>
                     <CardContent>
-                        <p className="text-muted">
-                            You are not part of any electricity market.{" "}
+                        <p>
+                            No electricity markets exist yet.{" "}
                             <Link
                                 to="/app/community/electricity-markets"
                                 className="underline hover:text-foreground"
                             >
-                                Join or create a market
+                                Create a market
                             </Link>{" "}
-                            to view market data.
+                            to get started.
                         </p>
                     </CardContent>
                 </PageCard>
             </div>
         );
     }
+
+    // selectedMarketId is always defined here (at minimum first available market)
+    if (!selectedMarketId) return null;
 
     return (
         <div className="py-4 md:p-8 flex flex-col gap-6">


### PR DESCRIPTION
## Summary
- Players not in any electricity market can now view the Markets Overview page, with the selector defaulting to the first available market
- The "not in a market" gate is removed; an empty state only appears when zero markets exist
- Fixed low-contrast `text-muted` on the empty state — text is now fully readable

Closes #703

## Test plan
- [ ] As a player with no market membership, navigate to Markets Overview — should see market selector and charts for the first available market
- [ ] As a player in a market, behaviour is unchanged — defaults to own market, can switch to others
- [ ] When no markets exist at all, the empty state renders with a "Create a market" link
- [ ] Empty state text is readable in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR opens the Markets Overview page to players who have no market membership by falling back to the first available market when neither a URL param nor a player-market ID is present. It also narrows the empty state to the case where zero markets exist (previously it also triggered for non-member players), fixes the low-contrast `text-muted` class, and updates the copy accordingly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no correctness issues found; both fallback hooks derive from the same underlying query, ruling out loading-race concerns.

The fallback chain (searchMarketId ?? playerMarket?.id ?? marketsData?.electricity_markets[0]?.id) is correct because useElectricityMarketForPlayer is derived synchronously from the same useElectricityMarkets query, so there is no window where marketsData is loaded but playerMarket is still undefined. The defensive if (!selectedMarketId) return null guard is dead code once markets exist, but it aids TypeScript narrowing and is harmless. No P0 or P1 issues identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/app/overviews/electricity-markets.tsx | Removes the 'not in a market' gate, adds first-available-market fallback, and cleans up the empty-state rendering; logic is sound thanks to both hooks deriving from the same underlying query. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MarketsOverviewContent mounts] --> B{marketsData loaded?}
    B -- No --> C[return null]
    B -- Yes --> D{markets.length gt 0?}
    D -- No --> E[Render empty state]
    D -- Yes --> F{Determine selectedMarketId}
    F --> G{searchMarketId defined?}
    G -- Yes --> H[Use URL param ID]
    G -- No --> I{playerMarket.id defined?}
    I -- Yes --> J[Use player market ID]
    I -- No --> K[Use markets at 0 .id]
    H --> L{selectedMarketId truthy?}
    J --> L
    K --> L
    L -- No --> M[return null defensive guard]
    L -- Yes --> N[Render selector and charts]
```

<sub>Reviews (1): Last reviewed commit: ["feat: allow market overview access witho..."](https://github.com/felixvonsamson/energetica/commit/34932e182e5458242cdaeb422769c78263456d40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30369312)</sub>

<!-- /greptile_comment -->