### PR TITLE
fix: split gauge label across fill boundary for legibility (#211)

### DIFF
--- a/frontend/src/components/ui/facility-gauge.tsx
+++ b/frontend/src/components/ui/facility-gauge.tsx
@@ -53,16 +53,19 @@ export function FacilityGauge({
             />
             {/* Label over the unfilled (track) portion. */}
             <span
-                className="absolute inset-0 flex items-center justify-center text-xs font-semibold text-gray-800 dark:text-white"
+                className="absolute inset-0 flex items-center justify-center text-xs font-semibold text-gray-800 dark:text-white transition-all"
                 style={{ clipPath: `inset(0 0 0 ${value}%)` }}
             >
                 {percentage}%
             </span>
-            {/* Label over the filled (asset color) portion. */}
+            {/* Label over the filled (asset color) portion. The two clip-paths
+               must share the same transition so they stay in sync — otherwise
+               an animating fill leaves a gap where neither span covers the
+               centred text. */}
             <span
                 className="absolute inset-0 flex items-center justify-center text-xs font-semibold transition-all"
                 style={{
-                    color: `var(${fgVar})`,
+                    color: `var(${fgVar}, var(--foreground))`,
                     clipPath: `inset(0 ${100 - value}% 0 0)`,
                 }}
                 aria-hidden="true"

--- a/frontend/src/components/ui/facility-gauge.tsx
+++ b/frontend/src/components/ui/facility-gauge.tsx
@@ -18,7 +18,13 @@ interface FacilityGaugeProps {
  * Displays a coloured gauge bar with percentage overlay.
  *
  * The gauge uses CSS variables for facility-specific colors:
- * `--asset-color-{facility-type}` where underscores are replaced with hyphens.
+ * `--asset-color-{facility-type}` for the fill, and
+ * `--asset-color-{facility-type}-fg` for the label colour over that fill.
+ *
+ * The label is rendered twice and clipped at the fill boundary so each side
+ * gets its own foreground colour: the asset-specific FG over the filled
+ * portion, and the default track FG over the unfilled portion. This keeps
+ * the percentage legible regardless of fill colour or theme.
  *
  * @example
  *     <FacilityGauge facilityType="coal_burner" value={75.5} />;
@@ -29,7 +35,9 @@ export function FacilityGauge({
     value,
     className = "",
 }: FacilityGaugeProps) {
-    const colorVar = `--asset-color-${facilityType.toLowerCase().replace(/_/g, "-")}`;
+    const slug = facilityType.toLowerCase().replace(/_/g, "-");
+    const colorVar = `--asset-color-${slug}`;
+    const fgVar = `--asset-color-${slug}-fg`;
     const percentage = Math.round(value);
 
     return (
@@ -43,7 +51,22 @@ export function FacilityGauge({
                     backgroundColor: `var(${colorVar})`,
                 }}
             />
-            <span className="absolute inset-0 flex items-center justify-center text-xs font-semibold text-gray-800 dark:text-white">
+            {/* Label over the unfilled (track) portion. */}
+            <span
+                className="absolute inset-0 flex items-center justify-center text-xs font-semibold text-gray-800 dark:text-white"
+                style={{ clipPath: `inset(0 0 0 ${value}%)` }}
+            >
+                {percentage}%
+            </span>
+            {/* Label over the filled (asset color) portion. */}
+            <span
+                className="absolute inset-0 flex items-center justify-center text-xs font-semibold transition-all"
+                style={{
+                    color: `var(${fgVar})`,
+                    clipPath: `inset(0 ${100 - value}% 0 0)`,
+                }}
+                aria-hidden="true"
+            >
                 {percentage}%
             </span>
         </div>

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as AppLoginRouteImport } from './routes/app/login'
 import { Route as AppDashboardRouteImport } from './routes/app/dashboard'
 import { Route as AppChangelogRouteImport } from './routes/app/changelog'
 import { Route as AppWikiIndexRouteImport } from './routes/app/wiki/index'
+import { Route as AppInternalIndexRouteImport } from './routes/app/internal/index'
 import { Route as AppWikiSlugRouteImport } from './routes/app/wiki/$slug'
 import { Route as AppOverviewsStorageRouteImport } from './routes/app/overviews/storage'
 import { Route as AppOverviewsResourcesRouteImport } from './routes/app/overviews/resources'
@@ -32,6 +33,7 @@ import { Route as AppOverviewsCashFlowRouteImport } from './routes/app/overviews
 import { Route as AppInternalTypographyRouteImport } from './routes/app/internal/typography'
 import { Route as AppInternalIconsRouteImport } from './routes/app/internal/icons'
 import { Route as AppInternalDesignRouteImport } from './routes/app/internal/design'
+import { Route as AppInternalColorsRouteImport } from './routes/app/internal/colors'
 import { Route as AppFacilitiesTechnologyRouteImport } from './routes/app/facilities/technology'
 import { Route as AppFacilitiesStorageRouteImport } from './routes/app/facilities/storage'
 import { Route as AppFacilitiesPowerPrioritiesRouteImport } from './routes/app/facilities/power-priorities'
@@ -111,6 +113,11 @@ const AppWikiIndexRoute = AppWikiIndexRouteImport.update({
   path: '/app/wiki/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AppInternalIndexRoute = AppInternalIndexRouteImport.update({
+  id: '/app/internal/',
+  path: '/app/internal/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AppWikiSlugRoute = AppWikiSlugRouteImport.update({
   id: '/app/wiki/$slug',
   path: '/app/wiki/$slug',
@@ -160,6 +167,11 @@ const AppInternalIconsRoute = AppInternalIconsRouteImport.update({
 const AppInternalDesignRoute = AppInternalDesignRouteImport.update({
   id: '/app/internal/design',
   path: '/app/internal/design',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AppInternalColorsRoute = AppInternalColorsRouteImport.update({
+  id: '/app/internal/colors',
+  path: '/app/internal/colors',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AppFacilitiesTechnologyRoute = AppFacilitiesTechnologyRouteImport.update({
@@ -257,6 +269,7 @@ export interface FileRoutesByFullPath {
   '/app/facilities/power-priorities': typeof AppFacilitiesPowerPrioritiesRoute
   '/app/facilities/storage': typeof AppFacilitiesStorageRoute
   '/app/facilities/technology': typeof AppFacilitiesTechnologyRoute
+  '/app/internal/colors': typeof AppInternalColorsRoute
   '/app/internal/design': typeof AppInternalDesignRoute
   '/app/internal/icons': typeof AppInternalIconsRoute
   '/app/internal/typography': typeof AppInternalTypographyRoute
@@ -267,6 +280,7 @@ export interface FileRoutesByFullPath {
   '/app/overviews/resources': typeof AppOverviewsResourcesRoute
   '/app/overviews/storage': typeof AppOverviewsStorageRoute
   '/app/wiki/$slug': typeof AppWikiSlugRoute
+  '/app/internal': typeof AppInternalIndexRoute
   '/app/wiki': typeof AppWikiIndexRoute
 }
 export interface FileRoutesByTo {
@@ -294,6 +308,7 @@ export interface FileRoutesByTo {
   '/app/facilities/power-priorities': typeof AppFacilitiesPowerPrioritiesRoute
   '/app/facilities/storage': typeof AppFacilitiesStorageRoute
   '/app/facilities/technology': typeof AppFacilitiesTechnologyRoute
+  '/app/internal/colors': typeof AppInternalColorsRoute
   '/app/internal/design': typeof AppInternalDesignRoute
   '/app/internal/icons': typeof AppInternalIconsRoute
   '/app/internal/typography': typeof AppInternalTypographyRoute
@@ -304,6 +319,7 @@ export interface FileRoutesByTo {
   '/app/overviews/resources': typeof AppOverviewsResourcesRoute
   '/app/overviews/storage': typeof AppOverviewsStorageRoute
   '/app/wiki/$slug': typeof AppWikiSlugRoute
+  '/app/internal': typeof AppInternalIndexRoute
   '/app/wiki': typeof AppWikiIndexRoute
 }
 export interface FileRoutesById {
@@ -333,6 +349,7 @@ export interface FileRoutesById {
   '/app/facilities/power-priorities': typeof AppFacilitiesPowerPrioritiesRoute
   '/app/facilities/storage': typeof AppFacilitiesStorageRoute
   '/app/facilities/technology': typeof AppFacilitiesTechnologyRoute
+  '/app/internal/colors': typeof AppInternalColorsRoute
   '/app/internal/design': typeof AppInternalDesignRoute
   '/app/internal/icons': typeof AppInternalIconsRoute
   '/app/internal/typography': typeof AppInternalTypographyRoute
@@ -343,6 +360,7 @@ export interface FileRoutesById {
   '/app/overviews/resources': typeof AppOverviewsResourcesRoute
   '/app/overviews/storage': typeof AppOverviewsStorageRoute
   '/app/wiki/$slug': typeof AppWikiSlugRoute
+  '/app/internal/': typeof AppInternalIndexRoute
   '/app/wiki/': typeof AppWikiIndexRoute
 }
 export interface FileRouteTypes {
@@ -372,6 +390,7 @@ export interface FileRouteTypes {
     | '/app/facilities/power-priorities'
     | '/app/facilities/storage'
     | '/app/facilities/technology'
+    | '/app/internal/colors'
     | '/app/internal/design'
     | '/app/internal/icons'
     | '/app/internal/typography'
@@ -382,6 +401,7 @@ export interface FileRouteTypes {
     | '/app/overviews/resources'
     | '/app/overviews/storage'
     | '/app/wiki/$slug'
+    | '/app/internal'
     | '/app/wiki'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -409,6 +429,7 @@ export interface FileRouteTypes {
     | '/app/facilities/power-priorities'
     | '/app/facilities/storage'
     | '/app/facilities/technology'
+    | '/app/internal/colors'
     | '/app/internal/design'
     | '/app/internal/icons'
     | '/app/internal/typography'
@@ -419,6 +440,7 @@ export interface FileRouteTypes {
     | '/app/overviews/resources'
     | '/app/overviews/storage'
     | '/app/wiki/$slug'
+    | '/app/internal'
     | '/app/wiki'
   id:
     | '__root__'
@@ -447,6 +469,7 @@ export interface FileRouteTypes {
     | '/app/facilities/power-priorities'
     | '/app/facilities/storage'
     | '/app/facilities/technology'
+    | '/app/internal/colors'
     | '/app/internal/design'
     | '/app/internal/icons'
     | '/app/internal/typography'
@@ -457,6 +480,7 @@ export interface FileRouteTypes {
     | '/app/overviews/resources'
     | '/app/overviews/storage'
     | '/app/wiki/$slug'
+    | '/app/internal/'
     | '/app/wiki/'
   fileRoutesById: FileRoutesById
 }
@@ -485,6 +509,7 @@ export interface RootRouteChildren {
   AppFacilitiesPowerPrioritiesRoute: typeof AppFacilitiesPowerPrioritiesRoute
   AppFacilitiesStorageRoute: typeof AppFacilitiesStorageRoute
   AppFacilitiesTechnologyRoute: typeof AppFacilitiesTechnologyRoute
+  AppInternalColorsRoute: typeof AppInternalColorsRoute
   AppInternalDesignRoute: typeof AppInternalDesignRoute
   AppInternalIconsRoute: typeof AppInternalIconsRoute
   AppInternalTypographyRoute: typeof AppInternalTypographyRoute
@@ -495,6 +520,7 @@ export interface RootRouteChildren {
   AppOverviewsResourcesRoute: typeof AppOverviewsResourcesRoute
   AppOverviewsStorageRoute: typeof AppOverviewsStorageRoute
   AppWikiSlugRoute: typeof AppWikiSlugRoute
+  AppInternalIndexRoute: typeof AppInternalIndexRoute
   AppWikiIndexRoute: typeof AppWikiIndexRoute
 }
 
@@ -591,6 +617,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppWikiIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/app/internal/': {
+      id: '/app/internal/'
+      path: '/app/internal'
+      fullPath: '/app/internal'
+      preLoaderRoute: typeof AppInternalIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/app/wiki/$slug': {
       id: '/app/wiki/$slug'
       path: '/app/wiki/$slug'
@@ -659,6 +692,13 @@ declare module '@tanstack/react-router' {
       path: '/app/internal/design'
       fullPath: '/app/internal/design'
       preLoaderRoute: typeof AppInternalDesignRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/app/internal/colors': {
+      id: '/app/internal/colors'
+      path: '/app/internal/colors'
+      fullPath: '/app/internal/colors'
+      preLoaderRoute: typeof AppInternalColorsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/app/facilities/technology': {
@@ -792,6 +832,7 @@ const rootRouteChildren: RootRouteChildren = {
   AppFacilitiesPowerPrioritiesRoute: AppFacilitiesPowerPrioritiesRoute,
   AppFacilitiesStorageRoute: AppFacilitiesStorageRoute,
   AppFacilitiesTechnologyRoute: AppFacilitiesTechnologyRoute,
+  AppInternalColorsRoute: AppInternalColorsRoute,
   AppInternalDesignRoute: AppInternalDesignRoute,
   AppInternalIconsRoute: AppInternalIconsRoute,
   AppInternalTypographyRoute: AppInternalTypographyRoute,
@@ -802,6 +843,7 @@ const rootRouteChildren: RootRouteChildren = {
   AppOverviewsResourcesRoute: AppOverviewsResourcesRoute,
   AppOverviewsStorageRoute: AppOverviewsStorageRoute,
   AppWikiSlugRoute: AppWikiSlugRoute,
+  AppInternalIndexRoute: AppInternalIndexRoute,
   AppWikiIndexRoute: AppWikiIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/frontend/src/routes/app/internal/colors.tsx
+++ b/frontend/src/routes/app/internal/colors.tsx
@@ -1,0 +1,313 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { HomeLayout } from "@/components/home-layout";
+import { FacilityGauge } from "@/components/ui/facility-gauge";
+import { Separator } from "@/components/ui/separator";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import {
+    TypographyH1,
+    TypographyH2,
+    TypographyH3,
+    TypographyLead,
+    TypographyMuted,
+    TypographyP,
+} from "@/components/ui/typography";
+
+export const Route = createFileRoute("/app/internal/colors")({
+    component: ColorsPage,
+    staticData: {
+        title: "Color & Gauge Test",
+        routeConfig: { requiredRole: null },
+    },
+});
+
+// Fill levels to test. 47% is the worst case for the "47%" label since the
+// text overlaps both the filled and unfilled portion of the gauge.
+const FILL_LEVELS = [0, 25, 47, 75, 100] as const;
+
+type Group = {
+    title: string;
+    note?: string;
+    facilities: { type: string; label: string }[];
+};
+
+const GROUPS: Group[] = [
+    {
+        title: "Power — Water",
+        facilities: [
+            { type: "watermill", label: "watermill" },
+            { type: "small_water_dam", label: "small_water_dam" },
+            { type: "large_water_dam", label: "large_water_dam" },
+        ],
+    },
+    {
+        title: "Power — Nuclear",
+        facilities: [
+            { type: "nuclear_reactor", label: "nuclear_reactor" },
+            { type: "nuclear_reactor_gen4", label: "nuclear_reactor_gen4" },
+        ],
+    },
+    {
+        title: "Power — Fossil",
+        facilities: [
+            { type: "steam_engine", label: "steam_engine" },
+            { type: "coal_burner", label: "coal_burner" },
+            { type: "gas_burner", label: "gas_burner" },
+            { type: "combined_cycle", label: "combined_cycle" },
+        ],
+    },
+    {
+        title: "Power — Wind",
+        facilities: [
+            { type: "windmill", label: "windmill" },
+            { type: "onshore_wind_turbine", label: "onshore_wind_turbine" },
+            { type: "offshore_wind_turbine", label: "offshore_wind_turbine" },
+        ],
+    },
+    {
+        title: "Power — Solar",
+        facilities: [
+            { type: "CSP_solar", label: "CSP_solar" },
+            { type: "PV_solar", label: "PV_solar" },
+        ],
+    },
+    {
+        title: "Storage",
+        facilities: [
+            { type: "small_pumped_hydro", label: "small_pumped_hydro" },
+            { type: "large_pumped_hydro", label: "large_pumped_hydro" },
+            { type: "lithium_ion_batteries", label: "lithium_ion_batteries" },
+            { type: "solid_state_batteries", label: "solid_state_batteries" },
+            { type: "molten_salt", label: "molten_salt" },
+            { type: "hydrogen_storage", label: "hydrogen_storage" },
+        ],
+    },
+    {
+        title: "Extraction",
+        facilities: [
+            { type: "coal_mine", label: "coal_mine" },
+            { type: "gas_drilling_site", label: "gas_drilling_site" },
+            { type: "uranium_mine", label: "uranium_mine" },
+        ],
+    },
+    {
+        title: "Resources",
+        facilities: [
+            { type: "coal", label: "coal" },
+            { type: "gas", label: "gas" },
+            { type: "uranium", label: "uranium" },
+            { type: "imports", label: "imports" },
+            { type: "exports", label: "exports" },
+            { type: "dumping", label: "dumping" },
+        ],
+    },
+    {
+        title: "Functional",
+        note: "research uses pure white in light mode and near-white in dark mode — a known contrast hot-spot.",
+        facilities: [
+            { type: "industry", label: "industry" },
+            { type: "research", label: "research" },
+            { type: "construction", label: "construction" },
+            { type: "transport", label: "transport" },
+            { type: "carbon_capture", label: "carbon_capture" },
+        ],
+    },
+];
+
+// The gauges that historically have the worst contrast on the label.
+const FOCUS_CASES = [
+    {
+        type: "coal_burner",
+        why: "Pure black fill — light-mode label 'text-gray-800' disappears on the filled side.",
+    },
+    {
+        type: "coal",
+        why: "Pure black fill — same issue as coal_burner.",
+    },
+    {
+        type: "large_water_dam",
+        why: "Very dark navy in light mode — dark label is hard to read on the filled side.",
+    },
+    {
+        type: "transport",
+        why: "Saturated purple — dark label has poor contrast on the filled side in light mode.",
+    },
+    {
+        type: "PV_solar",
+        why: "Saturated yellow — white label disappears on the filled side in dark mode.",
+    },
+    {
+        type: "research",
+        why: "White fill in light mode, near-white in dark mode — label vanishes on the filled side.",
+    },
+    {
+        type: "hydrogen_storage",
+        why: "Very light cyan — white label has poor contrast on the filled side in dark mode.",
+    },
+    {
+        type: "uranium_mine",
+        why: "Bright yellow — white label disappears on the filled side in dark mode.",
+    },
+];
+
+function GaugeRow({ type, label }: { type: string; label: string }) {
+    return (
+        <div className="grid grid-cols-[10rem_1fr] items-center gap-3">
+            <code className="text-xs text-muted-foreground truncate" title={type}>
+                {label}
+            </code>
+            <div className="grid grid-cols-5 gap-2">
+                {FILL_LEVELS.map((v) => (
+                    <FacilityGauge key={v} facilityType={type} value={v} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function FillLevelHeader() {
+    return (
+        <div className="grid grid-cols-[10rem_1fr] items-center gap-3 mb-2">
+            <span />
+            <div className="grid grid-cols-5 gap-2 text-center text-[10px] uppercase tracking-widest text-muted-foreground">
+                {FILL_LEVELS.map((v) => (
+                    <span key={v}>{v}%</span>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function ColorsPage() {
+    return (
+        <HomeLayout>
+            <div className="flex flex-col gap-10 px-6 lg:px-8 max-w-5xl mx-auto py-8">
+                <section className="flex items-start justify-between gap-4">
+                    <div className="flex flex-col gap-2">
+                        <TypographyH1>Color &amp; Gauge Legibility</TypographyH1>
+                        <TypographyLead>
+                            Visual regression sheet for asset colors as
+                            rendered by{" "}
+                            <code className="font-mono text-base">
+                                FacilityGauge
+                            </code>
+                            .
+                        </TypographyLead>
+                        <TypographyMuted>
+                            Each row shows the same gauge at 0%, 25%, 47%, 75%
+                            and 100% fill. The 47% case is the worst for the
+                            label since &quot;47%&quot; spans both the filled
+                            and unfilled portion. Toggle the theme to verify
+                            both light and dark mode.
+                        </TypographyMuted>
+                    </div>
+                    <ThemeToggle />
+                </section>
+
+                {/* ── Focus cases ───────────────────────────────────────── */}
+                <section className="flex flex-col gap-4">
+                    <TypographyH2>Contrast hot-spots (regression check)</TypographyH2>
+                    <TypographyP>
+                        These gauges previously had legibility problems on the
+                        filled side. The label is now split at the fill
+                        boundary: the unfilled side uses the default track
+                        foreground, the filled side uses{" "}
+                        <code className="font-mono">
+                            --asset-color-&#123;asset&#125;-fg
+                        </code>
+                        . Eyeball each one in both themes — the
+                        &quot;47%&quot; column should read end-to-end.
+                    </TypographyP>
+                    <div className="rounded-xl border border-border bg-card p-5 flex flex-col gap-4">
+                        <FillLevelHeader />
+                        {FOCUS_CASES.map(({ type, why }) => (
+                            <div
+                                key={type}
+                                className="flex flex-col gap-1.5 pb-3 border-b border-border last:border-0 last:pb-0"
+                            >
+                                <GaugeRow type={type} label={type} />
+                                <TypographyMuted className="text-xs pl-[10.75rem]">
+                                    {why}
+                                </TypographyMuted>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <Separator />
+
+                {/* ── Full matrix ───────────────────────────────────────── */}
+                <section className="flex flex-col gap-6">
+                    <TypographyH2>All assets</TypographyH2>
+                    {GROUPS.map((group) => (
+                        <div
+                            key={group.title}
+                            className="rounded-xl border border-border bg-card p-5"
+                        >
+                            <TypographyH3 className="mb-1">
+                                {group.title}
+                            </TypographyH3>
+                            {group.note && (
+                                <TypographyMuted className="text-xs mb-4">
+                                    {group.note}
+                                </TypographyMuted>
+                            )}
+                            <FillLevelHeader />
+                            <div className="flex flex-col gap-3">
+                                {group.facilities.map((f) => (
+                                    <GaugeRow
+                                        key={f.type}
+                                        type={f.type}
+                                        label={f.label}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                </section>
+
+                {/* ── On different surfaces ─────────────────────────────── */}
+                <section className="flex flex-col gap-4">
+                    <TypographyH2>On different surfaces</TypographyH2>
+                    <TypographyMuted>
+                        The gauge track uses{" "}
+                        <code className="font-mono">
+                            bg-gray-200 dark:bg-gray-700
+                        </code>
+                        , which doesn&apos;t adapt to the surrounding surface.
+                        Same gauge rendered on background, card, and muted to
+                        check that the empty portion still reads as a track.
+                    </TypographyMuted>
+                    <div className="grid sm:grid-cols-3 gap-3">
+                        {[
+                            { name: "background", className: "bg-background" },
+                            { name: "card", className: "bg-card" },
+                            { name: "muted", className: "bg-muted" },
+                        ].map((s) => (
+                            <div
+                                key={s.name}
+                                className={`${s.className} border border-border rounded-xl p-4 flex flex-col gap-3`}
+                            >
+                                <TypographyMuted className="text-xs uppercase tracking-widest">
+                                    {s.name}
+                                </TypographyMuted>
+                                <FacilityGauge
+                                    facilityType="onshore_wind_turbine"
+                                    value={47}
+                                />
+                                <FacilityGauge
+                                    facilityType="coal_burner"
+                                    value={47}
+                                />
+                                <FacilityGauge
+                                    facilityType="PV_solar"
+                                    value={47}
+                                />
+                            </div>
+                        ))}
+                    </div>
+                </section>
+            </div>
+        </HomeLayout>
+    );
+}

--- a/frontend/src/routes/app/internal/index.tsx
+++ b/frontend/src/routes/app/internal/index.tsx
@@ -1,0 +1,89 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Gauge, Palette, Shapes, Type } from "lucide-react";
+
+import { HomeLayout } from "@/components/home-layout";
+import {
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
+import {
+    TypographyH1,
+    TypographyLead,
+} from "@/components/ui/typography";
+
+export const Route = createFileRoute("/app/internal/")({
+    component: InternalIndexPage,
+    staticData: {
+        title: "Internal",
+        routeConfig: { requiredRole: null },
+    },
+});
+
+const pages = [
+    {
+        to: "/app/internal/design",
+        title: "Design System",
+        description:
+            "Color tokens, asset colors, buttons, inputs, feedback, progress, cards, and data display.",
+        icon: Palette,
+    },
+    {
+        to: "/app/internal/typography",
+        title: "Typography",
+        description:
+            "Headings, body text, modifiers, and data-display typography components.",
+        icon: Type,
+    },
+    {
+        to: "/app/internal/icons",
+        title: "Icons",
+        description:
+            "Asset, resource, technology, and special icons with usage analysis.",
+        icon: Shapes,
+    },
+    {
+        to: "/app/internal/colors",
+        title: "Color & Gauge Test",
+        description:
+            "All asset colors rendered as FacilityGauges at multiple fill levels — verify label legibility in light and dark mode.",
+        icon: Gauge,
+    },
+] as const;
+
+function InternalIndexPage() {
+    return (
+        <HomeLayout>
+            <div className="flex flex-col gap-8 px-6 lg:px-8 max-w-5xl mx-auto py-8">
+                <section className="flex flex-col gap-2">
+                    <TypographyH1>Internal</TypographyH1>
+                    <TypographyLead>
+                        Reference pages for the design system, typography, and
+                        icon library.
+                    </TypographyLead>
+                </section>
+
+                <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {pages.map(({ to, title, description, icon: Icon }) => (
+                        <Link
+                            key={to}
+                            to={to}
+                            className="group rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                            <Card className="h-full transition-colors group-hover:border-accent group-hover:bg-muted">
+                                <CardHeader className="gap-3">
+                                    <Icon className="size-6 text-foreground" />
+                                    <CardTitle>{title}</CardTitle>
+                                    <CardDescription>
+                                        {description}
+                                    </CardDescription>
+                                </CardHeader>
+                            </Card>
+                        </Link>
+                    ))}
+                </section>
+            </div>
+        </HomeLayout>
+    );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -277,6 +277,50 @@
         --asset-color-transport: rgb(106, 0, 244);
         --asset-color-carbon-capture: rgb(173, 181, 189);
 
+        /* Asset foreground tokens
+           Theme-agnostic constants — each asset's *-fg picks one of these two
+           based on the luminance of its fill color. Used by FacilityGauge to
+           keep labels legible on the filled portion of the bar. */
+        --asset-fg-on-light: #000000;
+        --asset-fg-on-dark:  #ffffff;
+
+        /* Asset colour foregrounds (light mode) — picked from the asset's
+           light-mode fill colour. */
+        --asset-color-watermill-fg:               var(--asset-fg-on-light);
+        --asset-color-small-water-dam-fg:         var(--asset-fg-on-dark);
+        --asset-color-large-water-dam-fg:         var(--asset-fg-on-dark);
+        --asset-color-nuclear-reactor-fg:         var(--asset-fg-on-light);
+        --asset-color-nuclear-reactor-gen4-fg:    var(--asset-fg-on-light);
+        --asset-color-steam-engine-fg:            var(--asset-fg-on-dark);
+        --asset-color-coal-burner-fg:             var(--asset-fg-on-dark);
+        --asset-color-gas-burner-fg:              var(--asset-fg-on-light);
+        --asset-color-combined-cycle-fg:          var(--asset-fg-on-dark);
+        --asset-color-windmill-fg:                var(--asset-fg-on-light);
+        --asset-color-onshore-wind-turbine-fg:    var(--asset-fg-on-dark);
+        --asset-color-offshore-wind-turbine-fg:   var(--asset-fg-on-dark);
+        --asset-color-csp-solar-fg:               var(--asset-fg-on-light);
+        --asset-color-pv-solar-fg:                var(--asset-fg-on-light);
+        --asset-color-small-pumped-hydro-fg:      var(--asset-fg-on-dark);
+        --asset-color-large-pumped-hydro-fg:      var(--asset-fg-on-dark);
+        --asset-color-lithium-ion-batteries-fg:   var(--asset-fg-on-dark);
+        --asset-color-solid-state-batteries-fg:   var(--asset-fg-on-dark);
+        --asset-color-molten-salt-fg:             var(--asset-fg-on-dark);
+        --asset-color-hydrogen-storage-fg:        var(--asset-fg-on-light);
+        --asset-color-coal-mine-fg:               var(--asset-fg-on-dark);
+        --asset-color-gas-drilling-site-fg:       var(--asset-fg-on-light);
+        --asset-color-uranium-mine-fg:            var(--asset-fg-on-light);
+        --asset-color-coal-fg:                    var(--asset-fg-on-dark);
+        --asset-color-gas-fg:                     var(--asset-fg-on-light);
+        --asset-color-uranium-fg:                 var(--asset-fg-on-light);
+        --asset-color-imports-fg:                 var(--asset-fg-on-dark);
+        --asset-color-exports-fg:                 var(--asset-fg-on-light);
+        --asset-color-dumping-fg:                 var(--asset-fg-on-dark);
+        --asset-color-industry-fg:                var(--asset-fg-on-dark);
+        --asset-color-research-fg:                var(--asset-fg-on-light);
+        --asset-color-construction-fg:            var(--asset-fg-on-dark);
+        --asset-color-transport-fg:               var(--asset-fg-on-dark);
+        --asset-color-carbon-capture-fg:          var(--asset-fg-on-light);
+
         /* Map tile colours */
         --map-selected-tile-hover: var(--color-pine-800);
         --map-tile-current-player: hsl(0, 64%, 47%);
@@ -431,6 +475,44 @@
         --asset-color-construction: rgb(255, 163, 60);
         --asset-color-transport: rgb(156, 80, 255);
         --asset-color-carbon-capture: rgb(153, 161, 169);
+
+        /* Asset colour foregrounds (dark mode) — picked from the asset's
+           dark-mode fill colour. --asset-fg-on-light/-on-dark are inherited
+           from :root. */
+        --asset-color-watermill-fg:               var(--asset-fg-on-light);
+        --asset-color-small-water-dam-fg:         var(--asset-fg-on-dark);
+        --asset-color-large-water-dam-fg:         var(--asset-fg-on-dark);
+        --asset-color-nuclear-reactor-fg:         var(--asset-fg-on-light);
+        --asset-color-nuclear-reactor-gen4-fg:    var(--asset-fg-on-light);
+        --asset-color-steam-engine-fg:            var(--asset-fg-on-dark);
+        --asset-color-coal-burner-fg:             var(--asset-fg-on-dark);
+        --asset-color-gas-burner-fg:              var(--asset-fg-on-dark);
+        --asset-color-combined-cycle-fg:          var(--asset-fg-on-dark);
+        --asset-color-windmill-fg:                var(--asset-fg-on-light);
+        --asset-color-onshore-wind-turbine-fg:    var(--asset-fg-on-dark);
+        --asset-color-offshore-wind-turbine-fg:   var(--asset-fg-on-dark);
+        --asset-color-csp-solar-fg:               var(--asset-fg-on-light);
+        --asset-color-pv-solar-fg:                var(--asset-fg-on-light);
+        --asset-color-small-pumped-hydro-fg:      var(--asset-fg-on-dark);
+        --asset-color-large-pumped-hydro-fg:      var(--asset-fg-on-dark);
+        --asset-color-lithium-ion-batteries-fg:   var(--asset-fg-on-dark);
+        --asset-color-solid-state-batteries-fg:   var(--asset-fg-on-dark);
+        --asset-color-molten-salt-fg:             var(--asset-fg-on-dark);
+        --asset-color-hydrogen-storage-fg:        var(--asset-fg-on-light);
+        --asset-color-coal-mine-fg:               var(--asset-fg-on-dark);
+        --asset-color-gas-drilling-site-fg:       var(--asset-fg-on-light);
+        --asset-color-uranium-mine-fg:            var(--asset-fg-on-light);
+        --asset-color-coal-fg:                    var(--asset-fg-on-dark);
+        --asset-color-gas-fg:                     var(--asset-fg-on-dark);
+        --asset-color-uranium-fg:                 var(--asset-fg-on-light);
+        --asset-color-imports-fg:                 var(--asset-fg-on-dark);
+        --asset-color-exports-fg:                 var(--asset-fg-on-light);
+        --asset-color-dumping-fg:                 var(--asset-fg-on-dark);
+        --asset-color-industry-fg:                var(--asset-fg-on-dark);
+        --asset-color-research-fg:                var(--asset-fg-on-light);
+        --asset-color-construction-fg:            var(--asset-fg-on-dark);
+        --asset-color-transport-fg:               var(--asset-fg-on-dark);
+        --asset-color-carbon-capture-fg:          var(--asset-fg-on-dark);
 
         /* Map tile colours - same as light mode */
         --map-selected-tile-hover: var(--color-bone-100);


### PR DESCRIPTION
## Summary
- Fixes #211 — black label on dark gauge fills (large_water_dam, coal_burner, transport, …) is now legible, and the inverse case (white label on PV_solar / research / hydrogen_storage in dark mode) is fixed too.
- The label inside `FacilityGauge` is rendered twice and clipped at the fill boundary: the unfilled side keeps the default track colour, the filled side uses a per-asset `--asset-color-{asset}-fg` token. Each token resolves to one of two shared constants (`--asset-fg-on-light: #000` / `--asset-fg-on-dark: #fff`), so the per-asset choice is enum-like and easy to review.
- Adds an `/app/internal` index page and a new `/app/internal/colors` page that renders every asset gauge at 0 / 25 / 47 / 75 / 100% fill as a manual regression check across both themes (47% is the worst case since the label spans the boundary).

## Test plan
- [ ] Open `/app/overviews/power` and confirm large_water_dam, coal_burner, transport gauges read correctly in light mode.
- [ ] Toggle dark mode on the same page and confirm PV_solar, research, hydrogen_storage, uranium_mine gauges read correctly.
- [ ] Visit `/app/internal/colors`, scroll the "Contrast hot-spots" and "All assets" sections, scrub the page in both themes, and confirm the "47%" column is end-to-end legible on every row.
- [ ] Spot-check borderline picks (`steam_engine`, `gas_burner` dark, `solid_state_batteries`, `exports` dark) — flag any that still look weak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes gauge label legibility by rendering the text twice — once clipped to the unfilled track region and once to the filled region — so each half can carry its own foreground color. New `--asset-color-{slug}-fg` CSS tokens in both light and dark blocks map every asset to one of two shared constants (`#000` / `#fff`) based on the luminance of the fill.

- **`facility-gauge.tsx`**: Both `clipPath` spans carry `transition-all` so the clip boundaries stay in sync during fill animation, and the filled-side color falls back to `var(--foreground)` if a token is missing.
- **`global.css`**: 31 new `-fg` tokens added per theme block; light-mode and dark-mode picks differ where the fill colour changes enough to need a different foreground (e.g. `gas-burner-fg` flips from `on-light` to `on-dark`).
- **`colors.tsx` / `index.tsx`**: New `/app/internal/colors` page renders every asset at 0/25/47/75/100% fill as a manual regression sheet; `/app/internal/` index links all dev pages together.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the dual-span clip technique is mathematically correct, transition sync is handled, and a fallback protects against missing tokens.

The clip paths are complementary so there is no gap or overlap at any fill level. Both spans carry transition-all, keeping them in sync during animation. The filled-side color falls back to var(--foreground) for any asset whose token is absent. The CSS token table covers every asset in both theme blocks. The new internal pages are dev-only tooling with no production impact.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/ui/facility-gauge.tsx | Core fix: label rendered twice with complementary clipPath regions so each half gets an appropriate foreground color; both spans carry transition-all to keep clip boundaries in sync during animation, and a var(--foreground) fallback guards missing tokens. |
| frontend/src/styles/global.css | Adds --asset-color-{slug}-fg tokens for every asset in both light and dark blocks, each resolving to one of two shared constants; values differ between modes where the fill colour changes enough to flip the contrast requirement. |
| frontend/src/routes/app/internal/colors.tsx | New internal dev page rendering every asset gauge at 0/25/47/75/100% fill; 47% chosen as worst case since the label text spans the clip boundary. Provides a manual regression sheet in both themes. |
| frontend/src/routes/app/internal/index.tsx | New index landing page for the /app/internal section linking to design, typography, icons, and the new colors pages. Straightforward navigation scaffold. |
| frontend/src/routeTree.gen.ts | Auto-generated TanStack Router tree extended with entries for /app/internal/ and /app/internal/colors; no manual changes, consistent with existing route registration patterns. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant FacilityGauge
    participant CSS

    Browser->>FacilityGauge: render(facilityType, value)
    FacilityGauge->>CSS: resolve asset fill color
    CSS-->>FacilityGauge: var(--asset-color-slug)
    FacilityGauge->>Browser: fill div at width=percentage%

    note over FacilityGauge: Label rendered twice, clipped at fill boundary
    FacilityGauge->>Browser: span1 clipPath inset(0 0 0 value%) text-gray-800/white
    FacilityGauge->>CSS: resolve fg token
    CSS-->>FacilityGauge: var(--asset-color-slug-fg) resolves to #000 or #fff
    FacilityGauge->>Browser: span2 clipPath inset(0 100-value% 0 0) asset-fg aria-hidden

    note over Browser: Complementary clips cover full width with no gap
    note over Browser: Both spans share transition-all for sync animation
```

<sub>Reviews (2): Last reviewed commit: ["fix: sync gauge label clip-path transiti..."](https://github.com/felixvonsamson/energetica/commit/e7a0508c441cb2404a292e2eec598275621f536d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31057570)</sub>

<!-- /greptile_comment -->