### PR TITLE
fix: don't start merit-order curves at (0, 0)

### DIFF
--- a/frontend/src/lib/charts/ui-utils.ts
+++ b/frontend/src/lib/charts/ui-utils.ts
@@ -51,8 +51,9 @@ export function interpolateAtX(
  * Transforms order data into a stepped curve for visualization. Creates points
  * for a ragged supply or demand curve from discrete orders.
  *
- * The resulting curve starts at (0,0), then for each order creates a vertical
- * step (price change) followed by a horizontal step (quantity change).
+ * The resulting curve starts at (0, firstPrice) so it does not include a
+ * vertical segment at x=0 rising from zero — a useful property for demand
+ * curves whose first order sits at the highest price.
  *
  * @param prices - Price for each order
  * @param cumulCapacities - Cumulative quantity at each order
@@ -68,9 +69,6 @@ export function createSteppedCurve(
     if (prices.length === 0) return [];
 
     const points: CurvePoint[] = [];
-
-    // Start at origin
-    points.push({ quantity: 0, price: 0 });
 
     for (let i = 0; i < prices.length; i++) {
         const prevCumul = i === 0 ? 0 : (cumulCapacities[i - 1] ?? 0);


### PR DESCRIPTION
## Summary
- Removes the unconditional `(0, 0)` seed point in `createSteppedCurve`, which produced a vertical spike at x=0 on the merit-order chart — most visible on the demand curve, where it shot up from zero to the highest demand price before stepping rightward.
- Curves now start at `(0, firstPrice)`. The loop's first iteration already pushes that point (since `prevCumul` is 0 when `i === 0`), so the `(0, 0)` seed was strictly producing the spurious segment.

Fixes #715

## Test plan
- [ ] Open the Electricity Markets overview, verify the demand curve starts at the highest demand price on the y-axis (no vertical line up from 0).
- [ ] Verify the supply curve starts at the lowest supply price (no vertical line up from 0).
- [ ] Toggle Supply / Demand views and step the tick slider; both curves render correctly across ticks.
- [ ] Drag-to-zoom; clipped curves still terminate at the visible window edges as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the unconditional `{ quantity: 0, price: 0 }` seed point from `createSteppedCurve`, which caused a spurious vertical segment at x=0 on merit-order charts (most visible on the demand curve, where it shot up from zero to the highest price). Since the loop's first iteration already emits `{ quantity: 0, price: firstPrice }` (because `prevCumul` is 0 when `i === 0`), the removed point was strictly redundant and harmful.

- **`frontend/src/lib/charts/ui-utils.ts`**: Drops three lines (the `// Start at origin` comment and the `points.push({ quantity: 0, price: 0 })` call) and updates the JSDoc to reflect the new starting invariant.
- No callers (`supply-demand-chart.tsx`) need changes: `clipCurve`/`interpolateAtX` behavior is unchanged because the new first point at `(0, firstPrice)` is handled identically by the bracket-search and vertical-segment logic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, well-reasoned removal of a seed point that was already superseded by the loop's first iteration.

The deleted point { quantity: 0, price: 0 } was genuinely redundant: the loop's i === 0 branch emits { quantity: 0, price: firstPrice }, so the only effect of the old seed was the spurious (0,0) → (0, firstPrice) vertical segment. interpolateAtX returns the same value at targetX=0 before and after (firstPrice in both cases), and clipCurve in supply-demand-chart.tsx is unaffected. The fix is limited to three lines in a single utility file.

No files require special attention — the change is confined to ui-utils.ts and has no ripple effects in its sole consumer.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/lib/charts/ui-utils.ts | Removes the (0,0) seed point from createSteppedCurve; loop already emits (0, firstPrice) on its first iteration, so the deletion is safe and eliminates the spurious vertical spike at x=0. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as supply-demand-chart
    participant CSC as createSteppedCurve
    participant IAX as interpolateAtX

    Caller->>CSC: prices[], cumulCapacities[], extensionPrice
    Note over CSC: i=0 → prevCumul=0<br/>push (0, prices[0])  ← was (0,0) before fix
    Note over CSC: push (cumul[0], prices[0])
    Note over CSC: i=1…n → vertical + horizontal steps
    CSC-->>Caller: CurvePoint[]

    Caller->>IAX: curve, visXMin
    Note over IAX: Bracket search finds (0, firstPrice)<br/>→ firstPrice (no longer (0,0) artifact)
    IAX-->>Caller: firstPrice | null
```

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t start merit-order curves at (..."](https://github.com/felixvonsamson/energetica/commit/f151d0aa15e19865706a869b748ae359f79c0e36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31043770)</sub>

<!-- /greptile_comment -->