### PR TITLE
fix: don't abort complete_project when push delivery fails (#753)

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -461,6 +461,12 @@ class Player(DBModel):
                     pass
             else:
                 engine.warn(f"Failed to send notification: {repr(ex)}")
+        except Exception as ex:  # noqa: BLE001
+            # Push delivery is best-effort: any transport/library failure (DNS, TCP, TLS, library
+            # bug, ...) must not abort the caller, since notify() is invoked from inside
+            # complete_project and a raise here leaves the player's state half-finished
+            # (project deleted, ActiveFacility never created). See issue #753.
+            engine.warn(f"Failed to send notification: {repr(ex)}")
 
     def notify(self, payload: PersistableNotificationPayload) -> None:
         """


### PR DESCRIPTION
## Summary

Closes #753.

`notify_subscription` only catches `WebPushException`, so transport-layer errors from the underlying `requests` stack (`ConnectionError`, `OSError`, TLS, ...) propagate up through `notify()` and abort whatever is calling it. When that caller is `complete_project()`, the abort happens **after `project.delete()`** but **before** the `ActiveFacility(...)` creation, leaving the player paid up but with no facility.

This caught one player on the edu server: a `[Errno 101] Network is unreachable` to `updates.push.services.mozilla.com` during a tick destroyed their coal-mine build (project deleted, money debited, no mine). Their state has since been restored manually; this PR makes sure it doesn't happen again.

The fix is minimal: add a broad `except Exception` to `notify_subscription` so any failure inside `webpush()` is logged via `engine.warn` but never propagates. Push delivery is best-effort — it must never affect game state.

## Test plan

- [ ] `bun run typecheck` (frontend unaffected, but full suite green)
- [ ] `ruff check` / `ruff format` clean on the changed file
- [ ] Manual: simulate a `webpush()` failure (e.g. `iptables -A OUTPUT -d updates.push.services.mozilla.com -j REJECT` on a dev box, or monkeypatch `webpush` in a REPL) during a `complete_project` and confirm the construction completes normally and the warning lands in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a broad `except Exception` handler in `notify_subscription` so transport-layer errors (`ConnectionError`, `OSError`, TLS failures, etc.) that bypass the existing `WebPushException` handler are caught, logged via `engine.warn`, and never re-raised. This prevents a partially-executed `complete_project` from leaving a player with no facility after their project was already deleted and money debited.

- `project.delete()` at line 345 of `complete_project` executes before `player.notify()` (lines 357–382) and before `ActiveFacility(...)` (line 404), so any unhandled exception from `notify_subscription` produced the broken state seen in production.
- The fix correctly places the broad handler after the specific `WebPushException` catch, annotates it with `# noqa: BLE001`, and uses identical warning formatting to keep the error visible in logs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, well-scoped catch that prevents a real production breakage without touching any game logic.

The change is a single 6-line addition in an exception handler, reproducing the exact pattern already used for `WebPushException`. The new `except Exception` block is placed after the more-specific handler (correct ordering), is explicitly suppressed by `# noqa: BLE001`, and its only side-effect is an `engine.warn` call. `Exception` correctly excludes `BaseException` subclasses like `KeyboardInterrupt` and `SystemExit`, so it won't mask shutdown signals. The bug it fixes is confirmed by a real production incident and the call sequence (`project.delete()` → `notify()` → `ActiveFacility(...)`) visibly leaves game state inconsistent on any unhandled raise from `notify_subscription`.

No files require special attention — the only changed file is `energetica/database/player.py`, and the change is minimal and contained within one exception handler.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/player.py | Adds a broad `except Exception` fallback in `notify_subscription` to swallow and log any non-WebPushException errors, preventing push delivery failures from aborting game-state mutations in `complete_project`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TE as tick_execution
    participant CP as complete_project()
    participant DB as Database
    participant NS as notify_subscription()
    participant WP as webpush()

    TE->>CP: complete_project(project)
    CP->>DB: project.delete()
    Note over DB: Project removed, money debited
    CP->>NS: player.notify() → notify_subscription()
    NS->>WP: webpush(...)
    alt Before fix — transport error
        WP-->>NS: raises ConnectionError / OSError / TLS error
        NS-->>CP: exception propagates
        Note over CP: ActiveFacility never created!
        Note over DB: Broken state: deleted project, no facility
    else After fix — transport error
        WP-->>NS: raises ConnectionError / OSError / TLS error
        NS->>NS: except Exception -> engine.warn(...)
        NS-->>CP: returns normally
        CP->>DB: ActiveFacility(...)
        Note over DB: Facility created correctly
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t abort complete\_project when p..."](https://github.com/felixvonsamson/energetica/commit/2f301c14c2441d676b49a7be2edf449eda956a4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31040627)</sub>

<!-- /greptile_comment -->