### PR TITLE
Fix #721: correct operator precedence in purchase dialog quantity calculation

### DIFF
--- a/frontend/src/components/electricity-markets/market-detail-dialog.tsx
+++ b/frontend/src/components/electricity-markets/market-detail-dialog.tsx
@@ -14,6 +14,7 @@ import { TypographyH2, TypographyH3 } from "@/components/ui/typography";
 import { useLatestChartDataSlice } from "@/hooks/use-charts";
 import { useMyMarket } from "@/hooks/use-electricity-markets";
 import { useGameTick } from "@/hooks/use-game-tick";
+import { useLastDefined } from "@/hooks/use-last-defined";
 import { usePlayerMap } from "@/hooks/use-players";
 import { formatPower } from "@/lib/format-utils";
 import { cn } from "@/lib/utils";
@@ -27,10 +28,6 @@ interface MarketDetailDialogProps {
     onLeave: (market: ElectricityMarket) => void;
 }
 
-/**
- * Dialog displaying detailed market information. Shows members, price, volume,
- * and action buttons.
- */
 export function MarketDetailDialog({
     isOpen,
     market,
@@ -38,21 +35,31 @@ export function MarketDetailDialog({
     onJoin,
     onLeave,
 }: MarketDetailDialogProps) {
+    const displayedMarket = useLastDefined(market);
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
             <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
-                {market !== null && MarketContent(market, onLeave, onJoin)}
+                {displayedMarket !== null && (
+                    <MarketContent
+                        market={displayedMarket}
+                        onLeave={onLeave}
+                        onJoin={onJoin}
+                    />
+                )}
             </DialogContent>
         </Dialog>
     );
 }
 
-// Content for MarketDetailDialog
-function MarketContent(
-    market: ElectricityMarket,
-    onLeave: (market: ElectricityMarket) => void,
-    onJoin: (market: ElectricityMarket) => void,
-) {
+function MarketContent({
+    market,
+    onLeave,
+    onJoin,
+}: {
+    market: ElectricityMarket;
+    onLeave: (market: ElectricityMarket) => void;
+    onJoin: (market: ElectricityMarket) => void;
+}) {
     const currentMarket = useMyMarket();
     const { currentTick } = useGameTick();
     const { data: marketData } = useLatestChartDataSlice({

--- a/frontend/src/components/facilities/facility-detail-dialog.tsx
+++ b/frontend/src/components/facilities/facility-detail-dialog.tsx
@@ -17,6 +17,7 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog";
 import { TypographyH2 } from "@/components/ui/typography";
+import { useLastDefined } from "@/hooks/use-last-defined";
 import { useQueueProject } from "@/hooks/use-projects";
 import { ProjectType, Requirement } from "@/types/projects";
 
@@ -43,10 +44,6 @@ interface FacilityDetailDialogProps<T> {
     onCompare?: (facility: T) => void;
 }
 
-/**
- * Dialog displaying detailed facility information. Shows full specs,
- * requirements, construction info, and action buttons.
- */
 export function FacilityDetailDialog<T>({
     isOpen,
     onClose,
@@ -57,6 +54,7 @@ export function FacilityDetailDialog<T>({
     extraHeaderContent,
     onCompare,
 }: FacilityDetailDialogProps<T>) {
+    const displayedFacility = useLastDefined(facility);
     const queueProjectMutation = useQueueProject();
 
     const handleConstruction = () => {
@@ -68,9 +66,9 @@ export function FacilityDetailDialog<T>({
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
             <DialogContent className="flex flex-col p-0 gap-0 overflow-hidden">
-                {facility !== null &&
+                {displayedFacility !== null &&
                     FacilityContent(
-                        facility,
+                        displayedFacility,
                         facilityType,
                         extraHeaderContent,
                         renderDescription,

--- a/frontend/src/components/resource-market/purchase-dialog.tsx
+++ b/frontend/src/components/resource-market/purchase-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
+import { useLastDefined } from "@/hooks/use-last-defined";
 import { usePurchaseAsk } from "@/hooks/use-resource-market";
 import { formatMass } from "@/lib/format-utils";
 import { RESOURCE_LABELS, ResourceType } from "@/types/resource-market";
@@ -29,10 +30,16 @@ export interface PurchaseDialogProps {
 }
 
 export function PurchaseDialog({ isOpen, onClose, ask }: PurchaseDialogProps) {
+    const displayedAsk = useLastDefined(ask);
     const [buyAll, setBuyAll] = useState(true);
     const [quantity, setQuantity] = useState(
-        (((ask?.quantity ?? 0) / 1000).toString()),
+        ((ask?.quantity ?? 0) / 1000).toString(),
     );
+
+    if (ask !== null && ask !== displayedAsk) {
+        setBuyAll(true);
+        setQuantity((ask.quantity / 1000).toString());
+    }
 
     const purchaseMutation = usePurchaseAsk();
 
@@ -50,154 +57,129 @@ export function PurchaseDialog({ isOpen, onClose, ask }: PurchaseDialogProps) {
         }
     };
 
-    const maxQuantityTons = (ask?.quantity ?? 0) / 1000;
-    const purchaseQuantityTons = buyAll
-        ? maxQuantityTons
-        : parseFloat(quantity || "0");
-    const totalCost = purchaseQuantityTons * (ask?.unit_price ?? 0) * 1000;
+    const maxQuantityTons = (displayedAsk?.quantity ?? 0) / 1000;
+    const purchaseQuantityTons = buyAll ? maxQuantityTons : parseFloat(quantity || "0");
+    const totalCost = purchaseQuantityTons * (displayedAsk?.unit_price ?? 0) * 1000;
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-            {ask !== null && (
-                <form onSubmit={handleSubmit} id="purchase-form">
-                    <DialogContent>
-                        <DialogHeader>
-                            <DialogTitle>Purchase Resources</DialogTitle>
-                            <DialogDescription>
-                                Buy resources from another player's listing.
-                            </DialogDescription>
-                        </DialogHeader>
+            {displayedAsk !== null && <form onSubmit={handleSubmit} id="purchase-form">
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Purchase Resources</DialogTitle>
+                        <DialogDescription>
+                            Buy resources from another player's listing.
+                        </DialogDescription>
+                    </DialogHeader>
 
-                        <div className="space-y-4">
-                            {/* Ask details */}
-                            <div className="bg-muted/50 p-4 rounded-lg space-y-2">
-                                <div className="flex justify-between">
-                                    <span className="font-semibold">
-                                        Resource:
-                                    </span>
-                                    <span className="capitalize">
-                                        {
-                                            RESOURCE_LABELS[
-                                                ask.resource_type as ResourceType
-                                            ]
-                                        }
-                                    </span>
-                                </div>
-                                <div className="flex justify-between">
-                                    <span className="font-semibold">
-                                        Available:
-                                    </span>
-                                    <span className="font-mono">
-                                        {formatMass(ask.quantity)}
-                                    </span>
-                                </div>
-                                <div className="flex justify-between">
-                                    <span className="font-semibold">
-                                        Price per ton:
-                                    </span>
-                                    <Money amount={ask.unit_price * 1000} />
-                                </div>
+                    <div className="space-y-4">
+                        <div className="bg-muted/50 p-4 rounded-lg space-y-2">
+                            <div className="flex justify-between">
+                                <span className="font-semibold">Resource:</span>
+                                <span className="capitalize">
+                                    {RESOURCE_LABELS[displayedAsk.resource_type as ResourceType]}
+                                </span>
                             </div>
-
-                            {/* Purchase amount selection */}
-                            <div className="space-y-3">
-                                <Label>Purchase Amount</Label>
-                                <div className="flex gap-2">
-                                    <Button
-                                        type="button"
-                                        variant={buyAll ? "default" : "outline"}
-                                        onClick={() => setBuyAll(true)}
-                                        className="flex-1"
-                                    >
-                                        Buy All
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant={
-                                            !buyAll ? "default" : "outline"
-                                        }
-                                        onClick={() => setBuyAll(false)}
-                                        className="flex-1"
-                                    >
-                                        Custom Amount
-                                    </Button>
-                                </div>
-
-                                {/* Custom amount input */}
-                                {!buyAll && (
-                                    <div className="space-y-2">
-                                        <Input
-                                            type="number"
-                                            value={quantity}
-                                            onChange={(e) =>
-                                                setQuantity(e.target.value)
-                                            }
-                                            min="0.01"
-                                            max={maxQuantityTons}
-                                            step="0.01"
-                                            placeholder="Enter quantity in tons"
-                                        />
-                                        <p className="text-xs text-muted-foreground">
-                                            Max: {maxQuantityTons.toFixed(2)}{" "}
-                                            tons
-                                        </p>
-                                    </div>
-                                )}
+                            <div className="flex justify-between">
+                                <span className="font-semibold">Available:</span>
+                                <span className="font-mono">
+                                    {formatMass(displayedAsk.quantity)}
+                                </span>
                             </div>
-
-                            {/* Purchase summary */}
-                            <div className="bg-muted/50 p-4 rounded-lg space-y-2">
-                                <div className="flex justify-between items-center">
-                                    <span className="text-sm text-muted-foreground">
-                                        Purchasing:
-                                    </span>
-                                    <span className="font-mono font-semibold">
-                                        {formatMass(
-                                            purchaseQuantityTons * 1000,
-                                        )}
-                                    </span>
-                                </div>
-                                <div className="border-t border-border pt-2 flex justify-between items-center">
-                                    <span className="font-semibold text-lg">
-                                        Total Cost:
-                                    </span>
-                                    <span className="text-lg font-bold">
-                                        <Money amount={totalCost} />
-                                    </span>
-                                </div>
+                            <div className="flex justify-between">
+                                <span className="font-semibold">Price per ton:</span>
+                                <Money amount={displayedAsk.unit_price * 1000} />
                             </div>
                         </div>
 
-                        <DialogFooter>
-                            <DialogClose asChild>
+                        <div className="space-y-3">
+                            <Label>Purchase Amount</Label>
+                            <div className="flex gap-2">
                                 <Button
-                                    variant="outline"
-                                    disabled={purchaseMutation.isPending}
+                                    type="button"
+                                    variant={buyAll ? "default" : "outline"}
+                                    onClick={() => setBuyAll(true)}
+                                    className="flex-1"
                                 >
-                                    Cancel
+                                    Buy All
                                 </Button>
-                            </DialogClose>
+                                <Button
+                                    type="button"
+                                    variant={!buyAll ? "default" : "outline"}
+                                    onClick={() => setBuyAll(false)}
+                                    className="flex-1"
+                                >
+                                    Custom Amount
+                                </Button>
+                            </div>
+
+                            {!buyAll && (
+                                <div className="space-y-2">
+                                    <Input
+                                        type="number"
+                                        value={quantity}
+                                        onChange={(e) =>
+                                            setQuantity(e.target.value)
+                                        }
+                                        min="0.01"
+                                        max={maxQuantityTons}
+                                        step="0.01"
+                                        placeholder="Enter quantity in tons"
+                                    />
+                                    <p className="text-xs text-muted-foreground">
+                                        Max: {maxQuantityTons.toFixed(2)} tons
+                                    </p>
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="bg-muted/50 p-4 rounded-lg space-y-2">
+                            <div className="flex justify-between items-center">
+                                <span className="text-sm text-muted-foreground">
+                                    Purchasing:
+                                </span>
+                                <span className="font-mono font-semibold">
+                                    {formatMass(purchaseQuantityTons * 1000)}
+                                </span>
+                            </div>
+                            <div className="border-t border-border pt-2 flex justify-between items-center">
+                                <span className="font-semibold text-lg">
+                                    Total Cost:
+                                </span>
+                                <span className="text-lg font-bold">
+                                    <Money amount={totalCost} />
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <DialogFooter>
+                        <DialogClose asChild>
                             <Button
-                                type="submit"
-                                form="purchase-form"
-                                variant={
-                                    purchaseMutation.isPending
-                                        ? "outline"
-                                        : "default"
-                                }
-                                disabled={
-                                    purchaseMutation.isPending ||
-                                    (!buyAll && !quantity)
-                                }
-                                className="flex items-center gap-2"
+                                variant="outline"
+                                disabled={purchaseMutation.isPending}
                             >
-                                {purchaseMutation.isPending && <Spinner />}
-                                Purchase
+                                Cancel
                             </Button>
-                        </DialogFooter>
-                    </DialogContent>
-                </form>
-            )}
+                        </DialogClose>
+                        <Button
+                            type="submit"
+                            form="purchase-form"
+                            variant={
+                                purchaseMutation.isPending ? "outline" : "default"
+                            }
+                            disabled={
+                                purchaseMutation.isPending ||
+                                (!buyAll && !quantity)
+                            }
+                            className="flex items-center gap-2"
+                        >
+                            {purchaseMutation.isPending && <Spinner />}
+                            Purchase
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </form>}
         </Dialog>
     );
 }

--- a/frontend/src/components/resource-market/purchase-dialog.tsx
+++ b/frontend/src/components/resource-market/purchase-dialog.tsx
@@ -31,7 +31,7 @@ export interface PurchaseDialogProps {
 export function PurchaseDialog({ isOpen, onClose, ask }: PurchaseDialogProps) {
     const [buyAll, setBuyAll] = useState(true);
     const [quantity, setQuantity] = useState(
-        (ask?.quantity ?? 0 / 1000).toString(),
+        (((ask?.quantity ?? 0) / 1000).toString()),
     );
 
     const purchaseMutation = usePurchaseAsk();
@@ -50,7 +50,7 @@ export function PurchaseDialog({ isOpen, onClose, ask }: PurchaseDialogProps) {
         }
     };
 
-    const maxQuantityTons = ask?.quantity ?? 0 / 1000;
+    const maxQuantityTons = (ask?.quantity ?? 0) / 1000;
     const purchaseQuantityTons = buyAll
         ? maxQuantityTons
         : parseFloat(quantity || "0");

--- a/frontend/src/components/technologies/technology-detail-dialog.tsx
+++ b/frontend/src/components/technologies/technology-detail-dialog.tsx
@@ -18,6 +18,7 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { TypographyH2 } from "@/components/ui/typography";
+import { useLastDefined } from "@/hooks/use-last-defined";
 import { useQueueProject } from "@/hooks/use-projects";
 import { getFacilityRoute } from "@/lib/facility-routes";
 import { ProjectType, Requirement } from "@/types/projects";
@@ -44,16 +45,13 @@ interface TechnologyDetailModalProps<T> {
     renderEffectsTable: (technology: T) => ReactNode;
 }
 
-/**
- * Modal displaying detailed technology information. Shows full specs,
- * requirements, research info, and action buttons.
- */
 export function TechnologyDetailDialog<T>({
     isOpen,
     onClose,
     technology,
     renderEffectsTable,
 }: TechnologyDetailModalProps<T>) {
+    const displayedTechnology = useLastDefined(technology);
     const queueProjectMutation = useQueueProject();
 
     const handleResearch = () => {
@@ -64,20 +62,20 @@ export function TechnologyDetailDialog<T>({
         onClose();
     };
 
-    const imageUrl = `/static/images/technologies/${technology?.name}.png`;
+    const imageUrl = `/static/images/technologies/${displayedTechnology?.name}.png`;
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
             <DialogContent className="flex flex-col p-0 gap-0 overflow-hidden max-w-4xl">
-                {technology === null ? null : (
+                {displayedTechnology !== null && (
                     <>
                         <DialogHeader className="sr-only">
                             <DialogTitle>
                                 <AssetName
-                                    assetId={technology.name}
+                                    assetId={displayedTechnology.name}
                                     mode="long"
                                 />
-                                {` Level ${technology.level}`}
+                                {` Level ${displayedTechnology.level}`}
                             </DialogTitle>
                             <DialogDescription>
                                 Technology details, requirements, and research
@@ -91,7 +89,7 @@ export function TechnologyDetailDialog<T>({
                             <div className="w-full overflow-hidden">
                                 <img
                                     src={imageUrl}
-                                    alt={`${technology.name} technology`}
+                                    alt={`${displayedTechnology.name} technology`}
                                     className="w-full aspect-[5/2] [@media(min-height:900px)]:aspect-[16/9] object-cover rounded-lg"
                                     onError={(e) => {
                                         e.currentTarget.style.display = "none";
@@ -103,16 +101,16 @@ export function TechnologyDetailDialog<T>({
                             <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
                                 <TypographyH2 className="flex items-center gap-2 mr-auto">
                                     <TechnologyIcon
-                                        technology={technology.name}
+                                        technology={displayedTechnology.name}
                                         size={28}
                                     />
                                     <AssetName
-                                        assetId={technology.name}
+                                        assetId={displayedTechnology.name}
                                         mode="long"
                                     />
                                 </TypographyH2>
                                 <p className="text-3xl text-muted-foreground">
-                                    Level {technology.level}
+                                    Level {displayedTechnology.level}
                                 </p>
                             </div>
 
@@ -122,12 +120,12 @@ export function TechnologyDetailDialog<T>({
                                     <div
                                         className="contents"
                                         dangerouslySetInnerHTML={{
-                                            __html: technology.description,
+                                            __html: displayedTechnology.description,
                                         }}
                                     />
                                 </div>
                                 <a
-                                    href={technology.wikipedia_link}
+                                    href={displayedTechnology.wikipedia_link}
                                     target="_blank"
                                     rel="noreferrer"
                                     className="flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground w-fit"
@@ -137,11 +135,11 @@ export function TechnologyDetailDialog<T>({
                                     Learn more
                                 </a>
                                 {/* Affected Facilities */}
-                                {technology.affected_facilities.length > 0 && (
+                                {displayedTechnology.affected_facilities.length > 0 && (
                                     <div>
                                         <strong>Affects:</strong>{" "}
                                         <span className="text-hyperlink">
-                                            {technology.affected_facilities.map(
+                                            {displayedTechnology.affected_facilities.map(
                                                 (facilityName, idx) => {
                                                     const route =
                                                         getFacilityRoute(
@@ -173,8 +171,7 @@ export function TechnologyDetailDialog<T>({
                                                                 />
                                                             )}
                                                             {idx <
-                                                                technology
-                                                                    .affected_facilities
+                                                                displayedTechnology.affected_facilities
                                                                     .length -
                                                                     1 && ", "}
                                                         </span>
@@ -188,7 +185,7 @@ export function TechnologyDetailDialog<T>({
 
                             {/* Effects Table */}
                             <CardContent className="flex justify-around">
-                                {renderEffectsTable(technology)}
+                                {renderEffectsTable(displayedTechnology)}
                             </CardContent>
                         </div>
 
@@ -196,19 +193,19 @@ export function TechnologyDetailDialog<T>({
                         <div className="shrink-0 border-t border-border bg-background px-6 py-4 flex flex-col gap-3">
                             {/* Construction info */}
                             <ConstructionInfo
-                                constructionTime={technology.construction_time}
+                                constructionTime={displayedTechnology.construction_time}
                                 constructionPower={
-                                    technology.construction_power
+                                    displayedTechnology.construction_power
                                 }
                                 className="w-full justify-evenly"
                             />
 
                             {/* Unlock requirements */}
-                            {technology.requirements.some(
+                            {displayedTechnology.requirements.some(
                                 (r) => r.status !== "satisfied",
                             ) && (
                                 <RequirementsDisplay
-                                    requirements={technology.requirements}
+                                    requirements={displayedTechnology.requirements}
                                 />
                             )}
 
@@ -216,19 +213,19 @@ export function TechnologyDetailDialog<T>({
                             <div className="flex items-center justify-around">
                                 <div className="flex items-center gap-2">
                                     <Money
-                                        amount={Math.round(technology.price)}
+                                        amount={Math.round(displayedTechnology.price)}
                                         long
                                         className="text-lg font-semibold"
                                     />
                                     {/* Knowledge spillover badge */}
-                                    {technology.discount && (
+                                    {displayedTechnology.discount && (
                                         <Tooltip>
                                             <TooltipTrigger asChild>
                                                 <span className="inline-flex items-center rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 px-2.5 py-1 text-sm font-semibold cursor-help select-none">
                                                     −
                                                     {Math.round(
                                                         (1 -
-                                                            technology.discount) *
+                                                            displayedTechnology.discount) *
                                                             100,
                                                     )}
                                                     %
@@ -254,21 +251,21 @@ export function TechnologyDetailDialog<T>({
                                     size="lg"
                                     onClick={handleResearch}
                                     disabled={
-                                        technology.requirements_status ===
+                                        displayedTechnology.requirements_status ===
                                         "unsatisfied"
                                     }
                                     variant={
-                                        technology.requirements_status ===
+                                        displayedTechnology.requirements_status ===
                                         "unsatisfied"
                                             ? "destructive"
                                             : "default"
                                     }
                                     className="px-8 text-base font-bold"
                                 >
-                                    {technology.requirements_status ===
+                                    {displayedTechnology.requirements_status ===
                                     "unsatisfied"
                                         ? "Locked"
-                                        : technology.requirements_status ===
+                                        : displayedTechnology.requirements_status ===
                                             "queued"
                                           ? "Queue Research"
                                           : "Start Research"}

--- a/frontend/src/hooks/use-last-defined.ts
+++ b/frontend/src/hooks/use-last-defined.ts
@@ -1,0 +1,7 @@
+import { useState } from "react";
+
+export function useLastDefined<T>(value: T | null): T | null {
+    const [last, setLast] = useState(value);
+    if (value !== null && value !== last) setLast(value);
+    return last;
+}


### PR DESCRIPTION
## Summary

Fixed operator precedence bugs in the resource market purchase dialog that caused the total cost to be calculated 1000× too high when using "Buy All".

## Problem

Due to missing parentheses, the division by 1000 was being ignored when calculating `maxQuantityTons`. This caused quantities to remain in kg instead of being converted to tonnes, resulting in the total cost calculation using incorrect units.

## Changes

- Fixed operator precedence on line 34 (initial quantity state)
- Fixed operator precedence on line 53 (maxQuantityTons calculation)

Both changes add proper parentheses to ensure `(quantity ?? 0) / 1000` is evaluated correctly.

## Testing

Tested locally with the dev server. The fix ensures:
- "Buy All" quantities are correctly calculated in tonnes
- Total cost uses consistent units (tonnes × $/kg × 1000 = $)
- Custom quantities continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the operator-precedence bug in `purchase-dialog.tsx` (`(ask?.quantity ?? 0) / 1000` vs `ask?.quantity ?? 0 / 1000`) that caused "Buy All" costs to be calculated 1000× too high. It also introduces a new `useLastDefined` hook applied across four dialogs to retain the last non-null prop value during close animations, and partially addresses the previously reported stale-state-on-reopen issue.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the operator-precedence fix is correct and the two P2 concerns do not affect runtime correctness.

No P0 or P1 issues found. The core bug fix is correct. Both flagged items are P2 style/best-practice concerns (setState-during-render anti-pattern) that cause extra renders but no incorrect behaviour.

`use-last-defined.ts` and `purchase-dialog.tsx` (lines 39-42) use the setState-during-render pattern; replacing with `useRef` / `useEffect` would be cleaner.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/hooks/use-last-defined.ts | New hook to retain the last non-null value; uses `useState` + calls setter during render (anti-pattern) rather than the simpler `useRef` approach. |
| frontend/src/components/resource-market/purchase-dialog.tsx | Core bug fix (operator precedence in `/1000` conversions) is correct; adopts `useLastDefined` for close-animation persistence, but resets `buyAll`/`quantity` during render rather than in a `useEffect`. |
| frontend/src/components/electricity-markets/market-detail-dialog.tsx | Adopts `useLastDefined` + refactors `MarketContent` to a proper JSX component; straightforward and correct. |
| frontend/src/components/facilities/facility-detail-dialog.tsx | Adds `useLastDefined` to retain last non-null facility during close animation; no logic changes. |
| frontend/src/components/technologies/technology-detail-dialog.tsx | Adds `useLastDefined` to retain last non-null technology during close animation; mechanical rename of `technology` → `displayedTechnology`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Parent passes ask prop"] --> B{"ask !== null?"}
    B -- "Yes" --> C["useLastDefined: setLast(ask)\n⚠ setState during render\n→ extra re-render"]
    B -- "No (dialog closing)" --> D["useLastDefined: return last\n(retains previous ask)"]
    C --> E{"ask !== displayedAsk?"}
    E -- "Yes (new listing)" --> F["setBuyAll / setQuantity\n⚠ setState during render\n→ extra re-render"]
    E -- "No" --> G["Render with current state"]
    F --> G
    D --> G
    G --> H["Compute maxQuantityTons\n= (displayedAsk?.quantity ?? 0) / 1000 ✅"]
    H --> I["totalCost = tons × unit_price × 1000 ✅"]
    I --> J["Render dialog UI"]
    J --> K{"User submits?"}
    K -- "ask === null (guard)" --> L["Early return — no purchase"]
    K -- "ask !== null" --> M["mutateAsync with ask.id"]
```

<sub>Reviews (2): Last reviewed commit: ["fix: restore dialog exit animations brok..."](https://github.com/felixvonsamson/energetica/commit/c954123fd7180e999a8492b1cfd6fea1aa3b6ec7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30567128)</sub>

<!-- /greptile_comment -->