### PR TITLE
Fix/716 y axis label fomatting

### DIFF
--- a/frontend/src/components/charts/co2-chart.tsx
+++ b/frontend/src/components/charts/co2-chart.tsx
@@ -4,6 +4,7 @@ import {
     EChartsTimeSeries,
     EChartsTimeSeriesConfig,
 } from "@/components/charts/echarts-time-series";
+import { formatConcentration, formatEmissions } from "@/lib/format-utils";
 
 // CO2 Chart Component
 interface CO2ChartProps {
@@ -26,7 +27,7 @@ export function CO2Chart({
         if (chartData.length === 0) return [];
 
         const REFERENCE_CO2 = 4e10; // kg - reference CO2 level
-        const KG_TO_PPM = 3 / 4e5; // Conversion factor
+        const KG_TO_PPB = 3 / 4e5; // Conversion factor: kg → ppb
 
         return chartData.map((dataPoint) => {
             const dp = dataPoint as Record<string, unknown>;
@@ -39,9 +40,9 @@ export function CO2Chart({
                 value = value - REFERENCE_CO2;
             }
 
-            // Apply concentration mode (convert to ppm)
+            // Apply concentration mode (convert to ppb)
             if (unitMode === "concentration") {
-                value = value * KG_TO_PPM;
+                value = value * KG_TO_PPB;
             }
 
             return {
@@ -51,38 +52,28 @@ export function CO2Chart({
                     viewMode === "relative"
                         ? 0
                         : unitMode === "concentration"
-                          ? REFERENCE_CO2 * KG_TO_PPM
+                          ? REFERENCE_CO2 * KG_TO_PPB
                           : REFERENCE_CO2,
             };
         });
     }, [chartData, viewMode, unitMode]);
 
-    // TODO: ensure these are from format utilities
     const formatValue = useCallback(
         (value: number): string => {
             if (unitMode === "concentration") {
-                // Format as ppm
-                const abs = Math.abs(value);
-                if (abs >= 1000) {
-                    return `${(value / 1000).toFixed(2)}‰`;
-                } else if (abs >= 1) {
-                    return `${value.toFixed(2)} ppm`;
-                } else {
-                    return `${(value * 1000).toFixed(2)} ppb`;
-                }
-            } else {
-                // Format as mass
-                const abs = Math.abs(value);
-                if (abs >= 1e12) {
-                    return `${(value / 1e12).toFixed(2)} Tt`;
-                } else if (abs >= 1e9) {
-                    return `${(value / 1e9).toFixed(2)} Gt`;
-                } else if (abs >= 1e6) {
-                    return `${(value / 1e6).toFixed(2)} Mt`;
-                } else {
-                    return `${(value / 1e3).toFixed(2)} t`;
-                }
+                return formatConcentration(value);
             }
+            return formatEmissions(value);
+        },
+        [unitMode],
+    );
+
+    const formatYAxis = useCallback(
+        (value: number): string => {
+            if (unitMode === "concentration") {
+                return formatConcentration(value);
+            }
+            return formatEmissions(value);
         },
         [unitMode],
     );
@@ -94,8 +85,9 @@ export function CO2Chart({
             getColor: (key: string) => (key === "CO2" ? "#ef4444" : "#9ca3af"),
             filterDataKeys: [],
             formatValue,
+            formatYAxis,
         }),
-        [formatValue],
+        [formatValue, formatYAxis],
     );
 
     return (

--- a/frontend/src/components/charts/co2-chart.tsx
+++ b/frontend/src/components/charts/co2-chart.tsx
@@ -58,17 +58,7 @@ export function CO2Chart({
         });
     }, [chartData, viewMode, unitMode]);
 
-    const formatValue = useCallback(
-        (value: number): string => {
-            if (unitMode === "concentration") {
-                return formatConcentration(value);
-            }
-            return formatEmissions(value);
-        },
-        [unitMode],
-    );
-
-    const formatYAxis = useCallback(
+    const formatCO2Value = useCallback(
         (value: number): string => {
             if (unitMode === "concentration") {
                 return formatConcentration(value);
@@ -84,10 +74,10 @@ export function CO2Chart({
             stacked: false,
             getColor: (key: string) => (key === "CO2" ? "#ef4444" : "#9ca3af"),
             filterDataKeys: [],
-            formatValue,
-            formatYAxis,
+            formatValue: formatCO2Value,
+            formatYAxis: formatCO2Value,
         }),
-        [formatValue, formatYAxis],
+        [formatCO2Value],
     );
 
     return (

--- a/frontend/src/components/charts/echarts-time-series.tsx
+++ b/frontend/src/components/charts/echarts-time-series.tsx
@@ -16,7 +16,6 @@ import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
 import {
     DataZoomComponent,
     GridComponent,
-    MarkLineComponent,
     ToolboxComponent,
     TooltipComponent,
 } from "echarts/components";
@@ -61,7 +60,6 @@ echarts.use([
     TooltipComponent,
     DataZoomComponent,
     ToolboxComponent,
-    MarkLineComponent,
     CanvasRenderer,
 ]);
 
@@ -107,11 +105,12 @@ export interface EChartsTimeSeriesConfig {
     gradientKeys?: string[];
     /** Whether to hide zero values in tooltip (default true) */
     hideZeroValues?: boolean;
-    referenceLines?: Array<{ x: number; label?: string }>;
     /** Y-axis minimum (default: auto) */
     yAxisMin?: number;
     /** Y-axis maximum (default: auto) */
     yAxisMax?: number;
+    /** Y-axis title label (e.g. "Price (coins/MWh)") */
+    yAxisLabel?: string;
 }
 
 export interface EChartsTimeSeriesProps {
@@ -390,8 +389,6 @@ export function EChartsTimeSeries({
             ticks.length > 0 ? Math.ceil(plotWidth / visibleTickCount) : 1;
 
         // Resolve CSS variables for canvas renderer
-        const primaryColor = resolveCSSVar("--primary");
-        const mutedColor = resolveCSSVar("--muted-foreground");
         const successColor = resolveCSSVar("--success");
         const destructiveColor = resolveCSSVar("--destructive");
 
@@ -416,8 +413,6 @@ export function EChartsTimeSeries({
                 else gradientOffsets[key] = dataMax / (dataMax - dataMin);
             }
         }
-
-        const allRefLines = [...(config.referenceLines ?? [])];
 
         const series: ECOption["series"] = visibleKeys.map((key) => {
             const rawColor = config.getColor?.(key) ?? "#888";
@@ -509,24 +504,6 @@ export function EChartsTimeSeries({
             };
         });
 
-        // Attach reference lines to the first visible series via markLine
-        if (series.length > 0 && allRefLines.length > 0) {
-            (series[0] as LineSeriesOption).markLine = {
-                silent: true,
-                symbol: ["none", "none"],
-                data: allRefLines.map((rl) => ({
-                    xAxis: rl.x,
-                    name: rl.label ?? "",
-                })),
-                lineStyle: { color: primaryColor, type: "dashed", width: 2 },
-                label: {
-                    formatter: "{b}",
-                    position: "insideStartTop",
-                    color: mutedColor,
-                    fontSize: 12,
-                },
-            };
-        }
 
         return {
             animation: false,
@@ -555,6 +532,13 @@ export function EChartsTimeSeries({
                 axisLabel: { formatter: config.formatYAxis, fontSize: 11 },
                 min: config.yAxisMin,
                 max: config.yAxisMax,
+                ...(config.yAxisLabel
+                    ? {
+                          name: config.yAxisLabel,
+                          nameLocation: "middle" as const,
+                          nameGap: 50,
+                      }
+                    : {}),
                 splitLine: {
                     lineStyle: { color: "rgba(128,128,128,0.15)" },
                 },

--- a/frontend/src/components/charts/emissions-chart.tsx
+++ b/frontend/src/components/charts/emissions-chart.tsx
@@ -129,8 +129,13 @@ export function EmissionsChart({
             getColor,
             filterDataKeys,
             formatValue,
+            formatYAxis:
+                viewMode === "percent"
+                    ? (v: number) => `${v.toFixed(0)}%`
+                    : (v: number) => formatEmissions(v),
+            yAxisMax: viewMode === "percent" ? 100 : undefined,
         }),
-        [getColor, filterDataKeys, formatValue],
+        [getColor, filterDataKeys, formatValue, viewMode],
     );
 
     return (

--- a/frontend/src/components/charts/market-clearing-volume-chart.tsx
+++ b/frontend/src/components/charts/market-clearing-volume-chart.tsx
@@ -123,9 +123,6 @@ export function MarketClearingVolumeChart({
                           playerMap?.[parseInt(key)]?.username ?? key
                     : undefined,
             hideZeroValues: false,
-            referenceLines: market
-                ? [{ x: market.created_tick, label: "Market Creation" }]
-                : [],
         }),
         [
             chartType,

--- a/frontend/src/components/charts/market-clearing-volume-chart.tsx
+++ b/frontend/src/components/charts/market-clearing-volume-chart.tsx
@@ -86,7 +86,6 @@ export function MarketClearingVolumeChart({
     breakdownMode,
     breakdownType,
 }: MarketClearingChartProps) {
-    const market = useElectricityMarket(marketId);
     const getColor = useAssetColorGetter();
     const playerMap = usePlayerMap();
 
@@ -132,7 +131,6 @@ export function MarketClearingVolumeChart({
             breakdownFilter,
             quantityFilter,
             playerMap,
-            market,
         ],
     );
 

--- a/frontend/src/components/charts/market-price-chart.tsx
+++ b/frontend/src/components/charts/market-price-chart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { ReactNode, useMemo } from "react";
 
 import {
     EChartsTimeSeries,
@@ -9,6 +9,16 @@ import { useChartData } from "@/hooks/use-charts";
 import { useElectricityMarket } from "@/hooks/use-electricity-markets";
 import { formatMoney } from "@/lib/format-utils";
 import { ResolutionOption } from "@/types/charts";
+
+function formatMarketPriceValue(value: number): ReactNode {
+    return (
+        <span className="inline-flex items-center gap-1">
+            {formatMoney(value)}
+            <CoinIcon className="w-3 h-3" />
+            /MWh
+        </span>
+    );
+}
 
 interface MarketPriceChartProps {
     selectedResolution: ResolutionOption;
@@ -52,18 +62,12 @@ export function MarketPriceChart({
             stacked: false,
             getColor: () => "var(--chart-2)",
             filterDataKeys: [],
-            formatValue: (value: number) => (
-                <span className="inline-flex items-center gap-1">
-                    {formatMoney(value)}
-                    <CoinIcon className="w-3 h-3" />
-                    /MWh
-                </span>
-            ),
+            formatValue: formatMarketPriceValue,
             formatYAxis: (value: number) => formatMoney(value),
             yAxisLabel: "Price (coins/MWh)",
             hideZeroValues: false,
         }),
-        [market],
+        [],
     );
 
     return (

--- a/frontend/src/components/charts/market-price-chart.tsx
+++ b/frontend/src/components/charts/market-price-chart.tsx
@@ -4,8 +4,10 @@ import {
     EChartsTimeSeries,
     EChartsTimeSeriesConfig,
 } from "@/components/charts/echarts-time-series";
+import { CoinIcon } from "@/components/ui/coin-icon";
 import { useChartData } from "@/hooks/use-charts";
 import { useElectricityMarket } from "@/hooks/use-electricity-markets";
+import { formatMoney } from "@/lib/format-utils";
 import { ResolutionOption } from "@/types/charts";
 
 interface MarketPriceChartProps {
@@ -50,12 +52,16 @@ export function MarketPriceChart({
             stacked: false,
             getColor: () => "var(--chart-2)",
             filterDataKeys: [],
-            formatValue: (value: number) => `$${value.toFixed(6)}`,
-            formatYAxis: (value: number) => `$${value.toFixed(6)}`,
+            formatValue: (value: number) => (
+                <span className="inline-flex items-center gap-1">
+                    {formatMoney(value)}
+                    <CoinIcon className="w-3 h-3" />
+                    /MWh
+                </span>
+            ),
+            formatYAxis: (value: number) => formatMoney(value),
+            yAxisLabel: "Price (coins/MWh)",
             hideZeroValues: false,
-            referenceLines: market
-                ? [{ x: market.created_tick, label: "Market Creation" }]
-                : [],
         }),
         [market],
     );

--- a/frontend/src/components/charts/power-chart.tsx
+++ b/frontend/src/components/charts/power-chart.tsx
@@ -106,7 +106,7 @@ export function PowerChart({
             formatYAxis:
                 viewMode === "percent"
                     ? (v: number) => `${v.toFixed(0)}%`
-                    : formatPower,
+                    : (v: number) => formatPower(v),
             yAxisMin: 0,
             yAxisMax: viewMode === "percent" ? 100 : undefined,
             hideZeroValues: true,

--- a/frontend/src/components/charts/supply-demand-chart.tsx
+++ b/frontend/src/components/charts/supply-demand-chart.tsx
@@ -519,7 +519,7 @@ function MeritOrderChartInner({
 
         return {
             animation: false,
-            grid: { left: 90, right: 20, top: 20, bottom: 55 },
+            grid: { left: 70, right: 20, top: 20, bottom: 55 },
             xAxis: {
                 type: "value",
                 min: quantityDomain[0],
@@ -541,7 +541,7 @@ function MeritOrderChartInner({
                 max: priceDomain[1],
                 name: "Price (coins/MWh)",
                 nameLocation: "middle",
-                nameGap: 70,
+                nameGap: 50,
                 axisLabel: {
                     formatter: (value: number) => formatMoney(value),
                     fontSize: 11,

--- a/frontend/src/components/charts/temperature-chart.tsx
+++ b/frontend/src/components/charts/temperature-chart.tsx
@@ -59,6 +59,7 @@ export function TemperatureChart({
                 key === "temperature" ? "#f59e0b" : "#9ca3af",
             filterDataKeys: [],
             formatValue,
+            formatYAxis: (v: number) => `${parseFloat(v.toFixed(2))}°C`,
         }),
         [],
     );

--- a/frontend/src/lib/format-utils.ts
+++ b/frontend/src/lib/format-utils.ts
@@ -10,7 +10,7 @@
 // Unit definitions
 const POWER_UNITS = [" W", " kW", " MW", " GW", " TW"];
 const ENERGY_UNITS = [" Wh", " kWh", " MWh", " GWh", " TWh"];
-const MASS_UNITS = [" kg", " t", " kt", " Mt"];
+const MASS_UNITS = [" kg", " t", " kt", " Mt", " Gt", " Tt"];
 const MASS_RATE_UNITS = [" g/h", " kg/h", " t/h", " kt/h"]; // Starts at g/h
 const CONCENTRATION_UNITS = [" ppb", " ppm", " ‰"];
 
@@ -145,27 +145,17 @@ export function formatUpgradeMass(
 }
 
 /**
- * Format emissions/large mass values using scientific metric prefixes (kg, t,
- * Mt, Gt, Tt). Uses absolute thresholds and displays decimals.
+ * Format emissions/large mass values (kg, t, kt, Mt, Gt, Tt).
+ *
+ * Uses a threshold of 1,000 so that Gt and Tt are reachable.
  *
  * @example
- *     formatEmissions(500); // "500.00 kg"
- *     formatEmissions(15000); // "15.00 t"
- *     formatEmissions(1500000000); // "1.50 Gt"
+ *     formatEmissions(500); // "500 kg"
+ *     formatEmissions(15000); // "15 t"
+ *     formatEmissions(1500000000000); // "1500 Mt"
  */
 export function formatEmissions(value: number): string {
-    const abs = Math.abs(value);
-    if (abs >= 1e12) {
-        return `${(value / 1e12).toFixed(2)} Tt`;
-    } else if (abs >= 1e9) {
-        return `${(value / 1e9).toFixed(2)} Gt`;
-    } else if (abs >= 1e6) {
-        return `${(value / 1e6).toFixed(2)} Mt`;
-    } else if (abs >= 1e3) {
-        return `${(value / 1e3).toFixed(2)} t`;
-    } else {
-        return `${value.toFixed(2)} kg`;
-    }
+    return generalFormat(value, MASS_UNITS);
 }
 
 // === Mass Rate Formatting ===

--- a/frontend/src/lib/format-utils.ts
+++ b/frontend/src/lib/format-utils.ts
@@ -147,8 +147,6 @@ export function formatUpgradeMass(
 /**
  * Format emissions/large mass values (kg, t, kt, Mt, Gt, Tt).
  *
- * Uses a threshold of 1,000 so that Gt and Tt are reachable.
- *
  * @example
  *     formatEmissions(500); // "500 kg"
  *     formatEmissions(15000); // "15 t"

--- a/frontend/src/routes/app/overviews/emissions.tsx
+++ b/frontend/src/routes/app/overviews/emissions.tsx
@@ -105,8 +105,8 @@ const CO2_UNIT_OPTIONS = [
 ] as const;
 
 const EMISSIONS_VIEW_OPTIONS = [
-    { value: "normal", label: "Normal" },
-    { value: "percent", label: "Percent" },
+    { value: "normal", label: "t" },
+    { value: "percent", label: "%" },
 ] as const;
 
 const EMISSIONS_CUMULATIVE_OPTIONS = [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes y-axis label formatting across all time-series charts by centralising formatters through `generalFormat`, replacing ad-hoc `toFixed(2)` strings, removing the now-unused `MarkLineComponent` / `referenceLines` infrastructure, and adding a new `yAxisLabel` option to `EChartsTimeSeriesConfig`. Notable correctness improvements include renaming `KG_TO_PPM` → `KG_TO_PPB` in the CO2 chart, consolidating duplicate `formatValue`/`formatYAxis` callbacks, and extending `MASS_UNITS` to include Gt and Tt.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only P2 findings remain (docstring inaccuracy, minor formatter inconsistency).

All changes are UI/display-only with no data-mutation paths. The two issues found are documentation and style nits (P2). No P0 or P1 findings.

frontend/src/lib/format-utils.ts (incorrect docstring example); frontend/src/components/charts/temperature-chart.tsx (minor formatter inconsistency).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/lib/format-utils.ts | Adds Gt/Tt to MASS_UNITS and delegates formatEmissions to generalFormat; docstring example has wrong output (missing thousands separator). |
| frontend/src/components/charts/echarts-time-series.tsx | Removes MarkLineComponent and referenceLines config; adds optional yAxisLabel prop. |
| frontend/src/components/charts/market-price-chart.tsx | Replaces raw $-string formatters with formatMoney and a ReactNode CoinIcon tooltip; removes referenceLines and stale market dep, adds yAxisLabel. |
| frontend/src/components/charts/co2-chart.tsx | Consolidates duplicate formatValue/formatYAxis into a single formatCO2Value callback; renames KG_TO_PPM to KG_TO_PPB for correctness. |
| frontend/src/components/charts/emissions-chart.tsx | Adds formatYAxis matching percent/normal viewMode and caps yAxisMax at 100 in percent mode. |
| frontend/src/components/charts/temperature-chart.tsx | Adds formatYAxis using parseFloat(v.toFixed(2)) — functional but inconsistent with formatTemperature utility and the tooltip formatter. |
| frontend/src/components/charts/market-clearing-volume-chart.tsx | Removes referenceLines and the market hook dependency; clean change. |
| frontend/src/components/charts/power-chart.tsx | Wraps formatPower in an arrow function for consistency; no semantic change. |
| frontend/src/components/charts/supply-demand-chart.tsx | Adjusts grid left (90→70) and nameGap (70→50) to tighten layout around the y-axis label. |
| frontend/src/routes/app/overviews/emissions.tsx | Renames view-mode toggle labels from 'Normal'/'Percent' to 't'/'%'. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/lib/format-utils.ts`, line 118-123 ([link](https://github.com/felixvonsamson/energetica/blob/39824829a21bb3d82553247001f95f8fdfa33753/frontend/src/lib/format-utils.ts#L118-L123)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`formatMass` docstring not updated**

   `MASS_UNITS` now includes `" Gt"` and `" Tt"`, so `formatMass` and `formatUpgradeMass` can now produce those units as well. The JSDoc still says "(kg, t, kt, Mt)" — worth updating to "(kg, t, kt, Mt, Gt, Tt)" to keep documentation accurate.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["implement greptile comments"](https://github.com/felixvonsamson/energetica/commit/b520129ed867e0b420c6b227910c74e856220a1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30558389)</sub>

<!-- /greptile_comment -->