### PR TITLE
Show installed capacity and capacity factor for storage in power overview

### DIFF
--- a/frontend/src/components/charts/power-chart.tsx
+++ b/frontend/src/components/charts/power-chart.tsx
@@ -8,6 +8,7 @@
  *  - Facility icon + name labels in the tooltip
  */
 
+import { Link } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 
 import {
@@ -329,10 +330,19 @@ export function PowerOverviewTable({
                                                 Capacity Factor
                                             </span>
                                         </TooltipTrigger>
-                                        <TooltipContent>
-                                            Avg. power output over the
-                                            displayed time range ÷ installed
-                                            capacity
+                                        <TooltipContent className="max-w-52 text-center leading-snug">
+                                            Average power output over the
+                                            displayed time range divided by
+                                            installed capacity.{" "}
+                                            <Link
+                                                to="/app/wiki/$slug"
+                                                params={{
+                                                    slug: "power-facilities",
+                                                }}
+                                                className="underline hover:opacity-80"
+                                            >
+                                                Learn more
+                                            </Link>
                                         </TooltipContent>
                                     </Tooltip>
                                     {getSortIndicator("used")}

--- a/frontend/src/components/charts/power-chart.tsx
+++ b/frontend/src/components/charts/power-chart.tsx
@@ -17,6 +17,11 @@ import {
 import { FacilityIcon } from "@/components/ui/asset-icon";
 import { FacilityName } from "@/components/ui/asset-name";
 import { FacilityGauge } from "@/components/ui/facility-gauge";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAssetColorGetter } from "@/hooks/use-asset-color-getter";
 import { useFacilities } from "@/hooks/use-facilities";
 import { useGameEngine } from "@/hooks/use-game";
@@ -318,7 +323,18 @@ export function PowerOverviewTable({
                                     className="py-3 px-4 text-center font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors min-w-37.5"
                                     onClick={() => handleSort("used")}
                                 >
-                                    Capacity Factor
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <span className="underline decoration-dotted cursor-help">
+                                                Capacity Factor
+                                            </span>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            Avg. power output over the
+                                            displayed time range ÷ installed
+                                            capacity
+                                        </TooltipContent>
+                                    </Tooltip>
                                     {getSortIndicator("used")}
                                 </th>
                             </>

--- a/frontend/src/components/charts/power-chart.tsx
+++ b/frontend/src/components/charts/power-chart.tsx
@@ -213,9 +213,10 @@ export function PowerOverviewTable({
                 const row: FacilityRow = { facilityType, totalEnergy };
 
                 if (isGeneration && facilitiesData) {
-                    const facilities = facilitiesData.power_facilities.filter(
-                        (f) => f.facility === facilityType,
-                    );
+                    const facilities = [
+                        ...facilitiesData.power_facilities,
+                        ...facilitiesData.storage_facilities,
+                    ].filter((f) => f.facility === facilityType);
                     if (facilities.length > 0) {
                         const installedCapacity = facilities.reduce(
                             (sum, f) => sum + f.max_power_generation,
@@ -317,7 +318,7 @@ export function PowerOverviewTable({
                                     className="py-3 px-4 text-center font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors min-w-37.5"
                                     onClick={() => handleSort("used")}
                                 >
-                                    Used Capacity
+                                    Capacity Factor
                                     {getSortIndicator("used")}
                                 </th>
                             </>


### PR DESCRIPTION
## Summary
- Storage facilities now populate the "Installed Cap." and gauge columns on the generation tab of the power overview, using their `max_power_generation` (max discharge rate).
- Renamed "Used Capacity" to "Capacity Factor" since the gauge shows `avg_power / max_power` as a percentage — the textbook definition of capacity factor.

Note: storage's discharge-side capacity factor will look structurally low (a battery doing daily peak-shaving spends most of its time idle or charging), but the number is well-defined and consistent with the column on this tab. Extending the consumption tab with the symmetric charge-side metric is left as future work.

Closes #643

## Test plan
- [ ] Open `/app/overviews/power` with a game that has at least one storage facility (e.g. small pumped hydro storage).
- [ ] On the **generation** tab, confirm the storage row now shows a value in the "Installed Cap." column and a populated gauge in the "Capacity Factor" column.
- [ ] Confirm the column header reads "Capacity Factor" (not "Used Capacity") and that sorting on that column still works.
- [ ] Non-storage rows (gas, solar, etc.) are unchanged.
- [ ] Consumption tab is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Storage facilities now populate the "Installed Cap." and "Capacity Factor" columns on the generation tab of the power overview by spreading `storage_facilities` into the same array used for `power_facilities` during the capacity lookup. The column header is also renamed from "Used Capacity" to "Capacity Factor" with a dotted-underline tooltip that defines the metric and links to the wiki.

- **Installed capacity & capacity factor for storage**: `storage_facilities` are spread into the combined array filtered by `facilityType`, using `max_power_generation` (discharge rate) for both installed-capacity aggregation and the capacity-factor calculation — consistent with how `power_facilities` are handled.
- **Column rename + tooltip**: "Used Capacity" → "Capacity Factor" with a Radix `Tooltip` explaining `avg_power / installed_capacity`; the `Link` inside `TooltipContent` renders in a portal so clicks do not accidentally trigger the sort handler on the `<th>`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, well-contained addition that reuses the same field access pattern already established by power_facilities.

Both StorageFacilityOut and PowerFacilityOut expose facility and max_power_generation, so spreading them into the same array is type-safe and the capacity calculation is correct. The only open question is whether the Learn more wiki link targets the most helpful wiki page, but this does not affect correctness or runtime behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/charts/power-chart.tsx | Adds storage facilities to the capacity/capacity-factor lookup in the generation table, and renames "Used Capacity" to "Capacity Factor" with an explanatory tooltip. Logic and types are correct; both `StorageFacilityOut` and `PowerFacilityOut` expose `facility` and `max_power_generation`. Minor: the tooltip's "Learn more" link targets the `power-facilities` wiki slug even for storage rows. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[chartData keys → facilityTypes] --> B{isGeneration && facilitiesData?}
    B -- No --> C[row: facilityType + totalEnergy only]
    B -- Yes --> D["[...power_facilities, ...storage_facilities]\n.filter(f => f.facility === facilityType)"]
    D -- "facilities.length === 0" --> C
    D -- "facilities.length > 0" --> E["installedCapacity = Σ max_power_generation"]
    E --> F["avgPower = totalEnergy / (ticks × timeInHours)"]
    F --> G["usedCapacity = avgPower / installedCapacity × 100"]
    G --> H[FacilityGauge value=usedCapacity]
    C --> I[Show '-' in Installed Cap. & Capacity Factor columns]
```

<sub>Reviews (3): Last reviewed commit: ["fix: full-text tooltip with wiki link on..."](https://github.com/felixvonsamson/energetica/commit/765d502ac62987a2d8786b9e5d6a73596b8fa141) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31054278)</sub>

<!-- /greptile_comment -->