### PR TITLE
fix: hide empty notification categories and fix modal size jumping

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,7 +7,7 @@ function formatFrontendFiles(filenames) {
   const relativePaths = filenames.map(f => f.replace(/^.*\/frontend\//, ''));
 
   return [
-    `cd frontend && npx eslint --max-warnings 0 --fix --cache ${relativePaths.join(' ')}`,
+    `cd frontend && npx eslint --max-warnings 0 --fix ${relativePaths.join(' ')}`,
     `cd frontend && npx prettier --write ${relativePaths.join(' ')}`,
   ];
 }

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,7 +7,7 @@ function formatFrontendFiles(filenames) {
   const relativePaths = filenames.map(f => f.replace(/^.*\/frontend\//, ''));
 
   return [
-    `cd frontend && npx eslint --max-warnings 0 --fix ${relativePaths.join(' ')}`,
+    `cd frontend && npx eslint --max-warnings 0 --fix --cache ${relativePaths.join(' ')}`,
     `cd frontend && npx prettier --write ${relativePaths.join(' ')}`,
   ];
 }

--- a/frontend/.env.edu
+++ b/frontend/.env.edu
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica-edu.org

--- a/frontend/.env.ethz
+++ b/frontend/.env.ethz
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica.ethz.ch

--- a/frontend/.env.game
+++ b/frontend/.env.game
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://energetica-game.org

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
+        "dev:edu": "vite --mode edu",
+        "dev:game": "vite --mode game",
+        "dev:ethz": "vite --mode ethz",
         "build": "vite build && bun run build:sw",
         "build:sw": "bun ../scripts/generate-sw-routes.ts && bun build src/service-worker.ts --outfile ../energetica/static/service-worker.js --target browser && { printf '// AUTO-GENERATED — do not edit. Run `bun run build:sw` in frontend/ to regenerate.\\n'; cat ../energetica/static/service-worker.js; } > /tmp/sw.js && mv /tmp/sw.js ../energetica/static/service-worker.js",
         "dev:sw": "bun build src/service-worker.ts --outfile ../energetica/static/service-worker.js --target browser --watch",

--- a/frontend/src/components/layout/notification-popup.tsx
+++ b/frontend/src/components/layout/notification-popup.tsx
@@ -61,13 +61,6 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
             );
     }, [data]);
 
-    const filteredNotifications = useMemo(() => {
-        if (activeCategory === "all") return notifications;
-        return notifications.filter(
-            (n) => getNotificationCategory(n.payload.type) === activeCategory,
-        );
-    }, [notifications, activeCategory]);
-
     const categoriesWithNotifications = useMemo(
         () =>
             CATEGORIES.filter((cat) =>
@@ -78,15 +71,21 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
         [notifications],
     );
 
-    // Reset to "all" if the active category becomes empty
-    useEffect(() => {
-        if (
+    const effectiveCategory = useMemo<InboxCategory | "all">(
+        () =>
             activeCategory !== "all" &&
             !categoriesWithNotifications.includes(activeCategory)
-        ) {
-            setActiveCategory("all");
-        }
-    }, [activeCategory, categoriesWithNotifications]);
+                ? "all"
+                : activeCategory,
+        [activeCategory, categoriesWithNotifications],
+    );
+
+    const filteredNotifications = useMemo(() => {
+        if (effectiveCategory === "all") return notifications;
+        return notifications.filter(
+            (n) => getNotificationCategory(n.payload.type) === effectiveCategory,
+        );
+    }, [notifications, effectiveCategory]);
 
     const unreadCount = useMemo(
         () => filteredNotifications.filter((n) => !n.read).length,
@@ -187,7 +186,7 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
                                 onClick={() => setActiveCategory("all")}
                                 className={cn(
                                     "px-3 py-1 rounded text-sm transition-colors shrink-0",
-                                    activeCategory === "all"
+                                    effectiveCategory === "all"
                                         ? "bg-primary text-primary-foreground"
                                         : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
                                 )}
@@ -200,7 +199,7 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
                                     onClick={() => setActiveCategory(cat)}
                                     className={cn(
                                         "px-3 py-1 rounded text-sm transition-colors shrink-0",
-                                        activeCategory === cat
+                                        effectiveCategory === cat
                                             ? "bg-primary text-primary-foreground"
                                             : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
                                     )}
@@ -237,7 +236,7 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
                             </div>
                         ) : filteredNotifications.length === 0 ? (
                             <div className="text-center text-muted-foreground py-8">
-                                {activeCategory === "all"
+                                {effectiveCategory === "all"
                                     ? "No notifications"
                                     : "No notifications in this category"}
                             </div>

--- a/frontend/src/components/layout/notification-popup.tsx
+++ b/frontend/src/components/layout/notification-popup.tsx
@@ -68,6 +68,26 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
         );
     }, [notifications, activeCategory]);
 
+    const categoriesWithNotifications = useMemo(
+        () =>
+            CATEGORIES.filter((cat) =>
+                notifications.some(
+                    (n) => getNotificationCategory(n.payload.type) === cat,
+                ),
+            ),
+        [notifications],
+    );
+
+    // Reset to "all" if the active category becomes empty
+    useEffect(() => {
+        if (
+            activeCategory !== "all" &&
+            !categoriesWithNotifications.includes(activeCategory)
+        ) {
+            setActiveCategory("all");
+        }
+    }, [activeCategory, categoriesWithNotifications]);
+
     const unreadCount = useMemo(
         () => filteredNotifications.filter((n) => !n.read).length,
         [filteredNotifications],
@@ -159,14 +179,14 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
                     </DialogDescription>
                 </DialogHeader>
 
-                <div className="flex flex-col max-h-[60vh]">
+                <div className="flex flex-col h-[60vh]">
                     {/* Category filter tabs + actions row */}
                     <div className="flex items-center justify-between mb-3 gap-2">
-                        <div className="flex gap-1 flex-wrap">
+                        <div className="flex gap-1 overflow-x-auto shrink min-w-0">
                             <button
                                 onClick={() => setActiveCategory("all")}
                                 className={cn(
-                                    "px-3 py-1 rounded text-sm transition-colors",
+                                    "px-3 py-1 rounded text-sm transition-colors shrink-0",
                                     activeCategory === "all"
                                         ? "bg-primary text-primary-foreground"
                                         : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
@@ -174,12 +194,12 @@ export function NotificationPopup({ isOpen, onClose }: NotificationPopupProps) {
                             >
                                 All
                             </button>
-                            {CATEGORIES.map((cat) => (
+                            {categoriesWithNotifications.map((cat) => (
                                 <button
                                     key={cat}
                                     onClick={() => setActiveCategory(cat)}
                                     className={cn(
-                                        "px-3 py-1 rounded text-sm transition-colors",
+                                        "px-3 py-1 rounded text-sm transition-colors shrink-0",
                                         activeCategory === cat
                                             ? "bg-primary text-primary-foreground"
                                             : "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
@@ -10,9 +10,11 @@ import rehypeSlug from "rehype-slug";
 import svgr from "vite-plugin-svgr";
 import path from "path";
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
+    const env = loadEnv(mode, process.cwd(), "");
     // Backend URL from environment variable, fallback to local development server
-    const backendUrl = process.env.VITE_BACKEND_URL || "http://localhost:8000";
+    const backendUrl = env.VITE_BACKEND_URL || "http://localhost:8000";
+    const wsUrl = backendUrl.replace(/^http/, "ws");
 
     return {
         plugins: [
@@ -48,7 +50,7 @@ export default defineConfig(({ mode }) => {
         resolve: {
             alias: { "@": path.resolve(__dirname, "./src") },
         },
-        base: mode === "development" ? "/" : "/static/react/",
+        base: command === "serve" ? "/" : "/static/react/",
         server: {
             proxy: {
                 // API endpoints
@@ -63,7 +65,7 @@ export default defineConfig(({ mode }) => {
                 },
                 // WebSocket connection
                 "^/socket.io": {
-                    target: backendUrl,
+                    target: wsUrl,
                     changeOrigin: true,
                     ws: true,
                 },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "private": true,
     "scripts": {
         "dev": "cd frontend && bun run dev",
-        "dev:remote": "cd frontend && VITE_BACKEND_URL=https://energetica-game.org bun run dev",
+        "dev:edu": "cd frontend && bun run dev:edu",
+        "dev:game": "cd frontend && bun run dev:game",
+        "dev:ethz": "cd frontend && bun run dev:ethz",
         "build": "cd frontend && bun run build",
         "lint": "cd frontend && bun run lint",
         "lint:fix": "cd frontend && bun run lint:fix",


### PR DESCRIPTION
## Summary

- Only show category filter buttons when there are notifications in that category (closes #605)
- Auto-reset to "All" if the active category becomes empty (e.g. after deleting the last notification in it)
- Fixed modal height jumping: replaced `max-h-[60vh]` with `h-[60vh]` so the dialog stays a consistent size
- Fixed category buttons reshuffling: replaced `flex-wrap` with `overflow-x-auto` so buttons scroll horizontally instead of wrapping to a second line

## Test plan

- [ ] Open notifications with notifications in multiple categories — only populated categories appear
- [ ] Delete all notifications in a category while it's selected — modal switches to "All"
- [ ] Switch between categories — modal height stays constant, no layout shift
- [ ] With many categories, verify the button bar scrolls horizontally rather than wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two independent sets of improvements: it fixes the notification popup UI (hiding empty category filters, auto-resetting the active category, stabilising modal height, and switching to horizontal scrolling for the button bar) and adds multi-environment dev scripts backed by mode-specific `.env` files and a corrected `loadEnv`/`wsUrl` setup in `vite.config.ts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are self-contained UI and dev-tooling improvements with no regressions identified.

No P0 or P1 findings. The derived `effectiveCategory` logic is correct, the `wsUrl` regex handles both `http` and `https` properly, and the `command === "serve"` base-path fix is more accurate than the previous `mode === "development"` check.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/layout/notification-popup.tsx | Adds `categoriesWithNotifications` and `effectiveCategory` derived state to hide empty categories and auto-reset selection; fixes layout with `h-[60vh]` and `overflow-x-auto` |
| frontend/vite.config.ts | Switches from `process.env` to `loadEnv` to read mode-specific `.env` files; derives `wsUrl` for the WebSocket proxy; switches `base` detection from `mode === "development"` to `command === "serve"` |
| frontend/package.json | Adds `dev:edu`, `dev:game`, `dev:ethz` scripts that pass the corresponding Vite mode flag |
| frontend/.env.edu | New env file setting `VITE_BACKEND_URL` for the edu deployment; no secrets |
| package.json | Replaces single `dev:remote` script with three environment-specific `dev:*` scripts delegating to `frontend/` |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[notifications list changes] --> B[categoriesWithNotifications\nfilter CATEGORIES that\nhave ≥1 notification]
    B --> C{activeCategory\n=== 'all'?}
    C -- Yes --> D[effectiveCategory = 'all']
    C -- No --> E{activeCategory in\ncategoriesWithNotifications?}
    E -- Yes --> F[effectiveCategory = activeCategory]
    E -- No --> G[effectiveCategory = 'all'\nauto-reset]
    D --> H[filteredNotifications\n= all notifications]
    F --> I[filteredNotifications\n= notifications in category]
    G --> H
    B --> J[Render only\ncategoriesWithNotifications\nas filter buttons]
```

<sub>Reviews (2): Last reviewed commit: ["fix: derive effective category instead o..."](https://github.com/felixvonsamson/energetica/commit/c14af6b0de6b050a44ef4f92c164ee2d6a644075) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30383003)</sub>

<!-- /greptile_comment -->