### PR TITLE
feat: named dev scripts for proxying to remote backends

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,7 +7,7 @@ function formatFrontendFiles(filenames) {
   const relativePaths = filenames.map(f => f.replace(/^.*\/frontend\//, ''));
 
   return [
-    `cd frontend && npx eslint --max-warnings 0 --fix --cache ${relativePaths.join(' ')}`,
+    `cd frontend && npx eslint --max-warnings 0 --fix ${relativePaths.join(' ')}`,
     `cd frontend && npx prettier --write ${relativePaths.join(' ')}`,
   ];
 }

--- a/frontend/.env.edu
+++ b/frontend/.env.edu
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica-edu.org

--- a/frontend/.env.ethz
+++ b/frontend/.env.ethz
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica.ethz.ch

--- a/frontend/.env.game
+++ b/frontend/.env.game
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica-game.org

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
+        "dev:edu": "vite --mode edu",
+        "dev:game": "vite --mode game",
+        "dev:ethz": "vite --mode ethz",
         "build": "vite build && bun run build:sw",
         "build:sw": "bun ../scripts/generate-sw-routes.ts && bun build src/service-worker.ts --outfile ../energetica/static/service-worker.js --target browser && { printf '// AUTO-GENERATED — do not edit. Run `bun run build:sw` in frontend/ to regenerate.\\n'; cat ../energetica/static/service-worker.js; } > /tmp/sw.js && mv /tmp/sw.js ../energetica/static/service-worker.js",
         "dev:sw": "bun build src/service-worker.ts --outfile ../energetica/static/service-worker.js --target browser --watch",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
@@ -10,9 +10,11 @@ import rehypeSlug from "rehype-slug";
 import svgr from "vite-plugin-svgr";
 import path from "path";
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
+    const env = loadEnv(mode, process.cwd(), "");
     // Backend URL from environment variable, fallback to local development server
-    const backendUrl = process.env.VITE_BACKEND_URL || "http://localhost:8000";
+    const backendUrl = env.VITE_BACKEND_URL || "http://localhost:8000";
+    const wsUrl = backendUrl.replace(/^http/, "ws");
 
     return {
         plugins: [
@@ -48,7 +50,7 @@ export default defineConfig(({ mode }) => {
         resolve: {
             alias: { "@": path.resolve(__dirname, "./src") },
         },
-        base: mode === "development" ? "/" : "/static/react/",
+        base: command === "serve" ? "/" : "/static/react/",
         server: {
             proxy: {
                 // API endpoints
@@ -63,7 +65,7 @@ export default defineConfig(({ mode }) => {
                 },
                 // WebSocket connection
                 "^/socket.io": {
-                    target: backendUrl,
+                    target: wsUrl,
                     changeOrigin: true,
                     ws: true,
                 },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "private": true,
     "scripts": {
         "dev": "cd frontend && bun run dev",
-        "dev:remote": "cd frontend && VITE_BACKEND_URL=https://energetica-game.org bun run dev",
+        "dev:edu": "cd frontend && bun run dev:edu",
+        "dev:game": "cd frontend && bun run dev:game",
+        "dev:ethz": "cd frontend && bun run dev:ethz",
         "build": "cd frontend && bun run build",
         "lint": "cd frontend && bun run lint",
         "lint:fix": "cd frontend && bun run lint:fix",


### PR DESCRIPTION
## Summary

- Replaces the single hardcoded `dev:remote` script with three named scripts: `dev:edu`, `dev:game`, `dev:ethz` (in both root and `frontend/` `package.json`)
- Backend URLs live in committed `.env.edu`, `.env.game`, `.env.ethz` files — easy to extend by adding a new file + one script line
- Fixes `vite.config.ts` to use Vite's `loadEnv` so `.env.[mode]` values actually reach the proxy config at build time
- Fixes base path detection to use `command === "serve"` instead of `mode === "development"`, so the dev server works in all named modes
- Fixes WebSocket proxy to use `wss://` when the backend is HTTPS

## Test plan

- [ ] `bun run dev` → proxies to `http://localhost:8000`
- [ ] `bun run dev:edu` → proxies to `https://energetica-edu.org`
- [ ] `bun run dev:game` → proxies to `https://energetica-game.org`
- [ ] `bun run dev:ethz` → proxies to `https://energetica.ethz.ch`
- [ ] `http://localhost:5173/` loads correctly (no redirect to `/static/react/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the single hardcoded `dev:remote` script with three named environment-specific dev scripts (`dev:edu`, `dev:game`, `dev:ethz`), backed by committed `.env.*` files containing public backend URLs. It also fixes two bugs in `vite.config.ts`: using `loadEnv` so mode-specific `.env` values reach the proxy config, and correcting base-path detection to use `command === "serve"` instead of `mode === "development"`.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — all changes are correct and well-scoped

No P0 or P1 issues found. The loadEnv usage, wsUrl derivation, base-path fix, and script additions are all implemented correctly. Committed .env.* files contain only public domain names (no secrets). The --cache removal in lint-staged is a minor cleanup with no risk.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/vite.config.ts | Switches to loadEnv for mode-specific env loading, derives wsUrl from backendUrl via regex, and fixes base path to use command === "serve" — all changes are correct |
| frontend/package.json | Adds three named vite --mode scripts; straightforward and correct |
| package.json | Replaces dev:remote with dev:edu / dev:game / dev:ethz delegates, removing the hardcoded VITE_BACKEND_URL inline export |
| frontend/.env.edu | New env file with public backend URL; intentionally committed (no secrets), not blocked by .gitignore |
| frontend/.env.game | New env file with public backend URL; intentionally committed |
| frontend/.env.ethz | New env file with public backend URL; intentionally committed |
| .lintstagedrc.js | Removes --cache flag from lint-staged eslint invocation; avoids stale cache hits on partial file sets |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun run dev:edu / dev:game / dev:ethz] --> B[vite --mode edu/game/ethz]
    B --> C[loadEnv reads frontend/.env.edu/game/ethz]
    C --> D{VITE_BACKEND_URL set?}
    D -- Yes --> E[backendUrl = remote HTTPS URL]
    D -- No / plain dev --> F[backendUrl = http://localhost:8000]
    E --> G[wsUrl = wss://...]
    F --> H[wsUrl = ws://localhost:8000]
    G --> I[Vite proxy: /api, /static, /socket.io → remote backend]
    H --> J[Vite proxy: /api, /static, /socket.io → local backend]
    B --> K{command === serve?}
    K -- Yes --> L[base = /]
    K -- No build --> M[base = /static/react/]
```

<sub>Reviews (2): Last reviewed commit: ["fix: remove --cache flag from lint-stage..."](https://github.com/felixvonsamson/energetica/commit/765bf1091fb8efc4efc046a70cb0de29eb4cc421) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30369513)</sub>

<!-- /greptile_comment -->