### PR TITLE
feat: per-chat mute toggle for push notifications

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -196,8 +196,6 @@ class Player(DBModel):
             }
         if not hasattr(self, "push_subscriptions"):
             self.push_subscriptions = []
-        if not hasattr(self, "muted_chat_ids"):
-            self.muted_chat_ids = {engine.general_chat_id}
         if not hasattr(self, "overdraft_warning_sent"):
             self.overdraft_warning_sent = False
         # Migrate old notification_opt_ins field

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -85,6 +85,7 @@ class Player(DBModel):
     # inactive: bool = False  # True if account is inactive
     show_chat_disclaimer: bool = True
     last_opened_chat_id: int = field(default_factory=lambda: engine.general_chat.id)
+    muted_chat_ids: set[int] = field(default_factory=lambda: {engine.general_chat_id})
 
     network: Network | None = None
 
@@ -195,6 +196,8 @@ class Player(DBModel):
             }
         if not hasattr(self, "push_subscriptions"):
             self.push_subscriptions = []
+        if not hasattr(self, "muted_chat_ids"):
+            self.muted_chat_ids = {engine.general_chat_id}
         if not hasattr(self, "overdraft_warning_sent"):
             self.overdraft_warning_sent = False
         # Migrate old notification_opt_ins field

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -250,7 +250,14 @@ class GameEngine(object):
             for member, member_data in data.items():
                 setattr(self, member, member_data)
         from energetica.database.active_facility import ActiveFacility  # late import to avoid circular dependency
+        from energetica.database.player import Player  # late import to avoid circular dependency
+
         ActiveFacility.rebuild_index()
+        # Migrate muted_chat_ids here rather than in Player.__setstate__ because
+        # engine.general_chat_id is still None when __setstate__ runs during pickle.load().
+        for player in Player.all():
+            if not hasattr(player, "muted_chat_ids"):
+                player.muted_chat_ids = {self.general_chat_id}
 
     def save_checkpoint(self, destination_filename: str = "checkpoints/last_checkpoint.tar.gz") -> None:
         self.save()

--- a/energetica/routers/chats.py
+++ b/energetica/routers/chats.py
@@ -75,6 +75,30 @@ def open_chat(  # noqa: ANN201
     chat.open_for_player(player)
 
 
+@router.post("/{chat_id}:mute", status_code=status.HTTP_204_NO_CONTENT)
+def mute_chat(  # noqa: ANN201
+    player: Annotated[Player, Depends(get_settled_player)],
+    chat_id: int,
+):
+    """Mute push notifications for a chat."""
+    chat = Chat.getitem(chat_id, error=HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found"))
+    if player not in chat.participants:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not a participant in this chat")
+    player.muted_chat_ids.add(chat_id)
+
+
+@router.post("/{chat_id}:unmute", status_code=status.HTTP_204_NO_CONTENT)
+def unmute_chat(  # noqa: ANN201
+    player: Annotated[Player, Depends(get_settled_player)],
+    chat_id: int,
+):
+    """Unmute push notifications for a chat."""
+    chat = Chat.getitem(chat_id, error=HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat not found"))
+    if player not in chat.participants:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You are not a participant in this chat")
+    player.muted_chat_ids.discard(chat_id)
+
+
 @router.post("", status_code=status.HTTP_201_CREATED)
 def create_group_chat(
     player: Annotated[Player, Depends(get_settled_player)],

--- a/energetica/routers/chats.py
+++ b/energetica/routers/chats.py
@@ -22,6 +22,7 @@ def get_chat_list(player: Annotated[Player, Depends(get_settled_player)]) -> Cha
         chats=[ChatOut.from_chat(player, chat) for chat in Chat.filter(lambda chat: player in chat.participants)],
         last_opened_chat_id=player.last_opened_chat_id,
         unread_chat_count=player.unread_chat_count(),
+        has_push_subscription=bool(player.push_subscriptions),
     )
 
 

--- a/energetica/schemas/chats.py
+++ b/energetica/schemas/chats.py
@@ -27,6 +27,7 @@ class ChatOut(BaseModel):
     is_group: bool
     unread_messages_count: int
     participant_ids: list[int]
+    is_muted: bool
 
     @classmethod
     def from_chat(cls, player: Player, chat: Chat) -> ChatOut:
@@ -37,6 +38,7 @@ class ChatOut(BaseModel):
             is_group=chat.is_group(),
             unread_messages_count=chat.unread_messages_count_for_player(player),
             participant_ids=sorted([p.id for p in chat.participants]),
+            is_muted=chat.id in player.muted_chat_ids,
         )
 
 

--- a/energetica/schemas/chats.py
+++ b/energetica/schemas/chats.py
@@ -16,6 +16,7 @@ class ChatListOut(BaseModel):
     chats: list[ChatOut]
     last_opened_chat_id: int
     unread_chat_count: int
+    has_push_subscription: bool
 
 
 class ChatOut(BaseModel):

--- a/energetica/utils/chat.py
+++ b/energetica/utils/chat.py
@@ -79,7 +79,8 @@ def add_message(player: Player, message_text: str, chat: Chat) -> Message:
         # Ensure the "unread chats" is updated
         if participant != player:
             participant.invalidate_queries(["chats"])
-            participant.push_only(payload)
+            if chat.id not in participant.muted_chat_ids:
+                participant.push_only(payload)
 
         participant.invalidate_queries(
             ["chats"],

--- a/frontend/src/components/chat/chat-list-item.tsx
+++ b/frontend/src/components/chat/chat-list-item.tsx
@@ -1,3 +1,5 @@
+import { BellOff } from "lucide-react";
+
 import { PlayerName } from "@/components/ui/player-name";
 import { useMyId, usePlayerMap } from "@/hooks/use-players";
 import type { Chat } from "@/types/chats";
@@ -35,11 +37,16 @@ export function ChatListItem({ chat, isSelected, onClick }: ChatListItemProps) {
                         chat.display_name
                     )}
                 </span>
-                {chat.unread_messages_count > 0 && (
-                    <span className="bg-red-500 text-white text-xs px-2 py-1 rounded-full shrink-0">
-                        {chat.unread_messages_count}
-                    </span>
-                )}
+                <div className="flex items-center gap-1 shrink-0">
+                    {chat.is_muted && (
+                        <BellOff className="w-3.5 h-3.5 text-muted-foreground" />
+                    )}
+                    {chat.unread_messages_count > 0 && (
+                        <span className="bg-red-500 text-white text-xs px-2 py-1 rounded-full">
+                            {chat.unread_messages_count}
+                        </span>
+                    )}
+                </div>
             </div>
         </button>
     );

--- a/frontend/src/components/chat/chat-list-item.tsx
+++ b/frontend/src/components/chat/chat-list-item.tsx
@@ -1,6 +1,11 @@
 import { BellOff } from "lucide-react";
 
 import { PlayerName } from "@/components/ui/player-name";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useMyId, usePlayerMap } from "@/hooks/use-players";
 import type { Chat } from "@/types/chats";
 
@@ -45,7 +50,14 @@ export function ChatListItem({
                 </span>
                 <div className="flex items-center gap-1 shrink-0">
                     {isPushEnabled && chat.is_muted && (
-                        <BellOff className="w-3.5 h-3.5 opacity-60" />
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <BellOff className="w-3.5 h-3.5 opacity-60" />
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                Notifications muted
+                            </TooltipContent>
+                        </Tooltip>
                     )}
                     {chat.unread_messages_count > 0 && (
                         <span className="bg-red-500 text-white text-xs px-2 py-1 rounded-full">

--- a/frontend/src/components/chat/chat-list-item.tsx
+++ b/frontend/src/components/chat/chat-list-item.tsx
@@ -8,9 +8,15 @@ interface ChatListItemProps {
     chat: Chat;
     isSelected: boolean;
     onClick: () => void;
+    isPushEnabled: boolean;
 }
 
-export function ChatListItem({ chat, isSelected, onClick }: ChatListItemProps) {
+export function ChatListItem({
+    chat,
+    isSelected,
+    onClick,
+    isPushEnabled,
+}: ChatListItemProps) {
     const myId = useMyId();
     const playerMap = usePlayerMap();
     const otherPlayer =
@@ -38,7 +44,7 @@ export function ChatListItem({ chat, isSelected, onClick }: ChatListItemProps) {
                     )}
                 </span>
                 <div className="flex items-center gap-1 shrink-0">
-                    {chat.is_muted && (
+                    {isPushEnabled && chat.is_muted && (
                         <BellOff className="w-3.5 h-3.5 opacity-60" />
                     )}
                     {chat.unread_messages_count > 0 && (

--- a/frontend/src/components/chat/chat-list-item.tsx
+++ b/frontend/src/components/chat/chat-list-item.tsx
@@ -55,7 +55,7 @@ export function ChatListItem({
                                 <BellOff className="w-3.5 h-3.5 opacity-60" />
                             </TooltipTrigger>
                             <TooltipContent>
-                                Notifications muted
+                                Push notifications muted
                             </TooltipContent>
                         </Tooltip>
                     )}

--- a/frontend/src/components/chat/chat-list-item.tsx
+++ b/frontend/src/components/chat/chat-list-item.tsx
@@ -29,7 +29,7 @@ export function ChatListItem({ chat, isSelected, onClick }: ChatListItemProps) {
                     : "hover:bg-gray-100 dark:hover:bg-muted"
             }`}
         >
-            <div className="flex justify-between items-start gap-2">
+            <div className="flex justify-between items-center gap-2">
                 <span className="font-medium truncate flex-1">
                     {otherPlayer ? (
                         <PlayerName player={otherPlayer} />
@@ -39,7 +39,7 @@ export function ChatListItem({ chat, isSelected, onClick }: ChatListItemProps) {
                 </span>
                 <div className="flex items-center gap-1 shrink-0">
                     {chat.is_muted && (
-                        <BellOff className="w-3.5 h-3.5 text-muted-foreground" />
+                        <BellOff className="w-3.5 h-3.5 opacity-60" />
                     )}
                     {chat.unread_messages_count > 0 && (
                         <span className="bg-red-500 text-white text-xs px-2 py-1 rounded-full">

--- a/frontend/src/components/chat/chat-sidebar.tsx
+++ b/frontend/src/components/chat/chat-sidebar.tsx
@@ -18,6 +18,7 @@ interface ChatSidebarProps {
     onChatSelect: (chatId: number) => void;
     onNewChatClick: () => void;
     onNewGroupChatClick: () => void;
+    isPushEnabled: boolean;
 }
 
 export function ChatSidebar({
@@ -27,6 +28,7 @@ export function ChatSidebar({
     onChatSelect,
     onNewChatClick,
     onNewGroupChatClick,
+    isPushEnabled,
 }: ChatSidebarProps) {
     return (
         <div className="w-full lg:w-72 flex flex-col gap-4">
@@ -56,6 +58,7 @@ export function ChatSidebar({
                                     chat={chat}
                                     isSelected={selectedChatId === chat.id}
                                     onClick={() => onChatSelect(chat.id)}
+                                    isPushEnabled={isPushEnabled}
                                 />
                             ))
                         )}

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -83,12 +83,15 @@ export function ChatWindow({
                         {selectedChat && (
                             <button
                                 onClick={handleMuteToggle}
+                                disabled={
+                                    muteChat.isPending || unmuteChat.isPending
+                                }
                                 aria-label={
                                     selectedChat.is_muted
                                         ? "Unmute notifications"
                                         : "Mute notifications"
                                 }
-                                className="shrink-0 p-2 hover:bg-gray-100 dark:hover:bg-muted rounded-lg transition-colors text-muted-foreground"
+                                className="shrink-0 p-2 hover:bg-gray-100 dark:hover:bg-muted rounded-lg transition-colors text-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 {selectedChat.is_muted ? (
                                     <BellOff className="w-5 h-5" />

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -1,9 +1,10 @@
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Bell, BellOff } from "lucide-react";
 
 import { MessageContainer } from "@/components/chat/message-container";
 import { MessageInput } from "@/components/chat/message-input";
 import { PlayerName } from "@/components/ui/player-name";
 import { TypographyH2 } from "@/components/ui/typography";
+import { useMuteChat, useUnmuteChat } from "@/hooks/use-chats";
 import { useMyId, usePlayerMap } from "@/hooks/use-players";
 import type { Message, Chat } from "@/types/chats";
 
@@ -36,12 +37,24 @@ export function ChatWindow({
 }: ChatWindowProps) {
     const myId = useMyId();
     const playerMap = usePlayerMap();
+    const muteChat = useMuteChat();
+    const unmuteChat = useUnmuteChat();
+
     const otherPlayer =
         selectedChat && !selectedChat.is_group && myId && playerMap
             ? (playerMap[
                   selectedChat.participant_ids.find((id) => id !== myId) ?? -1
               ] ?? null)
             : null;
+
+    const handleMuteToggle = () => {
+        if (!selectedChatId || !selectedChat) return;
+        if (selectedChat.is_muted) {
+            unmuteChat.mutate(selectedChatId);
+        } else {
+            muteChat.mutate(selectedChatId);
+        }
+    };
 
     return (
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -67,6 +80,23 @@ export function ChatWindow({
                                 "Select a chat"
                             )}
                         </TypographyH2>
+                        {selectedChat && (
+                            <button
+                                onClick={handleMuteToggle}
+                                aria-label={
+                                    selectedChat.is_muted
+                                        ? "Unmute notifications"
+                                        : "Mute notifications"
+                                }
+                                className="shrink-0 p-2 hover:bg-gray-100 dark:hover:bg-muted rounded-lg transition-colors text-muted-foreground"
+                            >
+                                {selectedChat.is_muted ? (
+                                    <BellOff className="w-5 h-5" />
+                                ) : (
+                                    <Bell className="w-5 h-5" />
+                                )}
+                            </button>
+                        )}
                     </div>
                 </div>
 

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft, Bell, BellOff } from "lucide-react";
 
 import { MessageContainer } from "@/components/chat/message-container";
 import { MessageInput } from "@/components/chat/message-input";
+import { Button } from "@/components/ui/button";
 import { PlayerName } from "@/components/ui/player-name";
 import { TypographyH2 } from "@/components/ui/typography";
 import { useMuteChat, useUnmuteChat } from "@/hooks/use-chats";
@@ -81,24 +82,26 @@ export function ChatWindow({
                             )}
                         </TypographyH2>
                         {selectedChat && (
-                            <button
+                            <Button
                                 onClick={handleMuteToggle}
                                 disabled={
                                     muteChat.isPending || unmuteChat.isPending
                                 }
+                                variant="outline"
+                                size="icon"
                                 aria-label={
                                     selectedChat.is_muted
                                         ? "Unmute notifications"
                                         : "Mute notifications"
                                 }
-                                className="shrink-0 p-2 hover:bg-gray-100 dark:hover:bg-muted rounded-lg transition-colors text-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="shrink-0"
                             >
                                 {selectedChat.is_muted ? (
                                     <BellOff className="w-5 h-5" />
                                 ) : (
                                     <Bell className="w-5 h-5" />
                                 )}
-                            </button>
+                            </Button>
                         )}
                     </div>
                 </div>

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -21,6 +21,7 @@ interface ChatWindowProps {
     isDialogOpen: boolean;
     onBackClick?: () => void;
     showBackButton?: boolean;
+    isPushEnabled: boolean;
 }
 
 export function ChatWindow({
@@ -35,6 +36,7 @@ export function ChatWindow({
     isDialogOpen,
     onBackClick,
     showBackButton,
+    isPushEnabled,
 }: ChatWindowProps) {
     const myId = useMyId();
     const playerMap = usePlayerMap();
@@ -81,7 +83,7 @@ export function ChatWindow({
                                 "Select a chat"
                             )}
                         </TypographyH2>
-                        {selectedChat && (
+                        {isPushEnabled && selectedChat && (
                             <Button
                                 onClick={handleMuteToggle}
                                 disabled={
@@ -120,6 +122,7 @@ export function ChatWindow({
 
                     {selectedChatId && (
                         <MessageInput
+                            key={selectedChatId}
                             onSend={onSend}
                             isDisabled={!selectedChat}
                             isDialogOpen={isDialogOpen}

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -101,8 +101,8 @@ export function ChatWindow({
                                         size="icon"
                                         aria-label={
                                             selectedChat.is_muted
-                                                ? "Unmute notifications"
-                                                : "Mute notifications"
+                                                ? "Unmute push notifications for this chat"
+                                                : "Mute push notifications for this chat"
                                         }
                                         className="shrink-0"
                                     >
@@ -115,8 +115,8 @@ export function ChatWindow({
                                 </TooltipTrigger>
                                 <TooltipContent>
                                     {selectedChat.is_muted
-                                        ? "Unmute notifications"
-                                        : "Mute notifications"}
+                                        ? "Unmute push notifications for this chat"
+                                        : "Mute push notifications for this chat"}
                                 </TooltipContent>
                             </Tooltip>
                         )}

--- a/frontend/src/components/chat/chat-window.tsx
+++ b/frontend/src/components/chat/chat-window.tsx
@@ -4,6 +4,11 @@ import { MessageContainer } from "@/components/chat/message-container";
 import { MessageInput } from "@/components/chat/message-input";
 import { Button } from "@/components/ui/button";
 import { PlayerName } from "@/components/ui/player-name";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { TypographyH2 } from "@/components/ui/typography";
 import { useMuteChat, useUnmuteChat } from "@/hooks/use-chats";
 import { useMyId, usePlayerMap } from "@/hooks/use-players";
@@ -84,26 +89,36 @@ export function ChatWindow({
                             )}
                         </TypographyH2>
                         {isPushEnabled && selectedChat && (
-                            <Button
-                                onClick={handleMuteToggle}
-                                disabled={
-                                    muteChat.isPending || unmuteChat.isPending
-                                }
-                                variant="outline"
-                                size="icon"
-                                aria-label={
-                                    selectedChat.is_muted
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        onClick={handleMuteToggle}
+                                        disabled={
+                                            muteChat.isPending ||
+                                            unmuteChat.isPending
+                                        }
+                                        variant="outline"
+                                        size="icon"
+                                        aria-label={
+                                            selectedChat.is_muted
+                                                ? "Unmute notifications"
+                                                : "Mute notifications"
+                                        }
+                                        className="shrink-0"
+                                    >
+                                        {selectedChat.is_muted ? (
+                                            <BellOff className="w-5 h-5" />
+                                        ) : (
+                                            <Bell className="w-5 h-5" />
+                                        )}
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    {selectedChat.is_muted
                                         ? "Unmute notifications"
-                                        : "Mute notifications"
-                                }
-                                className="shrink-0"
-                            >
-                                {selectedChat.is_muted ? (
-                                    <BellOff className="w-5 h-5" />
-                                ) : (
-                                    <Bell className="w-5 h-5" />
-                                )}
-                            </Button>
+                                        : "Mute notifications"}
+                                </TooltipContent>
+                            </Tooltip>
                         )}
                     </div>
                 </div>

--- a/frontend/src/hooks/use-chats.ts
+++ b/frontend/src/hooks/use-chats.ts
@@ -63,7 +63,8 @@ export function useChatMessages(chatId: number | null) {
     }, [chatId]);
 
     const loadMore = useCallback(async () => {
-        if (!chatId || !hasMore || isLoadingMore || messages.length === 0) return;
+        if (!chatId || !hasMore || isLoadingMore || messages.length === 0)
+            return;
         const oldestId = messages[0]?.id;
         if (oldestId === undefined) return;
         setIsLoadingMore(true);
@@ -82,7 +83,10 @@ export function useChatMessages(chatId: number | null) {
         setMessages((prev) => [...prev, message]);
     }, []);
 
-    /** Send a message with optimistic UI. Throws on error so the caller can restore input. */
+    /**
+     * Send a message with optimistic UI. Throws on error so the caller can
+     * restore input.
+     */
     const sendMessage = useCallback(
         async (text: string, playerId: number): Promise<void> => {
             if (!chatId) return;
@@ -103,7 +107,9 @@ export function useChatMessages(chatId: number | null) {
                 setMessages((prev) =>
                     prev.map((m) => (m.id === tempId ? realMessage : m)),
                 );
-                queryClient.invalidateQueries({ queryKey: queryKeys.chats.list });
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.chats.list,
+                });
             } catch (err) {
                 setMessages((prev) => prev.filter((m) => m.id !== tempId));
                 throw err;
@@ -112,7 +118,15 @@ export function useChatMessages(chatId: number | null) {
         [chatId],
     );
 
-    return { messages, hasMore, isLoading, isLoadingMore, loadMore, addMessage, sendMessage };
+    return {
+        messages,
+        hasMore,
+        isLoading,
+        isLoadingMore,
+        loadMore,
+        addMessage,
+        sendMessage,
+    };
 }
 
 export function useCreateGroupChat() {
@@ -133,6 +147,30 @@ export function useOpenChat() {
             chatsApi.openChat(chatId),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: queryKeys.chats.list });
+        },
+    });
+}
+
+export function useMuteChat() {
+    return useMutation<void, Error, number>({
+        mutationFn: chatsApi.muteChat,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.chats.list });
+        },
+        onError: () => {
+            toast.error("Failed to mute chat");
+        },
+    });
+}
+
+export function useUnmuteChat() {
+    return useMutation<void, Error, number>({
+        mutationFn: chatsApi.unmuteChat,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.chats.list });
+        },
+        onError: () => {
+            toast.error("Failed to unmute chat");
         },
     });
 }

--- a/frontend/src/lib/api/chats.ts
+++ b/frontend/src/lib/api/chats.ts
@@ -8,7 +8,10 @@ export const chatsApi = {
     getChatList: () =>
         apiClient.get<ApiResponse<"/api/v1/chats", "get">>("/chats"),
 
-    /** Get messages for a chat. Fetches the latest 50, or 50 before `before` message id. */
+    /**
+     * Get messages for a chat. Fetches the latest 50, or 50 before `before`
+     * message id.
+     */
     getChatMessages: (chatId: number, before?: number) =>
         apiClient.get<ApiResponse<"/api/v1/chats/{chat_id}/messages", "get">>(
             `/chats/${chatId}/messages`,
@@ -33,5 +36,17 @@ export const chatsApi = {
     openChat: (chatId: number) =>
         apiClient.post<ApiResponse<"/api/v1/chats/{chat_id}:open", "post">>(
             `/chats/${chatId}:open`,
+        ),
+
+    /** Mute push notifications for a chat. */
+    muteChat: (chatId: number) =>
+        apiClient.post<ApiResponse<"/api/v1/chats/{chat_id}:mute", "post">>(
+            `/chats/${chatId}:mute`,
+        ),
+
+    /** Unmute push notifications for a chat. */
+    unmuteChat: (chatId: number) =>
+        apiClient.post<ApiResponse<"/api/v1/chats/{chat_id}:unmute", "post">>(
+            `/chats/${chatId}:unmute`,
         ),
 };

--- a/frontend/src/routes/app/community/messages.tsx
+++ b/frontend/src/routes/app/community/messages.tsx
@@ -106,6 +106,8 @@ function MessagesContent() {
         openChat,
     } = useMessagesPage();
 
+    const isPushEnabled = chatListData?.has_push_subscription ?? false;
+
     const handleChatSelect = (chatId: number) => {
         setSelectedChatId(chatId);
         openChat(chatId);
@@ -155,6 +157,7 @@ function MessagesContent() {
                         onChatSelect={handleChatSelect}
                         onNewChatClick={() => setShowNewChatDialog(true)}
                         onNewGroupChatClick={() => setShowGroupChatDialog(true)}
+                        isPushEnabled={isPushEnabled}
                     />
                 )}
 
@@ -172,6 +175,7 @@ function MessagesContent() {
                         isDialogOpen={showNewChatDialog || showGroupChatDialog}
                         onBackClick={handleBackToList}
                         showBackButton={showMobileChatView && isMobile}
+                        isPushEnabled={isPushEnabled}
                     />
                 )}
             </div>

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -789,6 +789,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/chats/{chat_id}:mute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mute Chat
+         *
+         * Mute push notifications for a chat.
+         */
+        post: operations["mute_chat_api_v1_chats__chat_id__mute_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/chats/{chat_id}:unmute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unmute Chat
+         *
+         * Unmute push notifications for a chat.
+         */
+        post: operations["unmute_chat_api_v1_chats__chat_id__unmute_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/daily-quiz": {
         parameters: {
             query?: never;
@@ -2280,6 +2322,8 @@ export interface components {
             unread_messages_count: number;
             /** Participant Ids */
             participant_ids: number[];
+            /** Is Muted */
+            is_muted: boolean;
         };
         /**
          * ClimateDataResponse
@@ -5797,6 +5841,64 @@ export interface operations {
         };
     };
     open_chat_api_v1_chats__chat_id__open_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    mute_chat_api_v1_chats__chat_id__mute_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unmute_chat_api_v1_chats__chat_id__unmute_post: {
         parameters: {
             query?: never;
             header?: never;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2303,6 +2303,8 @@ export interface components {
             last_opened_chat_id: number;
             /** Unread Chat Count */
             unread_chat_count: number;
+            /** Has Push Subscription */
+            has_push_subscription: boolean;
         };
         /**
          * ChatOut


### PR DESCRIPTION
Closes #713

## Summary
- Adds `muted_chat_ids: set[int]` to `Player` (defaults to `{general_chat_id}` for all players)
- New `POST /chats/{id}:mute` and `POST /chats/{id}:unmute` endpoints
- `add_message()` skips `push_only()` for participants who have muted the chat
- Bell/BellOff toggle button in the chat header; BellOff indicator in the chat list item

## Test plan
- [ ] General chat has push notifications muted by default for new and existing players
- [ ] Clicking the bell in a chat header mutes/unmutes correctly and persists on reload
- [ ] BellOff icon appears in the sidebar for muted chats
- [ ] Sending a message does not trigger a push notification for muted participants
- [ ] Sending a message still triggers a push notification for non-muted participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-chat push-notification muting: a `muted_chat_ids: set[int]` field on `Player` (defaulting to `{general_chat_id}`), two new mute/unmute REST endpoints, a skip of `push_only()` in `add_message` for muted participants, and a Bell/BellOff toggle in the chat UI. Both issues flagged in the previous review round (the `None`-seeded migration and the missing pending guard on the mute button) have been correctly addressed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues remain; only a minor style inconsistency in the default_factory expression.

All previously flagged P1s are resolved: migration is correctly placed in `game_engine.load()` after the setattr loop so `general_chat_id` is a valid int, and the mute-button pending guard prevents duplicate mutations. The single remaining finding is a cosmetic accessor inconsistency (P2) that does not affect runtime behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/game_engine.py | Migration for `muted_chat_ids` correctly placed after `pickle.load()` completes and all engine attributes (including `general_chat_id`) are restored via the setattr loop, avoiding the `None` issue that would arise in `__setstate__`. |
| energetica/database/player.py | Adds `muted_chat_ids` field; default factory uses `engine.general_chat_id` (the stored int) while the adjacent `last_opened_chat_id` field uses `engine.general_chat.id` (object attribute access) — minor inconsistency but equivalent values at runtime. |
| energetica/routers/chats.py | New mute/unmute endpoints correctly validate participation with 404/403 guards and mutate `muted_chat_ids` using `add`/`discard`; returns 204 No Content. |
| energetica/utils/chat.py | Push notification now correctly skipped for muted participants; `participant.invalidate_queries` still fires for everyone, keeping unread counts up to date. |
| frontend/src/components/chat/chat-window.tsx | Bell/BellOff toggle added to chat header; button is correctly disabled while either mute or unmute mutation is pending, preventing duplicate requests. |
| frontend/src/hooks/use-chats.ts | New `useMuteChat` and `useUnmuteChat` hooks with proper query invalidation on success and toast errors on failure; mirrors existing mutation pattern. |
| energetica/schemas/chats.py | Added `is_muted` to `ChatOut` and `has_push_subscription` to `ChatListOut`; both correctly derived from player state. |
| frontend/src/components/chat/chat-list-item.tsx | BellOff indicator added in sidebar for muted chats; only shown when push is enabled, with accessible tooltip. |
| frontend/src/lib/api/chats.ts | Added `muteChat` and `unmuteChat` API calls using the generated type paths; consistent with existing call pattern. |
| frontend/src/types/api.generated.ts | Generated types correctly reflect the two new 204-returning endpoints and the new schema fields. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FE as Frontend
    participant API as /chats Router
    participant Player
    participant Chat

    FE->>API: POST /chats/{id}:mute
    API->>Chat: getitem(chat_id)
    Chat-->>API: chat
    API->>Chat: check player in participants
    API->>Player: muted_chat_ids.add(chat_id)
    API-->>FE: 204 No Content
    FE->>FE: invalidateQueries(chats.list)

    FE->>API: POST /chats/{id}:unmute
    API->>Chat: getitem(chat_id)
    Chat-->>API: chat
    API->>Player: muted_chat_ids.discard(chat_id)
    API-->>FE: 204 No Content
    FE->>FE: invalidateQueries(chats.list)

    Note over API,Player: On message send
    API->>Chat: add_message(player, text, chat)
    loop for each participant != sender
        Chat->>Player: check chat.id in muted_chat_ids
        alt not muted
            Player->>Player: push_only(payload)
        end
        Player->>Player: invalidate_queries
    end
```

<sub>Reviews (7): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/713-mute-c..."](https://github.com/felixvonsamson/energetica/commit/fa6a137bf6b23691183aef89ef14e0d2e3e79750) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30571621)</sub>

<!-- /greptile_comment -->