### PR TITLE
updatinng roots

### DIFF
--- a/frontend/src/types/app-routes.ts
+++ b/frontend/src/types/app-routes.ts
@@ -2,8 +2,8 @@
 // Run `bun run build:sw` to update.
 export type AppRoute =
     | '/about'
+    | '/for-educators'
     | '/landing-page'
-    | '/learning-tool'
     | '/sign-up'
     | '/app/changelog'
     | '/app/dashboard'


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the public route `/learning-tool` to `/for-educators`. The auto-generated `app-routes.ts` type union is updated to reflect the route that already exists in `routeTree.gen.ts`, `for-educators.tsx`, and all components that link to it (`header.tsx`, `footer.tsx`, `landing-page.tsx`). No usages of `/learning-tool` remain in the codebase.

- Drops `/learning-tool` from the `AppRoute` union type and adds `/for-educators`, keeping the type in sync with the actual route tree.
- The change is purely a rename; all consuming code already references the new route path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the route rename is complete and consistent across all affected files.

The `/learning-tool` route is fully removed from every file in the repo, and `/for-educators` is already wired up in the route tree, all link components, and now the AppRoute type. No dangling references or missing updates detected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/types/app-routes.ts | Replaces the `/learning-tool` route string with `/for-educators` in the auto-generated AppRoute union type; `/for-educators` is already present in routeTree.gen.ts and all referencing components |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks For Educators link] --> B[Router resolves '/for-educators']
    B --> C[for-educators.tsx component rendered]
    
    D[header.tsx] -->|to='/for-educators'| B
    E[footer.tsx] -->|to='/for-educators'| B
    F[landing-page.tsx] -->|to='/for-educators'| B
    
    G[routeTree.gen.ts] -->|defines route| B
    H[app-routes.ts AppRoute type] -->|includes '/for-educators'| B
    
    style A fill:#f9f,stroke:#333
    style C fill:#9f9,stroke:#333
```

<sub>Reviews (1): Last reviewed commit: ["updatinng roots"](https://github.com/felixvonsamson/energetica/commit/065400e919fdd9a5550d262fbc07cbc0fce154bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30905820)</sub>

<!-- /greptile_comment -->