### PR TITLE
feat: notification dot on daily quiz card when unanswered

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,7 +7,7 @@ function formatFrontendFiles(filenames) {
   const relativePaths = filenames.map(f => f.replace(/^.*\/frontend\//, ''));
 
   return [
-    `cd frontend && npx eslint --max-warnings 0 --fix --cache ${relativePaths.join(' ')}`,
+    `cd frontend && npx eslint --max-warnings 0 --fix ${relativePaths.join(' ')}`,
     `cd frontend && npx prettier --write ${relativePaths.join(' ')}`,
   ];
 }

--- a/frontend/.env.edu
+++ b/frontend/.env.edu
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica-edu.org

--- a/frontend/.env.ethz
+++ b/frontend/.env.ethz
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica.ethz.ch

--- a/frontend/.env.game
+++ b/frontend/.env.game
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica-game.org

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
+        "dev:edu": "vite --mode edu",
+        "dev:game": "vite --mode game",
+        "dev:ethz": "vite --mode ethz",
         "build": "vite build && bun run build:sw",
         "build:sw": "bun ../scripts/generate-sw-routes.ts && bun build src/service-worker.ts --outfile ../energetica/static/service-worker.js --target browser && { printf '// AUTO-GENERATED — do not edit. Run `bun run build:sw` in frontend/ to regenerate.\\n'; cat ../energetica/static/service-worker.js; } > /tmp/sw.js && mv /tmp/sw.js ../energetica/static/service-worker.js",
         "dev:sw": "bun build src/service-worker.ts --outfile ../energetica/static/service-worker.js --target browser --watch",

--- a/frontend/src/components/dashboard/daily-quiz.tsx
+++ b/frontend/src/components/dashboard/daily-quiz.tsx
@@ -10,15 +10,22 @@ import { getPushPref, setPushPref } from "@/lib/push-notification-prefs";
 import { cn } from "@/lib/utils";
 
 export function DailyQuizButton() {
+    const { data } = useDailyQuiz();
+    const answered = data != null && data.player_answer != null;
+    const showDot = data != null && !answered;
+
     return (
         <Link
             to="/app/dashboard/quiz"
             className={cn(
-                "bg-card hover:bg-muted",
+                "relative bg-card hover:bg-muted",
                 "p-6 rounded-lg text-center transition-colors block w-full",
                 "border border-transparent hover:border-pine dark:hover:border-brand-green",
             )}
         >
+            {showDot && (
+                <span className="absolute top-2 right-2 w-3 h-3 rounded-full bg-red-500" />
+            )}
             <HelpCircle className="w-8 h-8 mx-auto mb-2 text-foreground" />
             <TypographyH2 className="text-foreground">
                 <TypographyLarge>Daily Quiz</TypographyLarge>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
@@ -10,9 +10,11 @@ import rehypeSlug from "rehype-slug";
 import svgr from "vite-plugin-svgr";
 import path from "path";
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
+    const env = loadEnv(mode, process.cwd(), "");
     // Backend URL from environment variable, fallback to local development server
-    const backendUrl = process.env.VITE_BACKEND_URL || "http://localhost:8000";
+    const backendUrl = env.VITE_BACKEND_URL || "http://localhost:8000";
+    const wsUrl = backendUrl.replace(/^http/, "ws");
 
     return {
         plugins: [
@@ -48,7 +50,7 @@ export default defineConfig(({ mode }) => {
         resolve: {
             alias: { "@": path.resolve(__dirname, "./src") },
         },
-        base: mode === "development" ? "/" : "/static/react/",
+        base: command === "serve" ? "/" : "/static/react/",
         server: {
             proxy: {
                 // API endpoints
@@ -63,7 +65,7 @@ export default defineConfig(({ mode }) => {
                 },
                 // WebSocket connection
                 "^/socket.io": {
-                    target: backendUrl,
+                    target: wsUrl,
                     changeOrigin: true,
                     ws: true,
                 },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "private": true,
     "scripts": {
         "dev": "cd frontend && bun run dev",
-        "dev:remote": "cd frontend && VITE_BACKEND_URL=https://energetica-game.org bun run dev",
+        "dev:edu": "cd frontend && bun run dev:edu",
+        "dev:game": "cd frontend && bun run dev:game",
+        "dev:ethz": "cd frontend && bun run dev:ethz",
         "build": "cd frontend && bun run build",
         "lint": "cd frontend && bun run lint",
         "lint:fix": "cd frontend && bun run lint:fix",


### PR DESCRIPTION
<img width="304" height="139" alt="image" src="https://github.com/user-attachments/assets/ea7c1e45-04e3-4726-a58b-ff8f79748db8" />

## Summary

- Adds a red notification dot (top-right corner) to the Daily Quiz dashboard card when the player has not yet answered today's quiz
- Dot disappears once the quiz is answered
- No visual change to the card itself — consistent with iOS-style notification badge convention

Closes #584

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a red notification dot to the Daily Quiz dashboard card when the player hasn't yet answered today's quiz, disappearing once answered. It also ships several build-tooling improvements: new `--mode`-based `.env.*` files for multiple deployment targets replacing the old inline `VITE_BACKEND_URL=…` pattern, a fix for the Vite `base` option (using `command === "serve"` instead of `mode === "development"`), a proper WebSocket URL derived from `backendUrl`, and removal of the ESLint `--cache` flag in lint-staged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the notification dot logic is correct, cache invalidation is handled, and the tooling changes are clean improvements.

No P0 or P1 issues found. The feature is small and well-contained: it reuses the existing useDailyQuiz hook, the showDot logic is correct, and the onSuccess cache update in useSubmitQuizAnswer ensures the dot disappears without a page reload. The vite.config.ts fixes are all improvements over the previous code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/dashboard/daily-quiz.tsx | Calls useDailyQuiz() in DailyQuizButton and conditionally renders a red dot when data is loaded but player_answer is null; cache invalidation via setQueryData in useSubmitQuizAnswer ensures the dot disappears after answering without a reload. |
| frontend/vite.config.ts | Switches base URL detection to command === "serve" (more correct than mode === "development"), adds loadEnv for reading .env.{mode} files, and derives a proper wsUrl for the socket.io proxy. |
| frontend/package.json | Adds dev:edu, dev:game, and dev:ethz scripts using Vite --mode to select the matching .env.* file. |
| package.json | Replaces single dev:remote script (hardcoded energetica-game.org URL) with three per-environment scripts delegating to frontend package.json. |
| .lintstagedrc.js | Removes --cache flag from the ESLint lint-staged command, preventing stale-cache false-negatives at the cost of slightly slower lint runs. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant DB as DailyQuizButton (Dashboard)
    participant H as useDailyQuiz hook
    participant API as Backend API
    participant QC as React Query Cache

    U->>DB: Visit dashboard
    DB->>H: useDailyQuiz()
    H->>QC: Check cache (queryKeys.dailyQuiz.today)
    alt Cache miss
        QC->>API: GET /api/daily-quiz/today
        API-->>QC: { question, player_answer, ... }
    end
    QC-->>H: data
    H-->>DB: data
    DB->>DB: showDot = data != null && player_answer == null
    DB-->>U: Render card (with red dot if unanswered)

    U->>API: Submit answer (useSubmitQuizAnswer)
    API-->>QC: setQueryData(updated data with player_answer)
    QC-->>DB: data updated (player_answer != null)
    DB-->>U: Red dot disappears
```

<sub>Reviews (1): Last reviewed commit: ["feat: show notification dot on daily qui..."](https://github.com/felixvonsamson/energetica/commit/ae5c4caa4a6a57f2a9265c53bb83e0edb16ba41a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30379447)</sub>

<!-- /greptile_comment -->