### PR TITLE
fix: use timezone-aware UTC datetimes for chat and notification timestamps

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,7 +7,7 @@ function formatFrontendFiles(filenames) {
   const relativePaths = filenames.map(f => f.replace(/^.*\/frontend\//, ''));
 
   return [
-    `cd frontend && npx eslint --max-warnings 0 --fix --cache ${relativePaths.join(' ')}`,
+    `cd frontend && npx eslint --max-warnings 0 --fix ${relativePaths.join(' ')}`,
     `cd frontend && npx prettier --write ${relativePaths.join(' ')}`,
   ];
 }

--- a/energetica/database/messages.py
+++ b/energetica/database/messages.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Literal
 
 from energetica.database import DBModel
@@ -67,7 +67,7 @@ class Message:
     text: str
     chat: Chat
     player: Player
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
     def package(self) -> dict:
         """Package this message's data into a dictionary."""
@@ -143,7 +143,7 @@ class Notification(DBModel):
     type: NotificationType
     payload: dict
     player: Player
-    time: datetime = field(default_factory=datetime.now)
+    time: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     read: bool = False
     flagged: bool = False
     archived: bool = False

--- a/frontend/.env.edu
+++ b/frontend/.env.edu
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica-edu.org

--- a/frontend/.env.ethz
+++ b/frontend/.env.ethz
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica.ethz.ch

--- a/frontend/.env.game
+++ b/frontend/.env.game
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica-game.org

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
+        "dev:edu": "vite --mode edu",
+        "dev:game": "vite --mode game",
+        "dev:ethz": "vite --mode ethz",
         "build": "vite build && bun run build:sw",
         "build:sw": "bun ../scripts/generate-sw-routes.ts && bun build src/service-worker.ts --outfile ../energetica/static/service-worker.js --target browser && { printf '// AUTO-GENERATED — do not edit. Run `bun run build:sw` in frontend/ to regenerate.\\n'; cat ../energetica/static/service-worker.js; } > /tmp/sw.js && mv /tmp/sw.js ../energetica/static/service-worker.js",
         "dev:sw": "bun build src/service-worker.ts --outfile ../energetica/static/service-worker.js --target browser --watch",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
@@ -10,9 +10,11 @@ import rehypeSlug from "rehype-slug";
 import svgr from "vite-plugin-svgr";
 import path from "path";
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
+    const env = loadEnv(mode, process.cwd(), "");
     // Backend URL from environment variable, fallback to local development server
-    const backendUrl = process.env.VITE_BACKEND_URL || "http://localhost:8000";
+    const backendUrl = env.VITE_BACKEND_URL || "http://localhost:8000";
+    const wsUrl = backendUrl.replace(/^http/, "ws");
 
     return {
         plugins: [
@@ -48,7 +50,7 @@ export default defineConfig(({ mode }) => {
         resolve: {
             alias: { "@": path.resolve(__dirname, "./src") },
         },
-        base: mode === "development" ? "/" : "/static/react/",
+        base: command === "serve" ? "/" : "/static/react/",
         server: {
             proxy: {
                 // API endpoints
@@ -63,7 +65,7 @@ export default defineConfig(({ mode }) => {
                 },
                 // WebSocket connection
                 "^/socket.io": {
-                    target: backendUrl,
+                    target: wsUrl,
                     changeOrigin: true,
                     ws: true,
                 },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "private": true,
     "scripts": {
         "dev": "cd frontend && bun run dev",
-        "dev:remote": "cd frontend && VITE_BACKEND_URL=https://energetica-game.org bun run dev",
+        "dev:edu": "cd frontend && bun run dev:edu",
+        "dev:game": "cd frontend && bun run dev:game",
+        "dev:ethz": "cd frontend && bun run dev:ethz",
         "build": "cd frontend && bun run build",
         "lint": "cd frontend && bun run lint",
         "lint:fix": "cd frontend && bun run lint:fix",


### PR DESCRIPTION
Fixes #192

## Summary

- `Message.timestamp` and `Notification.time` were created with `datetime.now()`, producing naive datetimes (no timezone info)
- Pydantic/`.isoformat()` serialized these as `2024-01-01T12:00:00` (no `Z` suffix)
- JavaScript's `new Date()` parses timezone-less ISO strings as **local time**, so players outside UTC saw the raw UTC value displayed in their local slot — effectively showing UTC regardless of their timezone
- Fix: use `datetime.now(timezone.utc)`, which serializes as `2024-01-01T12:00:00+00:00`; `toLocaleString()` in the frontend then correctly converts to the browser's local timezone

## Test plan

- [ ] Send a chat message and verify the timestamp shown matches local time, not UTC
- [ ] Trigger a notification and verify its timestamp is in local time
- [ ] Verify from a browser in a non-UTC timezone (e.g. UTC+2: timestamp should appear 2h ahead of the UTC value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a timezone bug where `Message.timestamp` and `Notification.time` were created with naive `datetime.now()` (no timezone info), causing JavaScript to interpret the UTC values as local time. The fix uses `datetime.now(timezone.utc)`, ensuring ISO strings include a `+00:00` offset that `toLocaleString()` correctly converts to the browser's local timezone. The PR also adds environment-specific Vite dev modes (`dev:edu`, `dev:game`, `dev:ethz`) with corresponding `.env` files, and fixes the WebSocket proxy target to correctly use `wss://` when the backend URL is `https://`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the timezone fix is correct end-to-end across both the REST and WebSocket paths, and the Vite config changes are clean improvements.

All three data paths (REST API via Pydantic, WebSocket via isoformat(), and optimistic local send via new Date().toISOString()) now emit unambiguous UTC timestamps. The vite.config.ts fixes (`command === "serve"` base path and `wss://` WebSocket target) are independently correct improvements with no regressions. No P0 or P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/messages.py | Core fix: replaces `datetime.now()` with `datetime.now(timezone.utc)` for both `Message.timestamp` and `Notification.time`, producing timezone-aware ISO strings that JavaScript parses correctly as UTC. |
| frontend/vite.config.ts | Fixes two dev-mode issues: switches from `mode === "development"` to `command === "serve"` for the `base` path (so custom modes like `edu` get the correct base), and derives `wsUrl` via regex so the WebSocket proxy uses `wss://` for HTTPS backends instead of incorrectly targeting `https://`. |
| frontend/package.json | Replaces single `dev:remote` script (inline env var) with three mode-specific scripts (`dev:edu`, `dev:game`, `dev:ethz`) that load from corresponding `.env` files. |
| package.json | Root package.json updated to mirror the new `dev:edu`, `dev:game`, `dev:ethz` scripts from the frontend. |
| .lintstagedrc.js | Removes `--cache` flag from the ESLint lint-staged command, preventing stale cache from causing missed lint errors on staged files. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PY as Python Backend
    participant WS as WebSocket
    participant API as REST API
    participant JS as JavaScript Frontend

    Note over PY: datetime.now(timezone.utc)<br/>→ 2024-01-01T12:00:00+00:00

    PY->>WS: emit(display_new_message,<br/>{ time: timestamp.isoformat() })
    WS->>JS: { time: 2024-01-01T12:00:00+00:00 }
    JS->>JS: new Date(...+00:00) → UTC parsed ✓
    JS->>JS: toLocaleString() → local time ✓

    PY->>API: MessageOut(timestamp=datetime.now(tz.utc))
    API->>JS: { timestamp: 2024-01-01T12:00:00+00:00 }
    JS->>JS: formatTimestamp(ts) → toLocaleString() ✓

    PY->>API: NotificationOut(time=datetime.now(tz.utc))
    API->>JS: { time: 2024-01-01T12:00:00+00:00 }
    JS->>JS: new Date(n.time).toLocaleString() ✓
```

<sub>Reviews (1): Last reviewed commit: ["fix: use timezone-aware UTC datetimes fo..."](https://github.com/felixvonsamson/energetica/commit/762980d5354e796518e9582f1d14b90a78e7f70a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30376427)</sub>

<!-- /greptile_comment -->