### PR TITLE
RFC: Apache static serving, split build & multi-instance deployment

### DIFF
--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -1,4 +1,4 @@
-# RFC: Apache Static Serving, Split Build & Multi-Instance Deployment
+# RFC: Apache Static Serving, Split Build & Multi-Season Deployment
 
 **Status:** Draft  
 **Branch:** `rfc/static-serving-split-build`
@@ -7,7 +7,7 @@
 
 ## Problem
 
-FastAPI currently serves all static files (React bundles, images, game data) by proxying through Apache to uvicorn. Apache should handle static content natively and only forward dynamic traffic (API, WebSocket) to Python. Beyond the performance overhead, the current setup has no path to multi-instance deployment and bundles the landing/marketing site into the same JS bundle as the game.
+FastAPI currently serves all static files (React bundles, images, game data) by proxying through Apache to uvicorn. Apache should handle static content natively and only forward dynamic traffic (API, WebSocket) to Python. Beyond the performance overhead, the current setup has no path to multi-season deployment and bundles the landing/marketing site into the same JS bundle as the game.
 
 ---
 
@@ -15,8 +15,22 @@ FastAPI currently serves all static files (React bundles, images, game data) by 
 
 - Apache serves static files directly from the filesystem
 - Split the frontend into two independent bundles: **landing** (public marketing) and **app** (game)
-- Support multiple game instances per server via subdomains
-- Formalise server/instance terminology and tooling
+- Support multiple game seasons per server via subdomains
+- Formalise server/season terminology and tooling
+
+---
+
+## Rationale: Subdomains vs Subpaths
+
+Game seasons could have been deployed at subpaths (`energetica-game.org/autumn-2025/`) rather than subdomains (`autumn-2025.energetica-game.org`). Subdomains are the right choice for three reasons:
+
+**Password managers** save credentials per origin (scheme + hostname). With subdomains, `autumn-2025.energetica-game.org` and `spring-2026.energetica-game.org` are separate origins — separate credential entries, correct autofill. With subpaths, both seasons share `energetica-game.org` → password manager can't distinguish them → wrong autofill or credential collision.
+
+**localStorage** is also isolated per origin. Subdomains give free, automatic per-season isolation. With subpaths, all seasons share the same `energetica-game.org` localStorage namespace — every key would need an instance-slug prefix throughout the codebase to avoid collisions.
+
+**Session cookies** are the most critical. The session cookie is set with `path="/"` and no explicit domain, so it scopes to the current hostname. With subdomains, season A's session cookie physically cannot be sent to season B. With subpaths, all seasons share `energetica-game.org` cookies — logging into one season leaks the session cookie to all others, a real security problem. Fixing it would require FastAPI to set `path=/autumn-2025/` per season, which the auth system has no concept of.
+
+Subdomains also require less build configuration: subpaths need a per-season Vite `base`, TanStack Router `basepath`, and FastAPI `root_path` — all three layers needing to agree per season. Subdomains need only a new Apache vhost; one build works for all seasons.
 
 ---
 
@@ -25,24 +39,26 @@ FastAPI currently serves all static files (React bundles, images, game data) by 
 | Term | Definition |
 |------|------------|
 | **Server** | A VPS, identified by its SSH alias (e.g. `energetica-game`, `energetica-edu`, `energetica-ethz`) |
-| **Instance** | A single running game deployment on a server, identified by a kebab-case slug (e.g. `main`, `autumn-2025`) |
+| **Season** | A single running game deployment on a server, identified by a kebab-case slug (e.g. `autumn-2025`, `spring-2026`). Also used for private university or business deployments. |
 
-Subdomain pattern: `{instance}.{server-domain}` — e.g. `autumn-2025.energetica-game.org`.
+Subdomain pattern: `{season}.{server-domain}` — e.g. `autumn-2025.energetica-game.org`.
 
-The **apex domain always serves the landing page**, never a game instance directly.
+The **apex domain always serves the landing page**, never a season directly.
 
-### Instance name constraints
+> **Terminology note:** "campaign" and "sim" are strong alternatives to "season" — to be confirmed before the first multi-season deployment.
+
+### Season name constraints
 - Lowercase kebab-case only (`[a-z0-9][a-z0-9-]*[a-z0-9]`)
 - Reserved names: **`landing`** (used for the landing site directory)
 
-### Instance discovery
+### Season discovery
 Canonical source of truth is systemd: `systemctl list-units 'energetica-*.service'`. Filesystem enumeration of `/var/www/energetica-*/` is avoided since it would accidentally include `energetica-landing`.
 
 ---
 
 ## Architecture
 
-### Request routing (per-instance subdomain)
+### Request routing (per-season subdomain)
 
 ```
 autumn-2025.energetica-game.org
@@ -53,16 +69,16 @@ autumn-2025.energetica-game.org
 ├── /static/images/    → Apache serves energetica/static/images/
 ├── /static/data/      → Apache serves energetica/static/data/
 ├── /service-worker.js → Apache serves energetica/static/service-worker.js
-├── /manifest.json     → Apache serves energetica/static/app/manifest.json  (PWA, per-instance)
+├── /manifest.json     → Apache serves energetica/static/app/manifest.json  (PWA, per-season)
 ├── /                  → RedirectMatch ^/$ → /app/   (bare root → React router takes over)
 └── /app/*             → FallbackResource → energetica/static/app/index.html
 ```
 
-`manifest.json` is part of the app bundle output and must be served at the root path (PWA requirement). Apache aliases it explicitly. It is per-instance because the PWA manifest may eventually carry instance-specific metadata (name, scope, icons).
+`manifest.json` is part of the app bundle output and must be served at the root path (PWA requirement). Apache aliases it explicitly. It is per-season because the PWA manifest may eventually carry season-specific metadata (name, scope, icons).
 
 ```
 energetica-game.org  (landing — DocumentRoot /var/www/energetica-landing/, no game backend)
-└── /*  → FallbackResource → index.html  (SPA routing for /landing-page, /about, /for-educators)
+└── /*  → FallbackResource → index.html  (SPA routing for /landing-page, /about, /for-educators, /wiki/*, /changelog)
 ```
 
 The landing vhost uses `DocumentRoot /var/www/energetica-landing/`. With `base: "/"`, Vite emits assets at `/assets/index-abc123.js`; Apache serves them directly from DocumentRoot. No Alias needed.
@@ -85,7 +101,7 @@ Everything else (`StaticFiles` mount, all `FileResponse` page handlers) is remov
 
 | Bundle | Routes |
 |--------|--------|
-| **Landing** | `/`, `/landing-page`, `/about`, `/for-educators` |
+| **Landing** | `/`, `/landing-page`, `/about`, `/for-educators`, `/wiki/$slug`, `/changelog` |
 | **App** | `/app/*` (including `/app/sign-up`, moved from top-level `/sign-up`) |
 
 ### Directory structure
@@ -98,6 +114,10 @@ frontend/src/
     landing-page.tsx      ← moved from routes/
     about.tsx             ← moved from routes/
     for-educators.tsx     ← moved from routes/
+    wiki/
+      index.tsx           ← redirects /wiki → /wiki/introduction
+      $slug.tsx           ← same MDX glob as app wiki; auth-unaware layout
+    changelog.tsx         ← same MDX content as app changelog; auth-unaware layout
   routes/                 ← app routes (existing structure, landing files removed)
     __root.tsx            ← auth-aware root (existing, unchanged)
     app/
@@ -108,6 +128,8 @@ frontend/src/
   main.tsx                ← app entry: full providers (Auth, Socket, GameTick, Query, Theme, Resolution)
   main-landing.tsx        ← new; landing entry: light providers (Theme only)
 ```
+
+`vite.config.landing.ts` needs the same `@mdx-js/rollup` plugin configuration as `vite.config.ts` (remark-gfm, remark-math, rehype-katex, rehype-slug). The landing wiki and changelog use auth-unaware layout components; `wiki-layout.tsx` imports `GameLayout` and `useAuth` and cannot be used directly in the landing bundle.
 
 ### Vite configs
 
@@ -122,7 +144,7 @@ Both build outputs are **gitignored** and deployed via rsync:
 
 | Bundle | Output dir | Gitignored | Deployed to |
 |--------|-----------|------------|-------------|
-| app | `energetica/static/app/` | yes | `server:/var/www/energetica-{instance}/energetica/static/app/` |
+| app | `energetica/static/app/` | yes | `server:/var/www/energetica-{season}/energetica/static/app/` |
 | landing | `frontend/dist-landing/` | yes | `server:/var/www/energetica-landing/` |
 
 `.gitignore` must be updated: replace `energetica/static/react/*` with `energetica/static/app/*` and add `frontend/dist-landing/`.
@@ -148,25 +170,25 @@ scripts/
   infra/
     setup-base.sh             ← run once per server; installs Apache, Python, certbot, firewall, modules
     setup-landing.sh          ← run once per server; creates /var/www/energetica-landing/, main domain vhost
-    setup-instance.sh         ← run per instance; usage: setup-instance.sh <instance> <port>
+    setup-season.sh           ← run per season; usage: setup-season.sh <season> <port>
     apache-main.conf          ← main domain vhost template (static landing, no proxy)
-    apache-instance.conf      ← instance vhost template (app static + API proxy)
+    apache-season.conf        ← season vhost template (app static + API proxy)
     energetica.service        ← systemd service template
   deploy-landing.sh           ← build:landing → rsync dist-landing/ → server:/var/www/energetica-landing/
-  deploy-instance.sh          ← usage: --server <server> --instance <instance>
-  list-instances.sh           ← usage: --server <server>; queries systemd, prints name/port/status table
+  deploy-season.sh            ← usage: --server <server> --season <season>
+  list-seasons.sh             ← usage: --server <server>; queries systemd, prints name/port/status table
 ```
 
 `scripts/vps-setup.sh` is superseded by the three `infra/setup-*.sh` scripts and will be removed.
 
-### `deploy-instance.sh` flow
+### `deploy-season.sh` flow
 
 1. Build app bundle (`bun run build`)
 2. Confirm deployment summary (skipped with `--yes`)
-3. `rsync` Python backend code to server (excluding `.venv`, `instance/`, build artifacts)
+3. `rsync` Python backend code to server (excluding `.venv`, `season/`, build artifacts)
 4. `rsync` app bundle to server
 5. `pip install -r requirements.txt` on server if dependencies changed
-6. `systemctl restart energetica-{instance}`
+6. `systemctl restart energetica-{season}`
 7. Health check
 
 Scripts accept all inputs via arguments or env vars and support `--yes` to suppress confirmation prompts, making them callable from a CI job without modification. No commitment to a CI platform is made here.
@@ -180,35 +202,9 @@ No service restart — landing is pure static.
 
 ---
 
-## Migration Steps (single current instance)
-
-The existing `energetica-game.org` instance continues running during migration. Steps are ordered to avoid any static-file outage: Apache must be serving files directly **before** FastAPI stops serving them.
-
-**Code changes (no deployment yet):**
-1. Update `.gitignore`: replace `energetica/static/react/*` → `energetica/static/app/*`, add `frontend/dist-landing/`
-2. Implement split frontend (routes, Vite configs, entry points)
-3. Move `/sign-up` → `/app/sign-up`, update all internal links
-4. Build app bundle → output lands in `energetica/static/app/`
-
-**Cutover (order is critical):**
-
-5. `rsync` app bundle to server (`energetica/static/app/` now exists on server)
-6. Update Apache vhost on server, reload Apache — Apache now serves `/static/app/`, `/static/images/`, `/manifest.json`, etc. directly from the filesystem. FastAPI's `StaticFiles` mount is now redundant but still active; no outage.
-7. Remove `StaticFiles` mount and all `FileResponse` page handlers from FastAPI (`templates.py`), deploy and restart service — Apache is already covering static files, so this causes no gap.
-
-**Cleanup:**
-
-8. Deploy landing build to `/var/www/energetica-landing/` on server
-9. Delete `energetica/static/apple-app-site-association`
-10. Extract `scripts/infra/` configs, remove old `scripts/vps-setup.sh`
-
----
-
----
-
 ## Deferred / Out of Scope
 
 - **CI/CD** — deployment is via local scripts for now. Scripts are CI-compatible by design (all inputs via args/env vars, `--yes` flag, deterministic exit codes). Wiring to GitHub Actions or equivalent is a future decision.
 - **Admin dashboard** — currently stubbed. The server-side role gate in `templates.py` will be dropped along with all other `FileResponse` handlers. A proper frontend route guard and admin UI are a separate workstream.
 - **Landing images on multi-server** — landing pages reference images at `/static/images/`. On a server with no game instance (pure landing server), these paths would break. To be addressed when a second server deployment is made.
-- **Service worker on multiple instances** — currently scoped to `/`. Per-instance scoping implications (e.g. `autumn-2025.energetica-game.org/service-worker.js`) are not an architectural concern but should be tested when the first subdomain instance goes live.
+- **Service worker on multiple seasons** — currently scoped to `/`. Per-season scoping implications (e.g. `autumn-2025.energetica-game.org/service-worker.js`) are not an architectural concern but should be tested when the first subdomain season goes live.

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -54,16 +54,18 @@ autumn-2025.energetica-game.org
 ├── /static/data/      → Apache serves energetica/static/data/
 ├── /service-worker.js → Apache serves energetica/static/service-worker.js
 ├── /manifest.json     → Apache serves energetica/static/app/manifest.json  (PWA, per-instance)
+├── /                  → RedirectMatch ^/$ → /app/   (bare root → React router takes over)
 └── /app/*             → FallbackResource → energetica/static/app/index.html
 ```
 
 `manifest.json` is part of the app bundle output and must be served at the root path (PWA requirement). Apache aliases it explicitly. It is per-instance because the PWA manifest may eventually carry instance-specific metadata (name, scope, icons).
 
 ```
-energetica-game.org  (landing — no game backend)
-├── /static/landing/ → Apache serves /var/www/energetica-landing/static/landing/
-└── /*               → FallbackResource → /var/www/energetica-landing/index.html
+energetica-game.org  (landing — DocumentRoot /var/www/energetica-landing/, no game backend)
+└── /*  → FallbackResource → index.html  (SPA routing for /landing-page, /about, /for-educators)
 ```
+
+The landing vhost uses `DocumentRoot /var/www/energetica-landing/`. With `base: "/"`, Vite emits assets at `/assets/index-abc123.js`; Apache serves them directly from DocumentRoot. No Alias needed.
 
 ### What FastAPI keeps
 

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -159,15 +159,15 @@ scripts/
 
 ### `deploy-instance.sh` flow
 
-> **Note:** The exact mechanism for deploying Python backend code is an open question — see [Open Questions](#open-questions--deferred). The steps below describe the current pragmatic approach; CI/CD would replace steps 1–6.
-
 1. Build app bundle (`bun run build`)
-2. Confirm deployment summary
+2. Confirm deployment summary (skipped with `--yes`)
 3. `rsync` Python backend code to server (excluding `.venv`, `instance/`, build artifacts)
 4. `rsync` app bundle to server
 5. `pip install -r requirements.txt` on server if dependencies changed
 6. `systemctl restart energetica-{instance}`
 7. Health check
+
+Scripts accept all inputs via arguments or env vars and support `--yes` to suppress confirmation prompts, making them callable from a CI job without modification. No commitment to a CI platform is made here.
 
 ### `deploy-landing.sh` flow
 
@@ -194,30 +194,11 @@ The existing `energetica-game.org` instance continues running during migration:
 
 ---
 
-## Open Questions
-
-### CI/CD and deployment strategy
-
-The current deploy flow (rsync from a developer's local machine) has two problems:
-- It requires a working local build environment on every developer's machine
-- Deployments are not reproducible across machines
-
-Options under consideration:
-
-| Approach | Description | Tradeoff |
-|----------|-------------|----------|
-| **Local rsync** (current) | Developer builds locally, rsyncs to server | Simple; not reproducible |
-| **GitHub Actions** | Push to `main` → CI builds + rsyncs to server | Reproducible; requires CI secrets for SSH/rsync |
-| **Artifact-based** | CI builds a tarball, server pulls and extracts | Atomic; more infra overhead |
-
-Using `git pull` on the production server (previous approach) is intentionally avoided — it couples deployment to git history, exposes `.git` on the server, and makes dependency updates error-prone.
-
-This decision is deferred; the scripts should be written so the rsync steps are easily replaceable by a CI job.
-
 ---
 
 ## Deferred / Out of Scope
 
+- **CI/CD** — deployment is via local scripts for now. Scripts are CI-compatible by design (all inputs via args/env vars, `--yes` flag, deterministic exit codes). Wiring to GitHub Actions or equivalent is a future decision.
 - **Admin dashboard** — currently stubbed. The server-side role gate in `templates.py` will be dropped along with all other `FileResponse` handlers. A proper frontend route guard and admin UI are a separate workstream.
 - **Landing images on multi-server** — landing pages reference images at `/static/images/`. On a server with no game instance (pure landing server), these paths would break. To be addressed when a second server deployment is made.
 - **Service worker on multiple instances** — currently scoped to `/`. Per-instance scoping implications (e.g. `autumn-2025.energetica-game.org/service-worker.js`) are not an architectural concern but should be tested when the first subdomain instance goes live.

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -182,17 +182,25 @@ No service restart — landing is pure static.
 
 ## Migration Steps (single current instance)
 
-The existing `energetica-game.org` instance continues running during migration:
+The existing `energetica-game.org` instance continues running during migration. Steps are ordered to avoid any static-file outage: Apache must be serving files directly **before** FastAPI stops serving them.
 
+**Code changes (no deployment yet):**
 1. Update `.gitignore`: replace `energetica/static/react/*` → `energetica/static/app/*`, add `frontend/dist-landing/`
-2. Rename build output: `energetica/static/react/` → `energetica/static/app/`
-3. Implement split frontend (routes, Vite configs, entry points)
-4. Move `/sign-up` → `/app/sign-up`, update all internal links
-5. Remove `StaticFiles` mount and all `FileResponse` handlers from FastAPI (`templates.py`)
-6. Delete `energetica/static/apple-app-site-association`
-7. Extract `scripts/infra/` configs, update Apache vhost on server, reload Apache
+2. Implement split frontend (routes, Vite configs, entry points)
+3. Move `/sign-up` → `/app/sign-up`, update all internal links
+4. Build app bundle → output lands in `energetica/static/app/`
+
+**Cutover (order is critical):**
+
+5. `rsync` app bundle to server (`energetica/static/app/` now exists on server)
+6. Update Apache vhost on server, reload Apache — Apache now serves `/static/app/`, `/static/images/`, `/manifest.json`, etc. directly from the filesystem. FastAPI's `StaticFiles` mount is now redundant but still active; no outage.
+7. Remove `StaticFiles` mount and all `FileResponse` page handlers from FastAPI (`templates.py`), deploy and restart service — Apache is already covering static files, so this causes no gap.
+
+**Cleanup:**
+
 8. Deploy landing build to `/var/www/energetica-landing/` on server
-9. Remove old `scripts/vps-setup.sh`
+9. Delete `energetica/static/apple-app-site-association`
+10. Extract `scripts/infra/` configs, remove old `scripts/vps-setup.sh`
 
 ---
 

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -46,15 +46,18 @@ Canonical source of truth is systemd: `systemctl list-units 'energetica-*.servic
 
 ```
 autumn-2025.energetica-game.org
-├── /api/*          → ProxyPass → uvicorn :8001
-├── /socket.io      → ProxyPass → uvicorn :8001  (+ WS upgrade)
-├── /logout         → ProxyPass → uvicorn :8001
-├── /static/app/    → Apache serves /var/www/energetica-autumn-2025/energetica/static/app/
-├── /static/images/ → Apache serves /var/www/energetica-autumn-2025/energetica/static/images/
-├── /static/data/   → Apache serves /var/www/energetica-autumn-2025/energetica/static/data/
-├── /service-worker.js → Apache serves from static/
-└── /app/*          → FallbackResource → static/app/index.html
+├── /api/*             → ProxyPass → uvicorn :8001
+├── /socket.io         → ProxyPass → uvicorn :8001  (+ WS upgrade)
+├── /logout            → ProxyPass → uvicorn :8001
+├── /static/app/       → Apache serves energetica/static/app/
+├── /static/images/    → Apache serves energetica/static/images/
+├── /static/data/      → Apache serves energetica/static/data/
+├── /service-worker.js → Apache serves energetica/static/service-worker.js
+├── /manifest.json     → Apache serves energetica/static/app/manifest.json  (PWA, per-instance)
+└── /app/*             → FallbackResource → energetica/static/app/index.html
 ```
+
+`manifest.json` is part of the app bundle output and must be served at the root path (PWA requirement). Apache aliases it explicitly. It is per-instance because the PWA manifest may eventually carry instance-specific metadata (name, scope, icons).
 
 ```
 energetica-game.org  (landing — no game backend)
@@ -69,6 +72,8 @@ energetica-game.org  (landing — no game backend)
 - `/logout` — deletes session cookie, redirects to `/app/login`
 
 Everything else (`StaticFiles` mount, all `FileResponse` page handlers) is removed from FastAPI.
+
+`energetica/static/apple-app-site-association` is also removed — it is legacy and no longer used.
 
 ---
 

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -1,0 +1,186 @@
+# RFC: Apache Static Serving, Split Build & Multi-Instance Deployment
+
+**Status:** Draft  
+**Branch:** `rfc/static-serving-split-build`
+
+---
+
+## Problem
+
+FastAPI currently serves all static files (React bundles, images, game data) by proxying through Apache to uvicorn. Apache should handle static content natively and only forward dynamic traffic (API, WebSocket) to Python. Beyond the performance overhead, the current setup has no path to multi-instance deployment and bundles the landing/marketing site into the same JS bundle as the game.
+
+---
+
+## Goals
+
+- Apache serves static files directly from the filesystem
+- Split the frontend into two independent bundles: **landing** (public marketing) and **app** (game)
+- Support multiple game instances per server via subdomains
+- Formalise server/instance terminology and tooling
+
+---
+
+## Terminology
+
+| Term | Definition |
+|------|------------|
+| **Server** | A VPS, identified by its SSH alias (e.g. `energetica-game`, `energetica-edu`, `energetica-ethz`) |
+| **Instance** | A single running game deployment on a server, identified by a kebab-case slug (e.g. `main`, `autumn-2025`) |
+
+Subdomain pattern: `{instance}.{server-domain}` — e.g. `autumn-2025.energetica-game.org`.
+
+The **apex domain always serves the landing page**, never a game instance directly.
+
+### Instance name constraints
+- Lowercase kebab-case only (`[a-z0-9][a-z0-9-]*[a-z0-9]`)
+- Reserved names: **`landing`** (used for the landing site directory)
+
+### Instance discovery
+Canonical source of truth is systemd: `systemctl list-units 'energetica-*.service'`. Filesystem enumeration of `/var/www/energetica-*/` is avoided since it would accidentally include `energetica-landing`.
+
+---
+
+## Architecture
+
+### Request routing (per-instance subdomain)
+
+```
+autumn-2025.energetica-game.org
+├── /api/*          → ProxyPass → uvicorn :8001
+├── /socket.io      → ProxyPass → uvicorn :8001  (+ WS upgrade)
+├── /logout         → ProxyPass → uvicorn :8001
+├── /static/app/    → Apache serves /var/www/energetica-autumn-2025/energetica/static/app/
+├── /static/images/ → Apache serves /var/www/energetica-autumn-2025/energetica/static/images/
+├── /static/data/   → Apache serves /var/www/energetica-autumn-2025/energetica/static/data/
+├── /service-worker.js → Apache serves from static/
+└── /app/*          → FallbackResource → static/app/index.html
+```
+
+```
+energetica-game.org  (landing — no game backend)
+├── /static/landing/ → Apache serves /var/www/energetica-landing/static/landing/
+└── /*               → FallbackResource → /var/www/energetica-landing/index.html
+```
+
+### What FastAPI keeps
+
+- `/api/v1/*` — REST API
+- `/socket.io` — WebSocket
+- `/logout` — deletes session cookie, redirects to `/app/login`
+
+Everything else (`StaticFiles` mount, all `FileResponse` page handlers) is removed from FastAPI.
+
+---
+
+## Frontend Split Build
+
+### Route split
+
+| Bundle | Routes |
+|--------|--------|
+| **Landing** | `/`, `/landing-page`, `/about`, `/for-educators` |
+| **App** | `/app/*` (including `/app/sign-up`, moved from top-level `/sign-up`) |
+
+### Directory structure
+
+```
+frontend/src/
+  routes-landing/         ← new; scanned by landing Vite config
+    __root.tsx            ← simple root, no auth, just <Outlet />
+    index.tsx             ← redirects / → /landing-page
+    landing-page.tsx      ← moved from routes/
+    about.tsx             ← moved from routes/
+    for-educators.tsx     ← moved from routes/
+  routes/                 ← app routes (existing structure, landing files removed)
+    __root.tsx            ← auth-aware root (existing, unchanged)
+    app/
+      sign-up.tsx         ← moved from routes/sign-up.tsx
+      login.tsx
+      dashboard.tsx
+      ...
+  main.tsx                ← app entry: full providers (Auth, Socket, GameTick, Query, Theme, Resolution)
+  main-landing.tsx        ← new; landing entry: light providers (Theme only)
+```
+
+### Vite configs
+
+Two separate config files:
+
+| File | Bundle | `base` | Output dir |
+|------|--------|--------|------------|
+| `vite.config.ts` | app | `/static/app/` | `energetica/static/app/` |
+| `vite.config.landing.ts` | landing | `/` | `frontend/dist-landing/` |
+
+The app build output lives **inside the instance directory** (committed to git, deployed via rsync alongside the backend). The landing build output lives in `frontend/dist-landing/` (gitignored, deployed separately to `/var/www/energetica-landing/`).
+
+### `package.json` scripts
+
+```json
+"dev":            "vite",
+"dev:landing":    "vite --config vite.config.landing.ts",
+"build":          "vite build && bun run build:sw",
+"build:landing":  "vite build --config vite.config.landing.ts",
+"build:all":      "bun run build && bun run build:landing"
+```
+
+---
+
+## Infrastructure Scripts
+
+### New structure
+
+```
+scripts/
+  infra/
+    setup-base.sh             ← run once per server; installs Apache, Python, certbot, firewall, modules
+    setup-landing.sh          ← run once per server; creates /var/www/energetica-landing/, main domain vhost
+    setup-instance.sh         ← run per instance; usage: setup-instance.sh <instance> <port>
+    apache-main.conf          ← main domain vhost template (static landing, no proxy)
+    apache-instance.conf      ← instance vhost template (app static + API proxy)
+    energetica.service        ← systemd service template
+  deploy-landing.sh           ← build:landing → rsync dist-landing/ → server:/var/www/energetica-landing/
+  deploy-instance.sh          ← usage: --server <server> --instance <instance>
+  list-instances.sh           ← usage: --server <server>; queries systemd, prints name/port/status table
+```
+
+`scripts/vps-setup.sh` is superseded by the three `infra/setup-*.sh` scripts and will be removed.
+
+### `deploy-instance.sh` flow
+
+1. Build app bundle (`bun run build`)
+2. Validate git is clean (unless `--force`)
+3. Confirm deployment summary
+4. Verify commits are pushed
+5. `git pull` on server (backend code)
+6. `rsync` app bundle to server
+7. `systemctl restart energetica-{instance}`
+8. Health check
+
+### `deploy-landing.sh` flow
+
+1. Build landing bundle (`bun run build:landing`)
+2. `rsync dist-landing/` to `server:/var/www/energetica-landing/`
+
+No service restart — landing is pure static.
+
+---
+
+## Migration Steps (single current instance)
+
+The existing `energetica-game.org` instance continues running during migration:
+
+1. Rename build output: `energetica/static/react/` → `energetica/static/app/`
+2. Implement split frontend (routes, Vite configs, entry points)
+3. Move `/sign-up` → `/app/sign-up`, update all internal links
+4. Remove `StaticFiles` mount and all `FileResponse` handlers from FastAPI (`templates.py`)
+5. Extract `scripts/infra/` configs, update Apache vhost on server, reload Apache
+6. Deploy landing build to `/var/www/energetica-landing/` on server
+7. Remove old `scripts/vps-setup.sh`
+
+---
+
+## Deferred / Out of Scope
+
+- **Admin dashboard** — currently stubbed. The server-side role gate in `templates.py` will be dropped along with all other `FileResponse` handlers. A proper frontend route guard and admin UI are a separate workstream.
+- **Landing images on multi-server** — landing pages reference images at `/static/images/`. On a server with no game instance (pure landing server), these paths would break. To be addressed when a second server deployment is made.
+- **Service worker on multiple instances** — currently scoped to `/`. Per-instance scoping implications (e.g. `autumn-2025.energetica-game.org/service-worker.js`) are not an architectural concern but should be tested when the first subdomain instance goes live.

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -116,7 +116,14 @@ Two separate config files:
 | `vite.config.ts` | app | `/static/app/` | `energetica/static/app/` |
 | `vite.config.landing.ts` | landing | `/` | `frontend/dist-landing/` |
 
-The app build output lives **inside the instance directory** (committed to git, deployed via rsync alongside the backend). The landing build output lives in `frontend/dist-landing/` (gitignored, deployed separately to `/var/www/energetica-landing/`).
+Both build outputs are **gitignored** and deployed via rsync:
+
+| Bundle | Output dir | Gitignored | Deployed to |
+|--------|-----------|------------|-------------|
+| app | `energetica/static/app/` | yes | `server:/var/www/energetica-{instance}/energetica/static/app/` |
+| landing | `frontend/dist-landing/` | yes | `server:/var/www/energetica-landing/` |
+
+`.gitignore` must be updated: replace `energetica/static/react/*` with `energetica/static/app/*` and add `frontend/dist-landing/`.
 
 ### `package.json` scripts
 
@@ -152,14 +159,15 @@ scripts/
 
 ### `deploy-instance.sh` flow
 
+> **Note:** The exact mechanism for deploying Python backend code is an open question — see [Open Questions](#open-questions--deferred). The steps below describe the current pragmatic approach; CI/CD would replace steps 1–6.
+
 1. Build app bundle (`bun run build`)
-2. Validate git is clean (unless `--force`)
-3. Confirm deployment summary
-4. Verify commits are pushed
-5. `git pull` on server (backend code)
-6. `rsync` app bundle to server
-7. `systemctl restart energetica-{instance}`
-8. Health check
+2. Confirm deployment summary
+3. `rsync` Python backend code to server (excluding `.venv`, `instance/`, build artifacts)
+4. `rsync` app bundle to server
+5. `pip install -r requirements.txt` on server if dependencies changed
+6. `systemctl restart energetica-{instance}`
+7. Health check
 
 ### `deploy-landing.sh` flow
 
@@ -174,13 +182,37 @@ No service restart — landing is pure static.
 
 The existing `energetica-game.org` instance continues running during migration:
 
-1. Rename build output: `energetica/static/react/` → `energetica/static/app/`
-2. Implement split frontend (routes, Vite configs, entry points)
-3. Move `/sign-up` → `/app/sign-up`, update all internal links
-4. Remove `StaticFiles` mount and all `FileResponse` handlers from FastAPI (`templates.py`)
-5. Extract `scripts/infra/` configs, update Apache vhost on server, reload Apache
-6. Deploy landing build to `/var/www/energetica-landing/` on server
-7. Remove old `scripts/vps-setup.sh`
+1. Update `.gitignore`: replace `energetica/static/react/*` → `energetica/static/app/*`, add `frontend/dist-landing/`
+2. Rename build output: `energetica/static/react/` → `energetica/static/app/`
+3. Implement split frontend (routes, Vite configs, entry points)
+4. Move `/sign-up` → `/app/sign-up`, update all internal links
+5. Remove `StaticFiles` mount and all `FileResponse` handlers from FastAPI (`templates.py`)
+6. Delete `energetica/static/apple-app-site-association`
+7. Extract `scripts/infra/` configs, update Apache vhost on server, reload Apache
+8. Deploy landing build to `/var/www/energetica-landing/` on server
+9. Remove old `scripts/vps-setup.sh`
+
+---
+
+## Open Questions
+
+### CI/CD and deployment strategy
+
+The current deploy flow (rsync from a developer's local machine) has two problems:
+- It requires a working local build environment on every developer's machine
+- Deployments are not reproducible across machines
+
+Options under consideration:
+
+| Approach | Description | Tradeoff |
+|----------|-------------|----------|
+| **Local rsync** (current) | Developer builds locally, rsyncs to server | Simple; not reproducible |
+| **GitHub Actions** | Push to `main` → CI builds + rsyncs to server | Reproducible; requires CI secrets for SSH/rsync |
+| **Artifact-based** | CI builds a tarball, server pulls and extracts | Atomic; more infra overhead |
+
+Using `git pull` on the production server (previous approach) is intentionally avoided — it couples deployment to git history, exposes `.git` on the server, and makes dependency updates error-prone.
+
+This decision is deferred; the scripts should be written so the rsync steps are easily replaceable by a CI job.
 
 ---
 


### PR DESCRIPTION
## Summary

- Documents the decision to move static file serving from FastAPI to Apache
- Proposes a split frontend build: **landing** (public marketing) and **app** (game)
- Formalises **server/instance** terminology and subdomain-per-instance deployment model
- Restructures infra scripts into `scripts/infra/` with separate setup and deploy scripts

## RFC location

`docs/architecture/static-serving-and-deployment.md`

## Key decisions

- Apache serves `/static/app/`, `/static/images/`, `/static/data/` directly; FastAPI only handles `/api`, `/socket.io`, `/logout`
- Two Vite configs (`vite.config.ts` for app, `vite.config.landing.ts` for landing), two route directories, two entry points
- `/sign-up` moves to `/app/sign-up`
- Landing is a singleton per server at `/var/www/energetica-landing/`, deployed independently via `deploy-landing.sh`
- Game instances are identified by kebab-case slug = subdomain (e.g. `autumn-2025.energetica-game.org`); `landing` is reserved
- Instance discovery via systemd: `systemctl list-units 'energetica-*.service'`
- `vps-setup.sh` replaced by `infra/setup-base.sh`, `infra/setup-landing.sh`, `infra/setup-instance.sh <name> <port>`

## Not yet implemented

This PR is RFC-only. Implementation is a follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This RFC documents three interconnected architectural decisions: moving static file serving from FastAPI to Apache, splitting the frontend into separate landing and app Vite bundles, and introducing a subdomain-per-season multi-game deployment model with matching infra scripts. The document has incorporated all previous review feedback (DocumentRoot landing vhost, root redirect, manifest.json alias, migration cutover order, gitignore clarification).

- **Routing & bundle split**: Clear and correct — `FallbackResource` scoped to `/app/*`, `DocumentRoot` for landing, and `base: \"/static/app/\"` alignment are all consistent.
- **`deploy-season.sh` flow**: The service worker (`energetica/static/service-worker.js`) is built by `bun run build` but lives outside `energetica/static/app/`; the RFC's deploy steps have no equivalent of the explicit rsync line currently in `deploy.sh`, leaving the service worker undeployed on each season update.
- **`setup-season.sh`**: TLS certificate provisioning for new season subdomains is not mentioned. The existing `vps-setup.sh` uses certbot for the apex domain, but wildcard or per-subdomain cert acquisition for `{season}.energetica-game.org` is absent from the proposed script structure.

<h3>Confidence Score: 3/5</h3>

The RFC is well-reasoned and addresses all prior review feedback, but two concrete gaps in the proposed scripts need to be filled before implementation.

The deploy-season.sh flow has no step for the service worker file, which lives outside the app bundle directory and was handled by an explicit rsync in the old deploy.sh — omitting it means every season deployment silently ships a stale or absent service worker. Separately, setup-season.sh has no TLS provisioning step, so every new season subdomain will be unreachable over HTTPS until certificates are obtained manually.

docs/architecture/static-serving-and-deployment.md — specifically the deploy-season.sh flow (service worker rsync) and the setup-season.sh script description (TLS certificate provisioning).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/architecture/static-serving-and-deployment.md | New RFC document describing the Apache static-serving migration, split frontend build, and multi-season deployment model. Two gaps remain: the deploy-season.sh flow omits a deploy step for the service worker (built outside energetica/static/app/), and setup-season.sh has no TLS certificate provisioning for new season subdomains. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Client([Browser])
    Client -->|"*.energetica-game.org"| SeasonVHost["Apache: season vhost"]
    Client -->|"energetica-game.org"| LandingVHost["Apache: landing vhost\nDocumentRoot /var/www/energetica-landing/"]
    SeasonVHost -->|"/api/*, /socket.io, /logout"| Uvicorn["uvicorn :800X FastAPI"]
    SeasonVHost -->|"/static/app/"| AppBundle["energetica/static/app/"]
    SeasonVHost -->|"/service-worker.js"| SW["energetica/static/service-worker.js"]
    SeasonVHost -->|"/app/* FallbackResource"| AppBundle
    LandingVHost -->|"/* FallbackResource"| LandingIndex["/var/www/energetica-landing/index.html"]
```

<sub>Reviews (5): Last reviewed commit: ["docs(rfc): incorporate review feedback —..."](https://github.com/felixvonsamson/energetica/commit/a0e36e3487cc6589c7c3cc9daeab7e7c325e89d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30745317)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->