### PR TITLE
removed GHG effect achievement and making CO2 data available from the beginning

### DIFF
--- a/energetica/config/achievements.py
+++ b/energetica/config/achievements.py
@@ -117,12 +117,6 @@ achievements: dict = {
         "xp": 1,
         "requirements": [],
     },
-    "GHG_effect": {
-        "name": "Discover the Greenhouse Effect",
-        "unlocked_with": ["chemistry"],
-        "xp": 5,
-        "requirements": ["laboratory"],
-    },
 }
 
 # Taken an adapted from display_functions.js

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -131,7 +131,6 @@ class Player(DBModel):
             "network": 0,
             "laboratory": 0,
             "warehouse": 0,
-            "GHG_effect": 0,
             "storage_facilities": 0,
         },
     )
@@ -495,10 +494,6 @@ class Player(DBModel):
             net_emissions += value
         return net_emissions
 
-    def discovered_greenhouse_gas_effect(self) -> bool:
-        """Return True if the player has discovered the greenhouse gas effect."""
-        return bool(self.achievements["GHG_effect"])
-
     def _notify_milestone(self, achievement_key: str, milestone: dict) -> None:
         if achievement_key == "power_consumption":
             payload: NotificationPayload = AchievementMilestonePowerConsumptionPayload(
@@ -545,7 +540,7 @@ class Player(DBModel):
 
     def check_construction_achievements(self, construction_name: str) -> None:
         """Check for player achievements that may be unlocked by a construction."""
-        for achievement in ["laboratory", "warehouse", "GHG_effect", "storage_facilities"]:
+        for achievement in ["laboratory", "warehouse", "storage_facilities"]:
             if not self.achievements[achievement] and construction_name in achievements[achievement]["unlocked_with"]:
                 self.achievements[achievement] = 1
                 self.progression_metrics["xp"] += achievements[achievement]["xp"]
@@ -590,7 +585,7 @@ class Player(DBModel):
             requirements_met = all(self.achievements[requirement] for requirement in achievement_data["requirements"])
             if not requirements_met:
                 continue
-            if achievement_id in ["laboratory", "warehouse", "GHG_effect", "storage_facilities"]:
+            if achievement_id in ["laboratory", "warehouse", "storage_facilities"]:
                 if not self.achievements[achievement_id]:
                     achievement = AchievementUnlockOut(
                         type="unlock",

--- a/energetica/routers/leaderboards.py
+++ b/energetica/routers/leaderboards.py
@@ -17,6 +17,5 @@ def get_leaderboards(
 ) -> LeaderboardsOut:
     """Get the leaderboards data."""
     players = Player.all()
-    include_co2_emissions = player.discovered_greenhouse_gas_effect()
-    rows = [PlayerDetailStats.from_player(player, include_co2_emissions) for player in players]
+    rows = [PlayerDetailStats.from_player(player) for player in players]
     return LeaderboardsOut(rows=rows)

--- a/energetica/schemas/capabilities.py
+++ b/energetica/schemas/capabilities.py
@@ -31,7 +31,6 @@ class PlayerCapabilities(BaseModel):
     has_warehouse: bool  # Can access /resource-market, shipments section
     has_storage: bool  # Can access /storage page
     has_network: bool  # Can access /network page, market features
-    has_greenhouse_gas_effect: bool  # Has discovered climate/emissions tracking
 
     # Future capabilities (for when new features are added)
     # has_advanced_analytics: bool  # Advanced charts/analytics
@@ -50,5 +49,4 @@ class PlayerCapabilities(BaseModel):
             has_warehouse=bool(player.achievements.get("warehouse", 0)),
             has_storage=bool(player.achievements.get("storage_facilities", 0)),
             has_network=bool(player.achievements.get("network", 0)),
-            has_greenhouse_gas_effect=bool(player.achievements.get("GHG_effect", 0)),
         )

--- a/energetica/schemas/leaderboards.py
+++ b/energetica/schemas/leaderboards.py
@@ -74,10 +74,10 @@ class PlayerDetailStats(BaseModel):
     resources: ResourceStats
     technologies: TechnologiesStats
     functional_facilities: FunctionalFacilitiesStats
-    emissions: Optional[EmissionsStats] = None
+    emissions: EmissionsStats
 
     @classmethod
-    def from_player(cls, player: Player, include_emissions: bool) -> PlayerDetailStats:
+    def from_player(cls, player: Player) -> PlayerDetailStats:
         from energetica.enums import FunctionalFacilityType, TechnologyType
 
         metrics = player.progression_metrics
@@ -127,12 +127,10 @@ class PlayerDetailStats(BaseModel):
             carbon_capture=player.functional_facility_lvl[FunctionalFacilityType.CARBON_CAPTURE],
         )
 
-        emissions = None
-        if include_emissions:
-            emissions = EmissionsStats(
-                net_emissions=player.calculate_net_emissions(),
-                captured_co2=metrics.get("captured_co2", 0),
-            )
+        emissions = EmissionsStats(
+            net_emissions=player.calculate_net_emissions(),
+            captured_co2=metrics.get("captured_co2", 0),
+        )
 
         return PlayerDetailStats(
             player_id=player.id,

--- a/energetica/schemas/notifications.py
+++ b/energetica/schemas/notifications.py
@@ -100,7 +100,7 @@ class AchievementUnlockPayload(BaseModel):
     """One-shot achievement unlocked by constructing a specific facility."""
 
     type: Literal["achievement_unlock"] = "achievement_unlock"
-    achievement_key: Literal["laboratory", "warehouse", "storage_facilities", "GHG_effect"]
+    achievement_key: Literal["laboratory", "warehouse", "storage_facilities"]
     xp: int
 
 

--- a/energetica/technology_effects.py
+++ b/energetica/technology_effects.py
@@ -666,11 +666,8 @@ def _package_power_storage_extraction_facility_base(player: Player, facility_typ
         * const_config_assets[facility_type]["O&M_factor_per_day"]
         / 24,
         "lifespan": const_config_assets[facility_type]["lifespan"] / engine.in_game_seconds_per_tick,
-    } | (
-        {"construction_pollution": const_config_assets[facility_type]["base_construction_pollution"]}
-        if player.discovered_greenhouse_gas_effect()
-        else {}
-    )
+        "construction_pollution": const_config_assets[facility_type]["base_construction_pollution"],
+    }
 
 
 def package_power_facilities(player: Player) -> list[dict]:
@@ -769,15 +766,6 @@ def package_extraction_facilities(player: Player) -> list[dict]:
         }
         for extraction_facility in ExtractionFacilityType
     ]
-
-
-def project_is_hidden(player: Player, project_type: ProjectType) -> bool:
-    """
-    Return true if the facility is hidden to the player due to lack of achievements.
-
-    Such facilities should not be shown on the frontend.
-    """
-    return project_type == FunctionalFacilityType.CARBON_CAPTURE and not player.discovered_greenhouse_gas_effect()
 
 
 def next_level(player: Player, facility_or_technology: ProjectType) -> int:
@@ -898,18 +886,13 @@ def package_functional_facilities(player: Player) -> list[dict]:
     }
     return [
         _package_project_base(player, functional_facility)
-        | (
-            {
-                "construction_pollution": const_config_assets[functional_facility]["base_construction_pollution"]
-                * const_config_assets[functional_facility]["price_multiplier"]
-                ** player.functional_facility_lvl[FunctionalFacilityType.INDUSTRY],
-            }
-            if player.discovered_greenhouse_gas_effect()
-            else {}
-        )
+        | {
+            "construction_pollution": const_config_assets[functional_facility]["base_construction_pollution"]
+            * const_config_assets[functional_facility]["price_multiplier"]
+            ** player.functional_facility_lvl[FunctionalFacilityType.INDUSTRY],
+        }
         | special_keys[functional_facility]
         for functional_facility in FunctionalFacilityType
-        if not project_is_hidden(player, functional_facility)  # Hide carbon capture if not discovered
     ]
 
 

--- a/frontend/src/components/layout/top-bar.tsx
+++ b/frontend/src/components/layout/top-bar.tsx
@@ -53,6 +53,7 @@ import { usePlayerMoney } from "@/hooks/use-player-money";
 import { usePlayerWorkers } from "@/hooks/use-player-workers";
 import { cn } from "@/lib/utils";
 import { Money } from "@/types/money";
+import { Capabilities } from "@/types/players";
 import { Workers } from "@/types/workers";
 
 export function TopBar() {
@@ -344,13 +345,7 @@ function WorkersDisplay(
     isWorkersError: boolean,
     isWorkersLoading: boolean,
     workersData: Workers | undefined,
-    capabilities: {
-        has_laboratory: boolean;
-        has_warehouse: boolean;
-        has_storage: boolean;
-        has_network: boolean;
-        has_greenhouse_gas_effect: boolean;
-    } | null,
+    capabilities: Capabilities | null,
 ) {
     return (
         <>

--- a/frontend/src/hooks/use-route-static-data.ts
+++ b/frontend/src/hooks/use-route-static-data.ts
@@ -40,5 +40,5 @@ export function useRouteUnlocked(
     const routeConfig = staticData.routeConfig;
     if (!routeConfig || routeConfig.requiredRole !== "player")
         return { unlocked: true };
-    return routeConfig.isUnlocked(capabilities);
+    return routeConfig.isUnlocked ? routeConfig.isUnlocked(capabilities) : { unlocked: true };
 }

--- a/frontend/src/lib/achievement-config.ts
+++ b/frontend/src/lib/achievement-config.ts
@@ -155,8 +155,4 @@ export const ACHIEVEMENT_UNLOCK_CONFIG: Record<UnlockAchievementKey, UnlockConfi
         name: "First Storage Facility",
         body: "You have built your first storage facility, you can monitor the stored energy in the energy storage overview.",
     },
-    GHG_effect: {
-        name: "Discover the Greenhouse Effect",
-        body: "Scientists have discovered the greenhouse effect and have shown that climate change is caused by human activities and increases the risk of extreme weather events. You can now monitor your CO2 emissions and the climate anomalies in the emissions overview.",
-    },
 };

--- a/frontend/src/router.d.ts
+++ b/frontend/src/router.d.ts
@@ -15,7 +15,7 @@ type RouteConfig =
           // Routes that require a user with a "player" role
           requiredRole: "player";
           requiresSettledTile: boolean;
-          isUnlocked: (capabilities: Capabilities) => UnlockStatus;
+          isUnlocked?: (capabilities: Capabilities) => UnlockStatus;
       };
 
 declare module "@tanstack/react-router" {

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -38,7 +38,7 @@ function computeRedirect(
                 return "/app/settle";
             if (!routeConfig.requiresSettledTile && user.is_settled)
                 return "/app/dashboard";
-            if (!capabilities || !routeConfig.isUnlocked(capabilities).unlocked)
+            if (!capabilities || (routeConfig.isUnlocked && !routeConfig.isUnlocked(capabilities).unlocked))
                 return "/app/dashboard";
             return null;
         default:

--- a/frontend/src/routes/app/community/leaderboards.tsx
+++ b/frontend/src/routes/app/community/leaderboards.tsx
@@ -6,7 +6,6 @@ import { useState } from "react";
 import { GameLayout } from "@/components/layout/game-layout";
 import { PageCard, CardContent, Money } from "@/components/ui";
 import { PlayerName } from "@/components/ui/player-name";
-import { useHasCapability } from "@/hooks/use-capabilities";
 import { useLeaderboards } from "@/hooks/use-leaderboards";
 import { usePlayerMap } from "@/hooks/use-players";
 import { formatPower, formatEnergy, formatMass } from "@/lib/format-utils";
@@ -68,10 +67,6 @@ function LeaderboardsContent() {
 
     const { data: leaderboards, isLoading, error } = useLeaderboards();
     const playerMap = usePlayerMap();
-    const hasGreenhouseGasEffect = useHasCapability(
-        "has_greenhouse_gas_effect",
-    );
-
     if (isLoading) {
         return (
             <div className="p-4 md:p-8 text-center">
@@ -741,14 +736,10 @@ function LeaderboardsContent() {
                     <>
                         {commonCells}
                         <td className="py-3 px-4 text-right font-mono">
-                            {row.emissions
-                                ? formatMass(row.emissions.net_emissions)
-                                : "-"}
+                            {formatMass(row.emissions.net_emissions)}
                         </td>
                         <td className="py-3 px-4 text-right font-mono">
-                            {row.emissions
-                                ? formatMass(row.emissions.captured_co2)
-                                : "-"}
+                            {formatMass(row.emissions.captured_co2)}
                         </td>
                     </>
                 );
@@ -769,10 +760,6 @@ function LeaderboardsContent() {
                         "emissions",
                     ] as const
                 ).map((category) => {
-                    // Only show emissions if capability is enabled
-                    if (category === "emissions" && !hasGreenhouseGasEffect) {
-                        return null;
-                    }
                     return (
                         <button
                             key={category}

--- a/frontend/src/routes/app/dashboard.tsx
+++ b/frontend/src/routes/app/dashboard.tsx
@@ -114,9 +114,6 @@ function DashboardContent() {
     const { data: projectsData } = useProjects();
     const { data: shipmentsData } = useShipments();
 
-    const hasDiscoveredGreenhouse = useHasCapability(
-        "has_greenhouse_gas_effect",
-    );
     const hasNetwork = useHasCapability("has_network");
 
     // Check if there are any construction projects
@@ -213,13 +210,11 @@ function DashboardContent() {
                             title="Stored Energy"
                         />
                     )}
-                    {hasDiscoveredGreenhouse && (
-                        <QuickLinkCard
-                            to="/app/overviews/emissions"
-                            icon={Leaf}
-                            title="Emissions"
-                        />
-                    )}
+                    <QuickLinkCard
+                        to="/app/overviews/emissions"
+                        icon={Leaf}
+                        title="Emissions"
+                    />
                     {hasNetwork && (
                         <QuickLinkCard
                             to="/app/overviews/electricity-markets"

--- a/frontend/src/routes/app/overviews/emissions.tsx
+++ b/frontend/src/routes/app/overviews/emissions.tsx
@@ -30,10 +30,6 @@ export const Route = createFileRoute("/app/overviews/emissions")({
         routeConfig: {
             requiredRole: "player",
             requiresSettledTile: true,
-            isUnlocked: (cap) =>
-                cap.has_greenhouse_gas_effect
-                    ? { unlocked: true }
-                    : { unlocked: false, reason: "Research Chemistry lvl 1 to unlock" },
         },
         infoDialog: {
             contents: <EmissionsOverviewHelp />,

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2088,11 +2088,7 @@ export interface components {
              *
              * @enum {string}
              */
-            achievement_key:
-                | "laboratory"
-                | "warehouse"
-                | "storage_facilities"
-                | "GHG_effect";
+            achievement_key: "laboratory" | "warehouse" | "storage_facilities";
             /** Xp */
             xp: number;
         };
@@ -3391,8 +3387,6 @@ export interface components {
             has_storage: boolean;
             /** Has Network */
             has_network: boolean;
-            /** Has Greenhouse Gas Effect */
-            has_greenhouse_gas_effect: boolean;
         };
         /** PlayerDetailStats */
         PlayerDetailStats: {
@@ -3405,7 +3399,7 @@ export interface components {
             resources: components["schemas"]["ResourceStats"];
             technologies: components["schemas"]["TechnologiesStats"];
             functional_facilities: components["schemas"]["FunctionalFacilitiesStats"];
-            emissions?: components["schemas"]["EmissionsStats"] | null;
+            emissions: components["schemas"]["EmissionsStats"];
         };
         /**
          * PlayerOut


### PR DESCRIPTION
This is a bit of a bigger change to fix #614. 
I decided to remove the GHG effect discovery achievement from the game since it was not adding that much to the game.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `GHG_effect` achievement gate and makes CO2/emissions data available to all players from the start of the game. The change is applied consistently across the backend (achievement config, player model, leaderboard schema, capability schema, technology effects) and the frontend (route guards, leaderboard table, dashboard quick-links, and the emissions route config).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all references to the removed achievement are cleaned up across backend and frontend with no dangling dependencies.

The change is well-scoped and applied consistently: the achievement is removed from the config, player defaults, capability schema, leaderboard schema, technology effects, and every relevant frontend component. The isUnlocked field is correctly made optional in the router type and guarded in both __root.tsx and use-route-static-data.ts. No tests reference the removed code, and grep confirms no leftover references in the codebase. Existing players with GHG_effect in their stored achievements JSON are unaffected since nothing reads that key anymore.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/player.py | Removes GHG_effect from the achievements default dict, check_construction_achievements, and achievement ID list; deletes discovered_greenhouse_gas_effect() helper. All references cleaned up. |
| energetica/schemas/leaderboards.py | Emissions is now a required field on PlayerDetailStats instead of Optional; always computed from player data. |
| energetica/technology_effects.py | Removes project_is_hidden, always includes construction_pollution in facility packages, and removes carbon capture hide logic. |
| energetica/schemas/capabilities.py | Removes has_greenhouse_gas_effect field and its factory from PlayerCapabilities. |
| frontend/src/routes/__root.tsx | Updates computeRedirect to guard isUnlocked call with optional chaining since the field is now optional on RouteConfig. |
| frontend/src/routes/app/overviews/emissions.tsx | Removes isUnlocked gate from the emissions route so the page is accessible to all players from the start. |
| frontend/src/routes/app/community/leaderboards.tsx | Removes hasGreenhouseGasEffect capability check; emissions tab and cells are now unconditionally rendered. |
| frontend/src/routes/app/dashboard.tsx | Removes hasDiscoveredGreenhouse check; Emissions quick-link card is always shown on the dashboard. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Player Starts Game] --> B[Emissions data always available]
    B --> C[Dashboard: Emissions quick-link shown]
    B --> D[Leaderboards: emissions tab visible]
    B --> E[Emissions overview page accessible]
    B --> F[Carbon Capture facility visible]

    G[Old flow] --> H{Has GHG_effect achievement?}
    H -- No --> I[Emissions hidden / Carbon Capture hidden]
    H -- Yes --> J[Emissions visible / Carbon Capture visible]

    style G fill:#f99,stroke:#c00
    style A fill:#9f9,stroke:#090
```

<sub>Reviews (1): Last reviewed commit: ["removed GHG effect achievement and makin..."](https://github.com/felixvonsamson/energetica/commit/b80ac7f0f6845bedcb21cd355fb4bd7d374ba75b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30561150)</sub>

<!-- /greptile_comment -->