### PR TITLE
feat: persist chart state to localStorage (#616)

### DIFF
--- a/frontend/src/contexts/resolution-context.tsx
+++ b/frontend/src/contexts/resolution-context.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState, type ReactNode } from "react";
+import { createContext, useContext, type ReactNode } from "react";
 
+import { useLocalStorage } from "@/hooks/use-local-storage";
 import { ResolutionOption, resolutions } from "@/types/charts";
 
 interface ResolutionContextValue {
@@ -12,7 +13,10 @@ const ResolutionContext = createContext<ResolutionContextValue | undefined>(
 );
 
 export function ResolutionProvider({ children }: { children: ReactNode }) {
-    const [selectedResolutionIndex, setResolution] = useState(0);
+    const [selectedResolutionIndex, setResolution] = useLocalStorage(
+        "energetica:chart:resolutionIndex",
+        0,
+    );
     const selectedResolution =
         resolutions[selectedResolutionIndex] ?? resolutions[0]!;
 

--- a/frontend/src/hooks/use-local-storage.ts
+++ b/frontend/src/hooks/use-local-storage.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from "react";
+
+export function useLocalStorage<T>(
+    key: string,
+    defaultValue: T,
+): [T, (value: T) => void] {
+    const [state, setState] = useState<T>(() => {
+        try {
+            const stored = localStorage.getItem(key);
+            if (stored !== null) {
+                return JSON.parse(stored) as T;
+            }
+        } catch {
+            // ignore
+        }
+        return defaultValue;
+    });
+
+    const setValue = useCallback(
+        (value: T) => {
+            setState(value);
+            try {
+                localStorage.setItem(key, JSON.stringify(value));
+            } catch {
+                // ignore
+            }
+        },
+        [key],
+    );
+
+    return [state, setValue];
+}

--- a/frontend/src/hooks/use-local-storage.ts
+++ b/frontend/src/hooks/use-local-storage.ts
@@ -3,12 +3,19 @@ import { useState, useCallback } from "react";
 export function useLocalStorage<T>(
     key: string,
     defaultValue: T,
+    validate?: (value: unknown) => value is T,
 ): [T, (value: T) => void] {
     const [state, setState] = useState<T>(() => {
         try {
             const stored = localStorage.getItem(key);
             if (stored !== null) {
-                return JSON.parse(stored) as T;
+                const parsed: unknown = JSON.parse(stored);
+                const isValid = validate
+                    ? validate(parsed)
+                    : typeof parsed === typeof defaultValue;
+                if (isValid) {
+                    return parsed as T;
+                }
             }
         } catch {
             // ignore

--- a/frontend/src/hooks/use-toggle-set.ts
+++ b/frontend/src/hooks/use-toggle-set.ts
@@ -1,6 +1,6 @@
 /** Hook for managing a Set of toggled items (e.g., hidden chart series) */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 
 export function useToggleSet<T>(
     initialState?: Set<T>,
@@ -20,27 +20,30 @@ export function useToggleSet<T>(
         return initialState ?? new Set();
     });
 
+    // Keep a ref in sync so toggle can read current items without being
+    // listed as a dependency (avoids the toggle function changing on every render).
+    const itemsRef = useRef(items);
+    itemsRef.current = items;
+
     const toggle = useCallback(
         (item: T) => {
-            setItems((prev) => {
-                const next = new Set(prev);
-                if (next.has(item)) {
-                    next.delete(item);
-                } else {
-                    next.add(item);
+            const next = new Set(itemsRef.current);
+            if (next.has(item)) {
+                next.delete(item);
+            } else {
+                next.add(item);
+            }
+            setItems(next);
+            if (storageKey) {
+                try {
+                    localStorage.setItem(
+                        storageKey,
+                        JSON.stringify(Array.from(next)),
+                    );
+                } catch {
+                    // ignore
                 }
-                if (storageKey) {
-                    try {
-                        localStorage.setItem(
-                            storageKey,
-                            JSON.stringify(Array.from(next)),
-                        );
-                    } catch {
-                        // ignore
-                    }
-                }
-                return next;
-            });
+            }
         },
         [storageKey],
     );

--- a/frontend/src/hooks/use-toggle-set.ts
+++ b/frontend/src/hooks/use-toggle-set.ts
@@ -2,36 +2,48 @@
 
 import { useState, useCallback } from "react";
 
-/**
- * Manages a Set-based toggle state, commonly used for tracking visibility of
- * chart series or table rows.
- *
- * @example
- *     ```tsx
- *     const [hiddenSeries, toggleSeries] = useToggleSet<string>();
- *     <button onClick={() => toggleSeries("coal")}>
- *       {hiddenSeries.has("coal") ? "Show" : "Hide"}
- *     </button>
- *     ```;
- *
- * @param initialState - Initial Set of items (defaults to empty Set)
- * @returns Tuple of [items, toggle] where toggle adds/removes items from the
- *   Set
- */
-export function useToggleSet<T>(initialState?: Set<T>) {
-    const [items, setItems] = useState<Set<T>>(initialState ?? new Set());
-
-    const toggle = useCallback((item: T) => {
-        setItems((prev) => {
-            const next = new Set(prev);
-            if (next.has(item)) {
-                next.delete(item);
-            } else {
-                next.add(item);
+export function useToggleSet<T>(
+    initialState?: Set<T>,
+    storageKey?: string,
+) {
+    const [items, setItems] = useState<Set<T>>(() => {
+        if (storageKey) {
+            try {
+                const stored = localStorage.getItem(storageKey);
+                if (stored !== null) {
+                    return new Set(JSON.parse(stored) as T[]);
+                }
+            } catch {
+                // ignore
             }
-            return next;
-        });
-    }, []);
+        }
+        return initialState ?? new Set();
+    });
+
+    const toggle = useCallback(
+        (item: T) => {
+            setItems((prev) => {
+                const next = new Set(prev);
+                if (next.has(item)) {
+                    next.delete(item);
+                } else {
+                    next.add(item);
+                }
+                if (storageKey) {
+                    try {
+                        localStorage.setItem(
+                            storageKey,
+                            JSON.stringify(Array.from(next)),
+                        );
+                    } catch {
+                        // ignore
+                    }
+                }
+                return next;
+            });
+        },
+        [storageKey],
+    );
 
     return [items, toggle] as const;
 }

--- a/frontend/src/hooks/use-toggle-set.ts
+++ b/frontend/src/hooks/use-toggle-set.ts
@@ -1,6 +1,6 @@
 /** Hook for managing a Set of toggled items (e.g., hidden chart series) */
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 export function useToggleSet<T>(
     initialState?: Set<T>,
@@ -20,33 +20,26 @@ export function useToggleSet<T>(
         return initialState ?? new Set();
     });
 
-    // Keep a ref in sync so toggle can read current items without being
-    // listed as a dependency (avoids the toggle function changing on every render).
-    const itemsRef = useRef(items);
-    itemsRef.current = items;
+    useEffect(() => {
+        if (!storageKey) return;
+        try {
+            localStorage.setItem(storageKey, JSON.stringify(Array.from(items)));
+        } catch {
+            // ignore
+        }
+    }, [items, storageKey]);
 
-    const toggle = useCallback(
-        (item: T) => {
-            const next = new Set(itemsRef.current);
+    const toggle = useCallback((item: T) => {
+        setItems((prev) => {
+            const next = new Set(prev);
             if (next.has(item)) {
                 next.delete(item);
             } else {
                 next.add(item);
             }
-            setItems(next);
-            if (storageKey) {
-                try {
-                    localStorage.setItem(
-                        storageKey,
-                        JSON.stringify(Array.from(next)),
-                    );
-                } catch {
-                    // ignore
-                }
-            }
-        },
-        [storageKey],
-    );
+            return next;
+        });
+    }, []);
 
     return [items, toggle] as const;
 }

--- a/frontend/src/routes/app/overviews/cash-flow.tsx
+++ b/frontend/src/routes/app/overviews/cash-flow.tsx
@@ -8,7 +8,7 @@ import {
     PieChart,
     Funnel,
 } from "lucide-react";
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 
 import {
     NetProfitViewMode,
@@ -28,6 +28,7 @@ import {
 import { useResolution } from "@/contexts/resolution-context";
 import { useChartData } from "@/hooks/use-charts";
 import { useGameTick } from "@/hooks/use-game-tick";
+import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 
 export const Route = createFileRoute("/app/overviews/cash-flow")({
@@ -115,11 +116,23 @@ const NET_PROFIT_VIEW_MODE_OPTIONS = [
 
 function RevenuesOverviewContent() {
     const { currentTick } = useGameTick();
-    const [viewMode, setViewMode] = useState<"normal" | "percent">("normal");
+    const [viewMode, setViewMode] = useLocalStorage<"normal" | "percent">(
+        "energetica:chart:cashflow:viewMode",
+        "normal",
+    );
     const [netProfitViewMode, setNetProfitViewMode] =
-        useState<NetProfitViewMode>("net");
-    const [revenueType, setRevenueType] = useState<CashFlowType>("revenues");
-    const [hiddenFacilities, toggleFacility] = useToggleSet<string>();
+        useLocalStorage<NetProfitViewMode>(
+            "energetica:chart:cashflow:netProfitViewMode",
+            "net",
+        );
+    const [revenueType, setRevenueType] = useLocalStorage<CashFlowType>(
+        "energetica:chart:cashflow:revenueType",
+        "revenues",
+    );
+    const [hiddenFacilities, toggleFacility] = useToggleSet<string>(
+        undefined,
+        "energetica:chart:cashflow:hiddenFacilities",
+    );
     const { selectedResolution } = useResolution();
 
     // Fetch both revenue and op-costs chart data

--- a/frontend/src/routes/app/overviews/electricity-markets.tsx
+++ b/frontend/src/routes/app/overviews/electricity-markets.tsx
@@ -13,7 +13,7 @@ import {
     BarChart2,
     UserPlus,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import {
     BreakdownMode,
@@ -50,6 +50,7 @@ import {
     useElectricityMarket,
 } from "@/hooks/use-electricity-markets";
 import { useGameTick } from "@/hooks/use-game-tick";
+import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 import { formatPower } from "@/lib/format-utils";
 
@@ -164,10 +165,22 @@ function MarketsOverviewContent() {
     const latestQuantity = latestData.quantity ?? 0;
 
     // Breakdown state
-    const [breakdownEnabled, setBreakdownEnabled] = useState<boolean>(false);
-    const [breakdownType, setBreakdownType] = useState<BreakdownType>("supply");
-    const [breakdownMode, setBreakdownMode] = useState<BreakdownMode>("player");
-    const [hiddenBreakdownItems, toggleBreakdownItem] = useToggleSet<string>();
+    const [breakdownEnabled, setBreakdownEnabled] = useLocalStorage<boolean>(
+        "energetica:chart:markets:breakdownEnabled",
+        false,
+    );
+    const [breakdownType, setBreakdownType] = useLocalStorage<BreakdownType>(
+        "energetica:chart:markets:breakdownType",
+        "supply",
+    );
+    const [breakdownMode, setBreakdownMode] = useLocalStorage<BreakdownMode>(
+        "energetica:chart:markets:breakdownMode",
+        "player",
+    );
+    const [hiddenBreakdownItems, toggleBreakdownItem] = useToggleSet<string>(
+        undefined,
+        "energetica:chart:markets:hiddenBreakdownItems",
+    );
 
     // Handle market selection change
     const handleMarketChange = (marketId: number | undefined) => {

--- a/frontend/src/routes/app/overviews/emissions.tsx
+++ b/frontend/src/routes/app/overviews/emissions.tsx
@@ -2,7 +2,6 @@
 
 import { createFileRoute } from "@tanstack/react-router";
 import { Cloud, Thermometer, Globe, Leaf } from "lucide-react";
-import { useState } from "react";
 
 import { CO2Chart } from "@/components/charts/co2-chart";
 import {
@@ -21,6 +20,7 @@ import {
 import { useResolution } from "@/contexts/resolution-context";
 import { useChartData } from "@/hooks/use-charts";
 import { useGameTick } from "@/hooks/use-game-tick";
+import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 
 export const Route = createFileRoute("/app/overviews/emissions")({
@@ -112,22 +112,30 @@ const EMISSIONS_CUMULATIVE_OPTIONS = [
 
 function EmissionsOverviewContent() {
     const { currentTick } = useGameTick();
-    const [hiddenSources, toggleSource] = useToggleSet<string>();
-    const [co2ViewMode, setCo2ViewMode] = useState<"absolute" | "relative">(
+    const [hiddenSources, toggleSource] = useToggleSet<string>(
+        undefined,
+        "energetica:chart:emissions:hiddenSources",
+    );
+    const [co2ViewMode, setCo2ViewMode] = useLocalStorage<"absolute" | "relative">(
+        "energetica:chart:emissions:co2ViewMode",
         "absolute",
     );
-    const [co2UnitMode, setCo2UnitMode] = useState<
-        "concentration" | "quantity"
-    >("concentration");
-    const [tempViewMode, setTempViewMode] = useState<"absolute" | "relative">(
+    const [co2UnitMode, setCo2UnitMode] = useLocalStorage<"concentration" | "quantity">(
+        "energetica:chart:emissions:co2UnitMode",
+        "concentration",
+    );
+    const [tempViewMode, setTempViewMode] = useLocalStorage<"absolute" | "relative">(
+        "energetica:chart:emissions:tempViewMode",
         "absolute",
     );
-    const [emissionsViewMode, setEmissionsViewMode] = useState<
-        "normal" | "percent"
-    >("normal");
-    const [emissionsCumulativeMode, setEmissionsCumulativeMode] = useState<
-        "rates" | "cumulative"
-    >("rates");
+    const [emissionsViewMode, setEmissionsViewMode] = useLocalStorage<"normal" | "percent">(
+        "energetica:chart:emissions:viewMode",
+        "normal",
+    );
+    const [emissionsCumulativeMode, setEmissionsCumulativeMode] = useLocalStorage<"rates" | "cumulative">(
+        "energetica:chart:emissions:cumulativeMode",
+        "rates",
+    );
 
     const { selectedResolution } = useResolution();
 

--- a/frontend/src/routes/app/overviews/power.tsx
+++ b/frontend/src/routes/app/overviews/power.tsx
@@ -2,7 +2,6 @@
 
 import { createFileRoute } from "@tanstack/react-router";
 import { Zap, TrendingUp, TrendingDown, Funnel } from "lucide-react";
-import { useState } from "react";
 
 import {
     PowerChart,
@@ -21,6 +20,7 @@ import {
 import { useResolution } from "@/contexts/resolution-context";
 import { useChartData } from "@/hooks/use-charts";
 import { useGameTick } from "@/hooks/use-game-tick";
+import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 
 export const Route = createFileRoute("/app/overviews/power")({
@@ -95,12 +95,22 @@ const VIEW_MODE_OPTIONS = [
 
 function PowerOverviewContent() {
     const { currentTick } = useGameTick();
-    const [chartType, setChartType] = useState<"power-sources" | "power-sinks">(
+    const [chartType, setChartType] = useLocalStorage<"power-sources" | "power-sinks">(
+        "energetica:chart:power:chartType",
         "power-sources",
     );
-    const [viewMode, setViewMode] = useState<PowerChartViewMode>("absolute");
-    const [hiddenSources, toggleSource] = useToggleSet<string>();
-    const [hiddenSinks, toggleSink] = useToggleSet<string>();
+    const [viewMode, setViewMode] = useLocalStorage<PowerChartViewMode>(
+        "energetica:chart:power:viewMode",
+        "absolute",
+    );
+    const [hiddenSources, toggleSource] = useToggleSet<string>(
+        undefined,
+        "energetica:chart:power:hiddenSources",
+    );
+    const [hiddenSinks, toggleSink] = useToggleSet<string>(
+        undefined,
+        "energetica:chart:power:hiddenSinks",
+    );
 
     const { selectedResolution } = useResolution();
     // Fetch chart data to share between chart and table

--- a/frontend/src/routes/app/overviews/resources.tsx
+++ b/frontend/src/routes/app/overviews/resources.tsx
@@ -8,7 +8,6 @@ import {
     BarChart3,
     Funnel,
 } from "lucide-react";
-import { useState } from "react";
 
 import {
     ResourcesChart,
@@ -26,6 +25,7 @@ import {
 import { useResolution } from "@/contexts/resolution-context";
 import { useChartData } from "@/hooks/use-charts";
 import { useGameTick } from "@/hooks/use-game-tick";
+import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 
 export const Route = createFileRoute("/app/overviews/resources")({
@@ -115,8 +115,14 @@ const VIEW_MODE_OPTIONS = [
 
 function ResourcesOverviewContent() {
     const { currentTick } = useGameTick();
-    const [viewMode, setViewMode] = useState<"mass" | "percent">("percent");
-    const [hiddenResources, toggleResource] = useToggleSet<string>();
+    const [viewMode, setViewMode] = useLocalStorage<"mass" | "percent">(
+        "energetica:chart:resources:viewMode",
+        "percent",
+    );
+    const [hiddenResources, toggleResource] = useToggleSet<string>(
+        undefined,
+        "energetica:chart:resources:hiddenResources",
+    );
     const { selectedResolution } = useResolution();
 
     // Fetch absolute resource stocks for the table (always needed)

--- a/frontend/src/routes/app/overviews/storage.tsx
+++ b/frontend/src/routes/app/overviews/storage.tsx
@@ -2,7 +2,6 @@
 
 import { createFileRoute } from "@tanstack/react-router";
 import { Battery, TrendingUp, BarChart3, Funnel } from "lucide-react";
-import { useState } from "react";
 
 import {
     StorageChart,
@@ -20,6 +19,7 @@ import {
 import { useResolution } from "@/contexts/resolution-context";
 import { useChartData } from "@/hooks/use-charts";
 import { useGameTick } from "@/hooks/use-game-tick";
+import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 
 export const Route = createFileRoute("/app/overviews/storage")({
@@ -96,8 +96,14 @@ const VIEW_MODE_OPTIONS = [
 
 function StorageOverviewContent() {
     const { currentTick } = useGameTick();
-    const [viewMode, setViewMode] = useState<"normal" | "percent">("normal");
-    const [hiddenFacilities, toggleFacility] = useToggleSet<string>();
+    const [viewMode, setViewMode] = useLocalStorage<"normal" | "percent">(
+        "energetica:chart:storage:viewMode",
+        "normal",
+    );
+    const [hiddenFacilities, toggleFacility] = useToggleSet<string>(
+        undefined,
+        "energetica:chart:storage:hiddenFacilities",
+    );
 
     const { selectedResolution } = useResolution();
 


### PR DESCRIPTION
## Summary

- Adds `useLocalStorage<T>` hook for generic localStorage-backed state
- Extends `useToggleSet` with an optional `storageKey` param to persist hidden-series sets
- Persists resolution index in `ResolutionContext` so it survives page navigation
- All six overview pages (power, storage, emissions, resources, cash-flow, electricity-markets) now restore their controls from localStorage on mount

Closes #616

## Test plan

- [ ] Switch power chart to "Consumption (Sinks)", navigate to another overview, come back — selection is preserved
- [ ] Toggle a facility off in the table, navigate away and back — facility stays hidden
- [ ] Change resolution, navigate away and back — resolution is preserved
- [ ] Hard-reload the page — all controls restore to last-used values
- [ ] Verify no console errors on first visit (empty localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `useLocalStorage<T>` hook and extends `useToggleSet` with a `storageKey` option so that all six overview pages (power, storage, emissions, resources, cash-flow, electricity-markets) and the shared resolution context persist their UI controls across navigation and hard reloads. The implementation is clean: `useLocalStorage` validates deserialized values against the `typeof` of the default (with an optional type-guard escape hatch), and `useToggleSet` correctly moves the write side-effect into a `useEffect`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic or correctness issues; only a minor unnecessary write-on-mount in useToggleSet.

All findings are P2 style suggestions. The core persistence logic is correct: localStorage reads are validated, writes are wrapped in try/catch, and out-of-bounds resolution indices are handled safely with a nullish coalesce fallback.

frontend/src/hooks/use-toggle-set.ts — redundant mount write is the only item worth revisiting.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/hooks/use-local-storage.ts | New generic hook for localStorage-backed state; adds optional type-guard validator and falls back to `typeof` parity check when none is provided. Clean implementation. |
| frontend/src/hooks/use-toggle-set.ts | Adds optional `storageKey` param; uses `useEffect` for persistence (good). The effect fires on every mount—even when state was just hydrated from localStorage—causing a redundant write on each page visit. |
| frontend/src/contexts/resolution-context.tsx | Replaces `useState(0)` with `useLocalStorage`; out-of-bounds stored index is safely handled by `?? resolutions[0]`. |
| frontend/src/routes/app/overviews/power.tsx | Migrates chart-type, view-mode, and two hidden-series sets to localStorage with stable string keys. |
| frontend/src/routes/app/overviews/electricity-markets.tsx | Persists breakdown enabled flag, type, mode, and hidden items; keys are unique and well-namespaced. |
| frontend/src/routes/app/overviews/emissions.tsx | Persists five independent view-mode selections; straightforward migration from `useState`. |
| frontend/src/routes/app/overviews/cash-flow.tsx | Persists view mode, net-profit view mode, revenue type, and hidden facilities. |
| frontend/src/routes/app/overviews/resources.tsx | Migrates view mode and hidden resources to localStorage; no issues found. |
| frontend/src/routes/app/overviews/storage.tsx | Migrates view mode and hidden facilities to localStorage; no issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component Mounts] --> B{storageKey provided?}
    B -- No --> C[Use initialState / defaultValue]
    B -- Yes --> D{localStorage has key?}
    D -- No --> C
    D -- Yes --> E[JSON.parse stored value]
    E --> F{Validation passes?}
    F -- No --> C
    F -- Yes --> G[Hydrate state from storage]
    C --> H[React state initialised]
    G --> H

    H --> I[useEffect fires on mount - writes current state back to localStorage]
    I --> J[Component renders]

    J --> K[User interaction]
    K --> L[setValue / toggle called]
    L --> M[setState]
    M --> N[Re-render]
    N --> O[useEffect / inline write - updates localStorage]
    O --> J
```

<sub>Reviews (3): Last reviewed commit: ["fix: sync toggle-set to localStorage via..."](https://github.com/felixvonsamson/energetica/commit/74acb7d992f1c61e03c829a9e59cad40046c753c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30576754)</sub>

<!-- /greptile_comment -->