### PR TITLE
chore: tell claude that it can format code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,9 @@ Deprecated Frontend: Deprecated Jinja `energetica/templates/`
 
 ## package.json scripts
 
-- `bun run typecheck`
-- `bun run lint`
+- `bun run typecheck` 
+- `bun run format` and `bun run lint` - run both to these before committing
 - `bun run generate-types`
-- `bun run format`
 
 ## Python env
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Deprecated Frontend: Deprecated Jinja `energetica/templates/`
 - `bun run typecheck`
 - `bun run lint`
 - `bun run generate-types`
+- `bun run format`
 
 ## Python env
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Deprecated Frontend: Deprecated Jinja `energetica/templates/`
 ## package.json scripts
 
 - `bun run typecheck` 
-- `bun run format` and `bun run lint` - run both to these before committing
+- `bun run format` and `bun run lint` - run both before committing
 - `bun run generate-types`
 
 ## Python env


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `CLAUDE.md` to instruct Claude Code to run `bun run format` in addition to `bun run lint` before committing. The `format` script is confirmed to exist in `package.json` (delegates to `cd frontend && bun run format`). The change is accurate and straightforward.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no runtime impact.

Single documentation file updated; the referenced `bun run format` script exists in package.json and correctly delegates to the frontend formatter. No logic, security, or functionality is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Adds `bun run format` to the pre-commit instruction alongside `bun run lint`; the script exists in package.json. Minor trailing space added on the `typecheck` line. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Before committing] --> B[bun run typecheck]
    A --> C[bun run format]
    A --> D[bun run lint]
    C --> E[cd frontend && bun run format]
    D --> F[cd frontend && bun run lint]
```

<sub>Reviews (3): Last reviewed commit: ["Update CLAUDE.md"](https://github.com/felixvonsamson/energetica/commit/fe07350ed8d1ad4cda8500a8eb5bec9909f1463e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30569684)</sub>

<!-- /greptile_comment -->