### PR TITLE
fix #717: add confirmation dialog for single facility dismantle

### DIFF
--- a/frontend/src/components/facilities/facility-group-table.tsx
+++ b/frontend/src/components/facilities/facility-group-table.tsx
@@ -65,17 +65,20 @@ function ConfirmationContent({
         <div className="space-y-3">
             <p>
                 Are you sure you want to{" "}
-                {isDismantling ? "dismantle" : "upgrade"} all{" "}
+                {isDismantling ? "dismantle" : "upgrade"}{" "}
+                {count > 1 ? "all " : "this "}
                 <FacilityName facility={facilityName} as="strong" mode="long" />{" "}
-                facilities?
+                {count > 1 ? "facilities" : "facility"}?
             </p>
             <div className="bg-muted/50 p-4 rounded-lg space-y-2">
+                {count > 1 && (
+                    <div className="flex justify-between">
+                        <span className="font-semibold">Number of facilities:</span>
+                        <span>{count}</span>
+                    </div>
+                )}
                 <div className="flex justify-between">
-                    <span className="font-semibold">Number of facilities:</span>
-                    <span>{count}</span>
-                </div>
-                <div className="flex justify-between">
-                    <span className="font-semibold">Total cost:</span>
+                    <span className="font-semibold">{count > 1 ? "Total cost" : "Cost"}:</span>
                     <Money amount={totalCost} />
                 </div>
             </div>
@@ -113,15 +116,31 @@ function FacilityActions({
                     <span className="text-gray-400">-</span>
                 )}
             </td>
-            <td className="py-3 px-4 text-center">
+            <td className="py-3 px-4 text-center" onClick={(e) => e.stopPropagation()}>
                 {facility.dismantle_cost !== null ? (
-                    <button
-                        onClick={() => dismantleMutation.mutate(facility.id)}
-                        disabled={dismantleMutation.isPending}
-                        className="bg-destructive hover:bg-destructive/80 disabled:opacity-50 text-white px-3 py-1 rounded text-xs font-medium transition-colors"
-                    >
-                        <Money amount={facility.dismantle_cost} />
-                    </button>
+                    <ConfirmDialog
+                        trigger={
+                            <button
+                                disabled={dismantleMutation.isPending}
+                                className="bg-destructive hover:bg-destructive/80 disabled:opacity-50 text-white px-3 py-1 rounded text-xs font-medium transition-colors"
+                            >
+                                <Money amount={facility.dismantle_cost} />
+                            </button>
+                        }
+                        title="Confirm Dismantle"
+                        description={
+                            <ConfirmationContent
+                                facilityName={facility.facility}
+                                count={1}
+                                totalCost={facility.dismantle_cost}
+                                isDismantling={true}
+                            />
+                        }
+                        confirmLabel="Dismantle"
+                        variant="danger"
+                        onConfirm={() => dismantleMutation.mutate(facility.id)}
+                        isPending={dismantleMutation.isPending}
+                    />
                 ) : (
                     <span className="text-gray-400">-</span>
                 )}


### PR DESCRIPTION
## Summary
- Wraps the single-facility dismantle button in a `ConfirmDialog`, matching the existing "Dismantle All" pattern
- Confirmation shows facility name, cost, and "This action cannot be undone!" warning
- Reused `ConfirmationContent` with singular wording (hides count row, uses "this facility" / "Cost" labels when count is 1)

## Test plan
- [ ] Expand a facility group, click a dismantle button — confirm dialog appears
- [ ] Dialog shows correct facility name, cost, and warning banner
- [ ] Confirming dismantles the facility; cancelling does nothing
- [ ] "Dismantle All" dialog still works correctly with plural wording

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a confirmation dialog to the single-facility dismantle button by wrapping it in `ConfirmDialog` and extending `ConfirmationContent` to handle singular vs. plural wording via a `count > 1` branch. The `stopPropagation` guard on the dismantle `<td>` is a welcome addition.

- The shared `count > 1` condition in `ConfirmationContent` causes the **\"Dismantle All\"** and **\"Upgrade All\"** dialogs in `GroupActions` to render singular wording (\"dismantle **this** Solar Panel **facility**?\" / \"Cost:\") whenever a group has exactly one member — directly contradicting the bulk action button labels and hiding the \"Number of facilities\" row.

<h3>Confidence Score: 4/5</h3>

Merging introduces a UX regression: "Dismantle All" / "Upgrade All" dialogs show wrong singular wording for single-member groups.

One confirmed P1 (noted in the previous outside-diff comment) where the shared count>1 branch in ConfirmationContent causes GroupActions to render "dismantle this facility?" when count equals 1, directly contradicting the "Dismantle All" button label. No P0 issues. The single-facility dialog itself works correctly.

frontend/src/components/facilities/facility-group-table.tsx — specifically ConfirmationContent and its callers in GroupActions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/components/facilities/facility-group-table.tsx | Wraps single-facility dismantle in ConfirmDialog and extends ConfirmationContent with count-based singular/plural wording; the count>1 branch breaks GroupActions dialogs when a group has exactly one member. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Dismantle button\nin expanded facility row] --> B{dismantleMutation\n.isPending?}
    B -- Yes --> C[Button disabled\nNo dialog opens]
    B -- No --> D[ConfirmDialog opens]
    D --> E[ConfirmationContent renders\ncount=1 singular wording\n'dismantle this X facility?'\nCost: ...]
    E --> F{User action}
    F -- Cancel --> G[Dialog closes\nNo action taken]
    F -- Confirm --> H[dismantleMutation.mutate\nfacility.id]
    H --> I[Facility dismantled]

    J[User clicks Dismantle All\nin group summary row] --> K[ConfirmDialog opens]
    K --> L{count == 1?}
    L -- Yes, bug --> M["⚠️ Shows singular wording\n'dismantle this X facility?'\ncontradicts 'Dismantle All' label"]
    L -- No --> N[Shows plural wording\n'dismantle all X facilities?'\nNumber of facilities + Total cost]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/components/facilities/facility-group-table.tsx`, line 64-92 ([link](https://github.com/felixvonsamson/energetica/blob/93a7f88306e3dc328ea513b7672e416a277d138f/frontend/src/components/facilities/facility-group-table.tsx#L64-L92)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Singular wording breaks "Dismantle All"/"Upgrade All" dialogs when group has exactly 1 facility**

   The `count > 1` branch in `ConfirmationContent` is now shared by both the new single-row path (`count = 1`) and the existing bulk-action path in `GroupActions`. When a facility group has exactly one member, clicking **"Dismantle All"** or **"Upgrade All"** now renders `"dismantle this Solar Panel facility?"` with a `"Cost:"` label — directly contradicting the button label and hiding the "Number of facilities" row entirely.

   Consider adding an explicit `isBulk` prop to `ConfirmationContent` so the two call-sites can independently control wording regardless of count, then pass `isBulk={true}` from `GroupActions` and omit it from `FacilityActions`.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix #717: add confirmation dialog for si..."](https://github.com/felixvonsamson/energetica/commit/93a7f88306e3dc328ea513b7672e416a277d138f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30576141)</sub>

<!-- /greptile_comment -->