### PR TITLE
feat: tutorial notifications for daily quiz (#668)

### DIFF
--- a/energetica/database/messages.py
+++ b/energetica/database/messages.py
@@ -56,6 +56,8 @@ NotificationType = Literal[
     "achievement_milestone",
     "achievement_unlock",
     "tutorial_push_notifications",
+    "tutorial_daily_quiz",
+    "tutorial_quiz_push_notifications",
 ]
 
 

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -7,7 +7,7 @@ import json
 from urllib.parse import urlparse
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Iterable
@@ -201,8 +201,6 @@ class Player(DBModel):
         if not hasattr(self, "overdraft_warning_sent"):
             self.overdraft_warning_sent = False
         if not hasattr(self, "created_at"):
-            from datetime import timedelta
-
             self.created_at = datetime.now(timezone.utc) - timedelta(days=365)
         if not hasattr(self, "dispatched_tutorials"):
             self.dispatched_tutorials = []

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -7,7 +7,7 @@ import json
 from urllib.parse import urlparse
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import StrEnum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Iterable
@@ -81,6 +81,7 @@ class Player(DBModel):
         return self.user.username
 
     last_connection: datetime | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
     # inactive: bool = False  # True if account is inactive
     show_chat_disclaimer: bool = True
@@ -150,6 +151,7 @@ class Player(DBModel):
             "imported_energy": 0,
             "exported_energy": 0,
             "captured_co2": 0,
+            "quiz_answers_total": 0,
         },
     )
 
@@ -167,6 +169,7 @@ class Player(DBModel):
             "network_join_leave": False,
         }
     )
+    dispatched_tutorials: list[str] = field(default_factory=list)
     socketio_clients: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
@@ -197,6 +200,13 @@ class Player(DBModel):
             self.push_subscriptions = []
         if not hasattr(self, "overdraft_warning_sent"):
             self.overdraft_warning_sent = False
+        if not hasattr(self, "created_at"):
+            from datetime import timedelta
+
+            self.created_at = datetime.now(timezone.utc) - timedelta(days=365)
+        if not hasattr(self, "dispatched_tutorials"):
+            self.dispatched_tutorials = []
+        self.progression_metrics.setdefault("quiz_answers_total", 0)
         # Migrate old notification_opt_ins field
         if hasattr(self, "notification_opt_ins"):
             del self.__dict__["notification_opt_ins"]

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -311,16 +311,16 @@ class GameEngine(object):
                 and player.progression_metrics["quiz_answers_total"] == 0
                 and "tutorial_daily_quiz" not in player.dispatched_tutorials
             ):
-                player.notify(tutorial_daily_quiz)
                 player.dispatched_tutorials.append("tutorial_daily_quiz")
+                player.notify(tutorial_daily_quiz)
 
             if (
                 player.progression_metrics["quiz_answers_total"] >= 3
                 and not player.push_subscriptions
                 and "tutorial_quiz_push_notifications" not in player.dispatched_tutorials
             ):
-                player.notify(tutorial_quiz_push)
                 player.dispatched_tutorials.append("tutorial_quiz_push_notifications")
+                player.notify(tutorial_quiz_push)
 
     @property
     def general_chat(self) -> Chat:

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -250,6 +250,7 @@ class GameEngine(object):
             for member, member_data in data.items():
                 setattr(self, member, member_data)
         from energetica.database.active_facility import ActiveFacility  # late import to avoid circular dependency
+
         ActiveFacility.rebuild_index()
 
     def save_checkpoint(self, destination_filename: str = "checkpoints/last_checkpoint.tar.gz") -> None:
@@ -277,8 +278,14 @@ class GameEngine(object):
 
     def new_daily_question(self) -> None:
         """Load a new daily question from the csv file."""
+        from datetime import datetime, timedelta, timezone
+
         from energetica.database.player import Player
-        from energetica.schemas.notifications import QuizReminderPayload
+        from energetica.schemas.notifications import (
+            QuizReminderPayload,
+            TutorialDailyQuizPayload,
+            TutorialQuizPushNotificationsPayload,
+        )
 
         with open("energetica/static/data/daily_quiz_questions.csv", "r", encoding="utf-8") as file:
             csv_reader = list(csv.DictReader(file))
@@ -292,9 +299,28 @@ class GameEngine(object):
         self.daily_question["index"] = question_index
         self.daily_question["player_answers"] = {}
 
-        payload = QuizReminderPayload()
+        quiz_reminder = QuizReminderPayload()
+        tutorial_daily_quiz = TutorialDailyQuizPayload()
+        tutorial_quiz_push = TutorialQuizPushNotificationsPayload()
+        now = datetime.now(timezone.utc)
         for player in Player.all():
-            player.push_only(payload)
+            player.push_only(quiz_reminder)
+
+            if (
+                now - player.created_at >= timedelta(days=3)
+                and player.progression_metrics["quiz_answers_total"] == 0
+                and "tutorial_daily_quiz" not in player.dispatched_tutorials
+            ):
+                player.notify(tutorial_daily_quiz)
+                player.dispatched_tutorials.append("tutorial_daily_quiz")
+
+            if (
+                player.progression_metrics["quiz_answers_total"] >= 3
+                and not player.push_subscriptions
+                and "tutorial_quiz_push_notifications" not in player.dispatched_tutorials
+            ):
+                player.notify(tutorial_quiz_push)
+                player.dispatched_tutorials.append("tutorial_quiz_push_notifications")
 
     @property
     def general_chat(self) -> Chat:

--- a/energetica/schemas/notifications.py
+++ b/energetica/schemas/notifications.py
@@ -110,6 +110,18 @@ class TutorialPushNotificationsPayload(BaseModel):
     type: Literal["tutorial_push_notifications"] = "tutorial_push_notifications"
 
 
+class TutorialDailyQuizPayload(BaseModel):
+    """Tutorial notification informing the player that a daily quiz exists."""
+
+    type: Literal["tutorial_daily_quiz"] = "tutorial_daily_quiz"
+
+
+class TutorialQuizPushNotificationsPayload(BaseModel):
+    """Tutorial notification encouraging the player to enable push notifications for the quiz."""
+
+    type: Literal["tutorial_quiz_push_notifications"] = "tutorial_quiz_push_notifications"
+
+
 class ChatMessagePayload(BaseModel):
     type: Literal["chat_message"] = "chat_message"
     sender_username: str
@@ -211,6 +223,8 @@ PersistableNotificationPayload = Union[
     AchievementMilestoneBasePayload,
     AchievementUnlockPayload,
     TutorialPushNotificationsPayload,
+    TutorialDailyQuizPayload,
+    TutorialQuizPushNotificationsPayload,
 ]
 
 # Payloads that only trigger a browser push — no inbox entry.

--- a/energetica/utils/misc.py
+++ b/energetica/utils/misc.py
@@ -272,6 +272,7 @@ def submit_quiz_answer(player: Player, player_answer: str) -> bool:
     if player.id in quiz_data["player_answers"]:
         raise GameError(GameExceptionType.QUIZ_ALREADY_ANSWERED)
     quiz_data["player_answers"][player.id] = player_answer
+    player.progression_metrics["quiz_answers_total"] += 1
     if player_answer == quiz_data["answer"] or quiz_data["answer"] == "all correct":
         player.progression_metrics["xp"] += 1
         engine.log(f"{player.username} answered the quiz correctly")

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -180,7 +180,7 @@ const INBOX_NOTIFICATION_CONFIG = {
         pushBody: () =>
             "Answer a new question every day to earn XP and test your knowledge about energy systems and climate change.",
         inGameBody: () =>
-            "Answer a new question every day to earn XP and test your energy knowledge.",
+            "Answer a new question every day to earn XP and test your knowledge about energy systems and climate change.",
     },
     tutorial_quiz_push_notifications: {
         category: "tutorials",

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -173,6 +173,24 @@ const INBOX_NOTIFICATION_CONFIG = {
         inGameBody: () =>
             "Enable browser notifications in Settings to get updates on construction, market activity, and more, even when the game is closed.",
     },
+    tutorial_daily_quiz: {
+        category: "tutorials",
+        path: () => "/app/dashboard/quiz",
+        title: "Tip: Take the daily quiz",
+        pushBody: () =>
+            "Answer a new question every day to earn XP and test your energy knowledge.",
+        inGameBody: () =>
+            "Answer a new question every day to earn XP and test your energy knowledge.",
+    },
+    tutorial_quiz_push_notifications: {
+        category: "tutorials",
+        path: () => "/app/dashboard/quiz",
+        title: "Tip: Enable quiz notifications",
+        pushBody: () =>
+            "Enable browser notifications in Settings to get a daily reminder when a new quiz question is available.",
+        inGameBody: () =>
+            "Enable browser notifications in Settings to get a daily reminder when a new quiz question is available.",
+    },
 } satisfies { [T in NotificationType]: InboxNotificationDef<T> };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/notification-config.tsx
+++ b/frontend/src/lib/notification-config.tsx
@@ -178,7 +178,7 @@ const INBOX_NOTIFICATION_CONFIG = {
         path: () => "/app/dashboard/quiz",
         title: "Tip: Take the daily quiz",
         pushBody: () =>
-            "Answer a new question every day to earn XP and test your energy knowledge.",
+            "Answer a new question every day to earn XP and test your knowledge about energy systems and climate change.",
         inGameBody: () =>
             "Answer a new question every day to earn XP and test your energy knowledge.",
     },

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -3320,7 +3320,9 @@ export interface components {
                 | components["schemas"]["AchievementMilestoneEnergyStoragePayload"]
                 | components["schemas"]["AchievementMilestoneBasePayload"]
                 | components["schemas"]["AchievementUnlockPayload"]
-                | components["schemas"]["TutorialPushNotificationsPayload"];
+                | components["schemas"]["TutorialPushNotificationsPayload"]
+                | components["schemas"]["TutorialDailyQuizPayload"]
+                | components["schemas"]["TutorialQuizPushNotificationsPayload"];
         };
         /** NotificationPatchIn */
         NotificationPatchIn: {
@@ -4561,6 +4563,20 @@ export interface components {
             endpoint?: string | null;
         };
         /**
+         * TutorialDailyQuizPayload
+         *
+         * Tutorial notification informing the player that a daily quiz exists.
+         */
+        TutorialDailyQuizPayload: {
+            /**
+             * Type
+             *
+             * @constant
+             * @default tutorial_daily_quiz
+             */
+            type: "tutorial_daily_quiz";
+        };
+        /**
          * TutorialPushNotificationsPayload
          *
          * Tutorial notification encouraging the player to enable browser push
@@ -4574,6 +4590,21 @@ export interface components {
              * @default tutorial_push_notifications
              */
             type: "tutorial_push_notifications";
+        };
+        /**
+         * TutorialQuizPushNotificationsPayload
+         *
+         * Tutorial notification encouraging the player to enable push
+         * notifications for the quiz.
+         */
+        TutorialQuizPushNotificationsPayload: {
+            /**
+             * Type
+             *
+             * @constant
+             * @default tutorial_quiz_push_notifications
+             */
+            type: "tutorial_quiz_push_notifications";
         };
         /**
          * UserOut


### PR DESCRIPTION
## Summary

- Adds `created_at` timestamp to `Player` (closes #737), with `__setstate__` backward compat defaulting existing players to 1 year ago
- Adds `dispatched_tutorials: list[str]` to `Player` for reliable one-shot deduplication (immune to players deleting inbox notifications)
- Tracks `quiz_answers_total` in `progression_metrics`, incremented on every quiz submission
- Fires `tutorial_daily_quiz` once daily if player is ≥3 days old and has never answered a quiz
- Fires `tutorial_quiz_push_notifications` once daily if player has ≥3 quiz answers and no push subscriptions
- Both tutorial checks run inside `new_daily_question()` alongside the existing quiz reminder

## Test plan

- [ ] New player: confirm no tutorial fires within first 3 days
- [ ] New player after 3+ days with 0 quiz answers: confirm `tutorial_daily_quiz` appears in inbox once
- [ ] Player with 3+ quiz answers and no push subscriptions: confirm `tutorial_quiz_push_notifications` appears in inbox once
- [ ] Player who already has push subscriptions: confirm `tutorial_quiz_push_notifications` never fires
- [ ] Both tutorials: confirm they never fire a second time even if the player deletes the notification from their inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two tutorial notifications (`tutorial_daily_quiz` and `tutorial_quiz_push_notifications`) that fire once per player inside `new_daily_question()`, backed by a new `dispatched_tutorials` list for reliable deduplication. It also introduces a `created_at` timestamp on `Player` and a `quiz_answers_total` counter in `progression_metrics`, with `__setstate__` backward-compat guards for existing pickled players.

The previously flagged ordering issue (append before notify) is correctly addressed in the final code, and `timedelta` has been promoted to the module-level import in `player.py`. The tradeoffs around veteran players receiving `tutorial_daily_quiz` on first deploy have been discussed and accepted by the team.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no new blocking issues found; previously flagged P1s are resolved or accepted by the team.

All P1 concerns from prior review rounds have been resolved (append-before-notify ordering is correct, timedelta is at module level). The one accepted tradeoff (veteran players receiving tutorial_daily_quiz once on deploy) is a one-time cosmetic nudge with no data loss or security risk. The feature is well-scoped and the deduplication mechanism is sound.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/game_engine.py | Adds tutorial notification logic inside `new_daily_question()`; `dispatched_tutorials.append()` correctly precedes `player.notify()` to prevent duplicates on exception. Function-level `from datetime import datetime, timedelta, timezone` shadows module-level `import datetime` only within function scope — no runtime issue. |
| energetica/database/player.py | Adds `created_at`, `dispatched_tutorials`, and `quiz_answers_total` with correct backward-compat `__setstate__` guards; `timedelta` correctly promoted to module-level import. |
| energetica/utils/misc.py | Increments `quiz_answers_total` on every quiz submission, correctly placed before the correctness check. |
| energetica/schemas/notifications.py | Adds `TutorialDailyQuizPayload` and `TutorialQuizPushNotificationsPayload` and registers them in `PersistableNotificationPayload` union; consistent with existing tutorial payload pattern. |
| energetica/database/messages.py | Adds two new literals to `NotificationType`; straightforward and correct. |
| frontend/src/lib/notification-config.tsx | Adds frontend config entries for both new notification types with appropriate titles, bodies, and paths; satisfies the `satisfies` type constraint. |
| frontend/src/types/api.generated.ts | Auto-generated type definitions for the two new payload schemas; correctly mirrors the Python schema additions. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Scheduler
    participant GameEngine
    participant Player
    participant Inbox

    Scheduler->>GameEngine: new_daily_question()
    GameEngine->>GameEngine: load CSV question, reset player_answers
    loop for each Player
        GameEngine->>Player: push_only(QuizReminderPayload)
        alt age >= 3 days AND quiz_answers_total == 0 AND not dispatched
            GameEngine->>Player: dispatched_tutorials.append(tutorial_daily_quiz)
            GameEngine->>Inbox: notify(TutorialDailyQuizPayload)
        end
        alt quiz_answers_total >= 3 AND no push_subscriptions AND not dispatched
            GameEngine->>Player: dispatched_tutorials.append(tutorial_quiz_push_notifications)
            GameEngine->>Inbox: notify(TutorialQuizPushNotificationsPayload)
        end
    end

    Note over Player,Inbox: submit_quiz_answer() path
    Player->>GameEngine: submit_quiz_answer(answer)
    GameEngine->>Player: progression_metrics[quiz_answers_total] += 1
```

<sub>Reviews (3): Last reviewed commit: ["adapt wording 2"](https://github.com/felixvonsamson/energetica/commit/941386945166bda6b36e808b01d5895861267d28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30597926)</sub>

<!-- /greptile_comment -->