### PR TITLE
fix: GroupActions bulk dialog wording for single-member groups

### DIFF
--- a/frontend/src/components/facilities/facility-group-table.tsx
+++ b/frontend/src/components/facilities/facility-group-table.tsx
@@ -55,30 +55,33 @@ function ConfirmationContent({
     count,
     totalCost,
     isDismantling,
+    bulk = false,
 }: {
     facilityName: string;
     count: number;
     totalCost: number;
     isDismantling: boolean;
+    bulk?: boolean;
 }) {
+    const plural = bulk || count > 1;
     return (
         <div className="space-y-3">
             <p>
                 Are you sure you want to{" "}
                 {isDismantling ? "dismantle" : "upgrade"}{" "}
-                {count > 1 ? "all " : "this "}
+                {plural ? "all " : "this "}
                 <FacilityName facility={facilityName} as="strong" mode="long" />{" "}
-                {count > 1 ? "facilities" : "facility"}?
+                {plural ? "facilities" : "facility"}?
             </p>
             <div className="bg-muted/50 p-4 rounded-lg space-y-2">
-                {count > 1 && (
+                {plural && (
                     <div className="flex justify-between">
                         <span className="font-semibold">Number of facilities:</span>
                         <span>{count}</span>
                     </div>
                 )}
                 <div className="flex justify-between">
-                    <span className="font-semibold">{count > 1 ? "Total cost" : "Cost"}:</span>
+                    <span className="font-semibold">{plural ? "Total cost" : "Cost"}:</span>
                     <Money amount={totalCost} />
                 </div>
             </div>
@@ -190,6 +193,7 @@ function GroupActions({
                                 count={count}
                                 totalCost={totalUpgradeCost}
                                 isDismantling={false}
+                                bulk={true}
                             />
                         }
                         confirmLabel="Upgrade All"
@@ -222,6 +226,7 @@ function GroupActions({
                             count={count}
                             totalCost={totalDismantleCost}
                             isDismantling={true}
+                            bulk={true}
                         />
                     }
                     confirmLabel="Dismantle All"


### PR DESCRIPTION
## Summary
- Follow-up to #733: `ConfirmationContent` was extended with `count > 1` branching, but this broke the "Dismantle All" / "Upgrade All" dialogs in `GroupActions` when a group has exactly one facility — showing "dismantle **this** facility?" while the button says "Dismantle All"
- Adds a `bulk` prop (default `false`) to `ConfirmationContent`; `GroupActions` passes `bulk={true}` to always force plural wording regardless of count

## Test plan
- [ ] Group with 1 facility: "Dismantle All" dialog shows "dismantle **all** … facilities?" with count row
- [ ] Group with 1 facility: "Upgrade All" dialog shows "upgrade **all** … facilities?" with count row
- [ ] Single-row dismantle dialog still shows "dismantle **this** … facility?" with "Cost:"
- [ ] Groups with >1 facility unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `bulk` boolean prop (default `false`) to the `ConfirmationContent` component so that "Dismantle All" / "Upgrade All" group dialogs always render plural wording ("all … facilities") even when a group contains exactly one member. The individual per-row dismantle dialog is unaffected because it omits the prop.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped change with no logic or behavioral regressions.

The fix is a single boolean prop with a sensible default (`false`) that leaves all existing call-sites unchanged. The `plural` derivation (`bulk || count > 1`) correctly covers every combination of the two inputs. Individual-row dialogs are unaffected, and group dialogs consistently show plural wording as intended.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/facilities/facility-group-table.tsx | Adds `bulk` boolean prop to `ConfirmationContent` to force plural wording in GroupActions dialogs regardless of count; all call-sites updated correctly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ConfirmationContent called] --> B{bulk prop?}
    B -- true --> C[plural = true\nforce plural wording]
    B -- false --> D{count > 1?}
    D -- yes --> C
    D -- no --> E[plural = false\nsingular wording]
    C --> F["'all … facilities'\n'Number of facilities: N'\n'Total cost'"]
    E --> G["'this … facility'\n'Cost'"]

    H[GroupActions] -- bulk=true --> A
    I[FacilityActions] -- bulk=false default --> A
```

<sub>Reviews (1): Last reviewed commit: ["fix: GroupActions always uses bulk wordi..."](https://github.com/felixvonsamson/energetica/commit/06b5c44e9e9f23e6010e6c40f28a4cd18c4b079a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30616454)</sub>

<!-- /greptile_comment -->