### PR TITLE
feat: persist message drafts to localStorage per conversation

### DIFF
--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -87,6 +87,7 @@ export function ChatWindow({
                             onSend={onSend}
                             isDisabled={!selectedChat}
                             isDialogOpen={isDialogOpen}
+                            chatId={selectedChatId}
                         />
                     )}
                 </div>

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -84,6 +84,7 @@ export function ChatWindow({
 
                     {selectedChatId && (
                         <MessageInput
+                            key={selectedChatId}
                             onSend={onSend}
                             isDisabled={!selectedChat}
                             isDialogOpen={isDialogOpen}

--- a/frontend/src/components/chat/message-input.tsx
+++ b/frontend/src/components/chat/message-input.tsx
@@ -9,12 +9,18 @@ interface MessageInputProps {
     onSend: (text: string, playerId: number) => Promise<void>;
     isDisabled: boolean;
     isDialogOpen: boolean;
+    chatId: number;
 }
 
-export function MessageInput({ onSend, isDisabled, isDialogOpen }: MessageInputProps) {
-    const [message, setMessage] = useState("");
+export function MessageInput({ onSend, isDisabled, isDialogOpen, chatId }: MessageInputProps) {
+    const draftKey = `chat-draft-${chatId}`;
+    const [message, setMessage] = useState(() => localStorage.getItem(`chat-draft-${chatId}`) ?? "");
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const { user } = useAuth();
+
+    useEffect(() => {
+        setMessage(localStorage.getItem(`chat-draft-${chatId}`) ?? "");
+    }, [chatId]);
 
     const adjustHeight = useCallback(() => {
         const textarea = inputRef.current;
@@ -24,10 +30,22 @@ export function MessageInput({ onSend, isDisabled, isDialogOpen }: MessageInputP
         }
     }, []);
 
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const value = e.target.value;
+        setMessage(value);
+        if (value) {
+            localStorage.setItem(draftKey, value);
+        } else {
+            localStorage.removeItem(draftKey);
+        }
+        adjustHeight();
+    };
+
     const handleSend = async () => {
         if (!message.trim() || !user?.player_id) return;
         const messageText = message;
         setMessage("");
+        localStorage.removeItem(draftKey);
         if (inputRef.current) {
             inputRef.current.style.height = "auto";
             inputRef.current.focus();
@@ -36,6 +54,7 @@ export function MessageInput({ onSend, isDisabled, isDialogOpen }: MessageInputP
             await onSend(messageText, user.player_id);
         } catch (err) {
             setMessage(messageText);
+            localStorage.setItem(draftKey, messageText);
             toast.error(resolveErrorMessage(err));
         }
     };
@@ -62,10 +81,7 @@ export function MessageInput({ onSend, isDisabled, isDialogOpen }: MessageInputP
             <textarea
                 ref={inputRef}
                 value={message}
-                onChange={(e) => {
-                    setMessage(e.target.value);
-                    adjustHeight();
-                }}
+                onChange={handleChange}
                 onKeyDown={handleKeyDown}
                 placeholder="Type your message..."
                 disabled={isDisabled}

--- a/frontend/src/components/chat/message-input.tsx
+++ b/frontend/src/components/chat/message-input.tsx
@@ -26,16 +26,23 @@ export function MessageInput({ onSend, isDisabled, isDialogOpen, chatId }: Messa
         }
     }, []);
 
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        const value = e.target.value;
-        setMessage(value);
-        if (value) {
-            localStorage.setItem(draftKey, value);
-        } else {
-            localStorage.removeItem(draftKey);
-        }
-        adjustHeight();
-    };
+    const handleChange = useCallback(
+        (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            const value = e.target.value;
+            setMessage(value);
+            try {
+                if (value) {
+                    localStorage.setItem(draftKey, value);
+                } else {
+                    localStorage.removeItem(draftKey);
+                }
+            } catch {
+                // ignore QuotaExceededError
+            }
+            adjustHeight();
+        },
+        [draftKey, adjustHeight],
+    );
 
     const handleSend = async () => {
         if (!message.trim() || !user?.player_id) return;
@@ -50,7 +57,11 @@ export function MessageInput({ onSend, isDisabled, isDialogOpen, chatId }: Messa
             await onSend(messageText, user.player_id);
         } catch (err) {
             setMessage(messageText);
-            localStorage.setItem(draftKey, messageText);
+            try {
+                localStorage.setItem(draftKey, messageText);
+            } catch {
+                // ignore QuotaExceededError
+            }
             toast.error(resolveErrorMessage(err));
         }
     };

--- a/frontend/src/components/chat/message-input.tsx
+++ b/frontend/src/components/chat/message-input.tsx
@@ -18,10 +18,6 @@ export function MessageInput({ onSend, isDisabled, isDialogOpen, chatId }: Messa
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const { user } = useAuth();
 
-    useEffect(() => {
-        setMessage(localStorage.getItem(`chat-draft-${chatId}`) ?? "");
-    }, [chatId]);
-
     const adjustHeight = useCallback(() => {
         const textarea = inputRef.current;
         if (textarea) {

--- a/frontend/src/components/chat/message-input.tsx
+++ b/frontend/src/components/chat/message-input.tsx
@@ -14,7 +14,7 @@ interface MessageInputProps {
 
 export function MessageInput({ onSend, isDisabled, isDialogOpen, chatId }: MessageInputProps) {
     const draftKey = `chat-draft-${chatId}`;
-    const [message, setMessage] = useState(() => localStorage.getItem(`chat-draft-${chatId}`) ?? "");
+    const [message, setMessage] = useState(() => localStorage.getItem(draftKey) ?? "");
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const { user } = useAuth();
 


### PR DESCRIPTION
Closes #658

## Summary
- Drafts are saved to `localStorage` under `chat-draft-<chatId>` as you type
- Switching conversations loads the draft for that conversation
- Drafts are cleared on successful send and restored on send failure

## Test plan
- [ ] Type a draft in one conversation, switch to another, switch back — draft is restored
- [ ] Send a message — draft is cleared
- [ ] Navigate away from the messages page and return — draft is still there
- [ ] Refresh the page — draft is still there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-conversation message draft persistence using `localStorage`, restoring drafts when switching back to a conversation and clearing them on successful send (restoring on failure). The `key` prop on `MessageInput` correctly forces a remount on conversation switch so the lazy `useState` initializer picks up the right draft. All issues from the previous review round — missing `useCallback`, unhandled storage quota errors, and duplicate `localStorage` reads — have been addressed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — implementation is correct and all prior review feedback has been addressed.

No P0 or P1 issues. The only finding is a P2 (draft keys not scoped to the logged-in user, which could leak drafts on shared devices). The core logic — lazy initializer, useCallback, error handling, remount-on-switch — is all sound.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/chat/message-input.tsx | Adds per-chat draft persistence via localStorage; all previous review concerns (useCallback, QuotaExceededError, duplicate reads) are now addressed. One minor P2: drafts are not scoped to the logged-in user. |
| frontend/src/components/chat/chat-window.tsx | Passes chatId prop and adds key prop to MessageInput to force remount on conversation switch — correct pattern for isolating draft state per conversation. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Apply suggestions from code review"](https://github.com/felixvonsamson/energetica/commit/f527462b85404b2af8e140a841d90f025fdd2e07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30569800)</sub>

<!-- /greptile_comment -->