### PR TITLE
fix #696: clear stale ECharts tooltip circles on scroll and chart type change

### DIFF
--- a/frontend/src/components/charts/echarts-time-series.tsx
+++ b/frontend/src/components/charts/echarts-time-series.tsx
@@ -11,6 +11,7 @@
  * - React tooltip overlay with colored circles on the axis pointer
  */
 
+import { computePosition, flip, offset, shift } from "@floating-ui/dom";
 import { BarChart as EBarChart, LineChart as ELineChart } from "echarts/charts";
 import type { BarSeriesOption, LineSeriesOption } from "echarts/charts";
 import {
@@ -33,6 +34,7 @@ import {
     type ReactNode,
     useCallback,
     useEffect,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -158,6 +160,42 @@ function TSTooltip({
     const { currentTick } = useGameTick();
     const { data: gameEngine } = useGameEngine();
 
+    const divRef = useRef<HTMLDivElement>(null);
+
+    // Reposition the tooltip before each paint using Floating UI so it never
+    // bleeds off the viewport edge. computePosition resolves as a microtask
+    // (sync middleware), which still runs before the browser paints.
+    useLayoutEffect(() => {
+        const el = divRef.current;
+        if (!el) return;
+        const virtualEl = {
+            getBoundingClientRect() {
+                return {
+                    x: tooltip.clientX,
+                    y: tooltip.clientY,
+                    width: 0,
+                    height: 0,
+                    top: tooltip.clientY,
+                    left: tooltip.clientX,
+                    right: tooltip.clientX,
+                    bottom: tooltip.clientY,
+                };
+            },
+        };
+        computePosition(virtualEl, el, {
+            placement: "right-start",
+            strategy: "fixed",
+            middleware: [
+                offset({ mainAxis: 14, crossAxis: 8 }),
+                flip(),
+                shift({ padding: 8 }),
+            ],
+        }).then(({ x, y }) => {
+            el.style.left = `${x}px`;
+            el.style.top = `${y}px`;
+        });
+    }, [tooltip]);
+
     const timestamp =
         gameEngine && currentTick !== undefined
             ? `${formatDuration(currentTick - tooltip.tick - 1, gameEngine)} ago`
@@ -169,6 +207,7 @@ function TSTooltip({
 
     return (
         <div
+            ref={divRef}
             style={{
                 position: "fixed",
                 left: tooltip.clientX + 14,

--- a/frontend/src/components/charts/echarts-time-series.tsx
+++ b/frontend/src/components/charts/echarts-time-series.tsx
@@ -126,6 +126,7 @@ export interface EChartsTimeSeriesProps {
 // ── Tooltip overlay ───────────────────────────────────────────────────────────
 
 interface Circle {
+    seriesKey: string;
     clientX: number;
     clientY: number;
     color: string;
@@ -286,6 +287,12 @@ export function EChartsTimeSeries({
         [data.length, config.chartType, config.chartVariant, config.stacked],
     );
 
+    // Lags behind structuralKey during the post-setOption microtask window so
+    // stale circles are suppressed at render time rather than after a deferred
+    // setState fires.
+    const [appliedStructuralKey, setAppliedStructuralKey] =
+        useState(structuralKey);
+
     // Full data key: changes on every new tick arrival. Used as effect dep so
     // series are re-rendered on fresh data even without a zoom reset.
     const dataKey = useMemo(() => {
@@ -331,6 +338,15 @@ export function EChartsTimeSeries({
         el.addEventListener("wheel", handler, { capture: true, passive: true });
         return () =>
             el.removeEventListener("wheel", handler, { capture: true });
+    }, []);
+
+    // When the page scrolls, the fixed-position circles drift out of alignment
+    // with the chart. ZRender doesn't fire mouseout on scroll (the mouse didn't
+    // move), so we clear the tooltip explicitly.
+    useEffect(() => {
+        const clear = () => setTooltip(null);
+        window.addEventListener("scroll", clear, { capture: true, passive: true });
+        return () => window.removeEventListener("scroll", clear, { capture: true });
     }, []);
 
     // ── ECharts option ────────────────────────────────────────────────────────
@@ -719,6 +735,7 @@ export function EChartsTimeSeries({
                             cumulative,
                         ) as number;
                         circles.push({
+                            seriesKey: key,
                             clientX: lineClientX,
                             clientY: rect
                                 ? rect.top + pixelY
@@ -735,6 +752,7 @@ export function EChartsTimeSeries({
                             val,
                         ) as number;
                         circles.push({
+                            seriesKey: key,
                             clientX: lineClientX,
                             clientY: rect
                                 ? rect.top + pixelY
@@ -782,6 +800,8 @@ export function EChartsTimeSeries({
         if (isStructuralChange) {
             inst.setOption(option, { notMerge: true });
             queueMicrotask(() => {
+                setAppliedStructuralKey(structuralKey);
+                setTooltip(null);
                 setIsZoomed(false);
                 setZoomRange({ start: 0, end: 100 });
             });
@@ -864,11 +884,11 @@ export function EChartsTimeSeries({
                 </button>
             )}
 
-            {tooltip && !isLoading && (
+            {tooltip && !isLoading && appliedStructuralKey === structuralKey && (
                 <>
                     {tooltip.circles.map((c) => (
                         <div
-                            key={c.color}
+                            key={c.seriesKey}
                             style={{
                                 position: "fixed",
                                 left: c.clientX - 5,


### PR DESCRIPTION
## Summary

- Adds a `window` scroll listener (capture phase) to clear tooltip state on page scroll — ZRender never fires `mouseout` on scroll since the mouse doesn't move relative to the viewport, leaving fixed-position circles stranded in screen space
- Clears tooltip state (`queueMicrotask`) on structural chart changes (type/variant switch) — previously `isLoading=true` hid circles visually but the stale state caused them to reappear once loading finished
- Adds `seriesKey` field to `Circle` interface and uses it as the React key, replacing the buggy `key={c.color}` which caused React reconciliation failures when multiple of the 73 players share the same hash-based color

Closes #696.

## Test plan

- [ ] Open electricity markets, enable breakdown by player with a large network (73 members)
- [ ] Hover over the clearing volume chart — circles appear at series intersections
- [ ] Scroll the page — circles should disappear immediately
- [ ] Switch chart type (e.g. exports → imports, or player → production type) — circles should not reappear at stale positions after the new chart loads
- [ ] Verify no React key warnings in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three related tooltip-overlay bugs in `EChartsTimeSeries`: stale fixed-position circles left behind after page scroll, circles reappearing at wrong positions after a chart-type change, and duplicate React keys when multiple series share a hash-derived color. All three fixes are correct and well-scoped. The only minor item is a missing `.catch()` on the `computePosition` promise in the new `useLayoutEffect`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are isolated to tooltip overlay rendering with no impact on chart data or state management.

All three bug fixes are logically sound. The scroll listener correctly uses capture-phase and passive flags and is properly cleaned up. The appliedStructuralKey guard correctly suppresses stale circles during the notMerge window. The seriesKey React key fix is straightforward. The only finding is a P2 style suggestion (missing .catch on computePosition), which does not affect correctness since the inline style already serves as a fallback.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/charts/echarts-time-series.tsx | Adds scroll-clear listener, appliedStructuralKey guard, seriesKey React key fix, and Floating UI tooltip repositioning — all changes are targeted and correct |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ZRender
    participant EChartsTimeSeries
    participant TSTooltip
    participant FloatingUI

    User->>ZRender: mousemove over chart
    ZRender->>EChartsTimeSeries: mousemove handler fires
    EChartsTimeSeries->>EChartsTimeSeries: build circles + tooltip state
    EChartsTimeSeries->>EChartsTimeSeries: setTooltip(newState)
    EChartsTimeSeries->>TSTooltip: render with tooltip prop
    TSTooltip->>FloatingUI: computePosition(virtualEl, divRef)
    FloatingUI-->>TSTooltip: Promise resolve microtask
    TSTooltip->>TSTooltip: el.style.left/top updated before paint

    User->>Window: scroll
    Window->>EChartsTimeSeries: scroll event (capture, passive)
    EChartsTimeSeries->>EChartsTimeSeries: setTooltip(null) circles cleared

    User->>EChartsTimeSeries: change chart type/variant
    EChartsTimeSeries->>EChartsTimeSeries: structuralKey changes
    EChartsTimeSeries->>EChartsTimeSeries: appliedStructuralKey !== structuralKey circles hidden
    EChartsTimeSeries->>EChartsTimeSeries: inst.setOption notMerge true
    EChartsTimeSeries->>EChartsTimeSeries: queueMicrotask setAppliedStructuralKey + setTooltip null
```

<sub>Reviews (3): Last reviewed commit: ["fix: clamp chart tooltip to viewport usi..."](https://github.com/felixvonsamson/energetica/commit/e78bf8f132b1561c8516790be55c12b34e0858fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30575118)</sub>

<!-- /greptile_comment -->