### PR TITLE
fix: anchor static data paths to __file__, add worktree setup script

### DIFF
--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -29,6 +29,8 @@ from energetica.game_engine import GameEngine
 from energetica.schemas.simulate import Action
 from energetica.utils.browser_notifications import load_or_create_vapid_keys
 
+_REPO_ROOT = Path(__file__).parent.parent
+
 engine = GameEngine()
 
 globals.MAIN_EVENT_LOOP = asyncio.get_event_loop()
@@ -233,15 +235,15 @@ def create_app(
             new_admin = User(username="admin", pwhash=hashed_password, role="admin")
             engine.log(f"Admin account created with username '{new_admin.username}'")
             # TODO(mglst): I think it would make more sense to move this under the instance/ folder
-            with open("admin_accounts.txt", "w", encoding="utf-8") as file:
+            with open(_REPO_ROOT / "admin_accounts.txt", "w", encoding="utf-8") as file:
                 file.write(f"{new_admin.username},{admin_password}\n")
 
         if disable_signups:
             # if sign-ups are disabled, accounts have to be created from a file.
-            with open("players.txt", "r", encoding="utf-8") as file:
+            with open(_REPO_ROOT / "players.txt", "r", encoding="utf-8") as file:
                 lines = file.readlines()
 
-            with open("players.txt", "w", encoding="utf-8") as file:
+            with open(_REPO_ROOT / "players.txt", "w", encoding="utf-8") as file:
                 for line in lines:
                     line = line.strip()
                     if not line:

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -26,6 +26,8 @@ from energetica.schemas.simulate import Action, InitEngineAction
 if TYPE_CHECKING:
     from energetica.database.messages import Chat
 
+_DATA_DIR = Path(__file__).parent / "static" / "data"
+
 
 # This is the engine object
 class GameEngine(object):
@@ -65,10 +67,10 @@ class GameEngine(object):
         self.VAPID_PRIVATE_KEY: str = None  # type: ignore[assignment]
         self.general_chat_id: int = None  # type: ignore[assignment]
 
-        with open("energetica/static/data/industry_demand.pck", "rb") as file:
+        with open(_DATA_DIR / "industry_demand.pck", "rb") as file:
             # array of length 1440 of normalized daily industry demand variations
             self.industry_demand = pickle.load(file)
-        with open("energetica/static/data/industry_demand_year.pck", "rb") as file:
+        with open(_DATA_DIR / "industry_demand_year.pck", "rb") as file:
             # array of length 51 of normalized yearly industry demand variations
             self.industry_seasonal = pickle.load(file)
 
@@ -159,7 +161,7 @@ class GameEngine(object):
 
         self.clear_db()
 
-        with open("energetica/static/data/map.csv", "r", encoding="utf-8") as file:
+        with open(_DATA_DIR / "map.csv", "r", encoding="utf-8") as file:
             csv_reader = csv.DictReader(file)
             for row in csv_reader:
                 tile = HexTile(coordinates=(int(row["q"]), int(row["r"])), climate_risk=int(row["climate_risk"]))
@@ -293,7 +295,7 @@ class GameEngine(object):
             TutorialQuizPushNotificationsPayload,
         )
 
-        with open("energetica/static/data/daily_quiz_questions.csv", "r", encoding="utf-8") as file:
+        with open(_DATA_DIR / "daily_quiz_questions.csv", "r", encoding="utf-8") as file:
             csv_reader = list(csv.DictReader(file))
         if self.question_order is None:
             self.question_order = list(range(len(csv_reader)))

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run once after `git worktree add` to make the worktree fully operational.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_ROOT="$(dirname "$SCRIPT_DIR")"
+MAIN_REPO="$(git -C "$WORKTREE_ROOT" worktree list | head -1 | awk '{print $1}')"
+
+echo "Setting up worktree at $WORKTREE_ROOT"
+
+# Frontend deps
+echo "→ Installing frontend dependencies..."
+cd "$WORKTREE_ROOT/frontend"
+bun install
+
+# Python venv — symlink from main repo to avoid a redundant install
+if [ ! -e "$WORKTREE_ROOT/.venv" ]; then
+    echo "→ Symlinking .venv from main repo..."
+    ln -s "$MAIN_REPO/.venv" "$WORKTREE_ROOT/.venv"
+fi
+
+echo "✓ Done. Start the server from $WORKTREE_ROOT with: python main.py"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -14,7 +14,7 @@ cd "$WORKTREE_ROOT/frontend"
 bun install
 
 # Python venv — symlink from main repo to avoid a redundant install
-if [ ! -e "$WORKTREE_ROOT/.venv" ]; then
+if [ ! -e "$WORKTREE_ROOT/.venv" ] && [ ! -L "$WORKTREE_ROOT/.venv" ]; then
     echo "→ Symlinking .venv from main repo..."
     ln -s "$MAIN_REPO/.venv" "$WORKTREE_ROOT/.venv"
 fi


### PR DESCRIPTION
## Summary

- `open()` calls for static data files (`energetica/static/data/`) used CWD-relative paths, causing `FileNotFoundError` when the server is started from outside the repo/worktree root. Fixed by anchoring to `Path(__file__)` in `game_engine.py` and `__init__.py`.
- `admin_accounts.txt` and `players.txt` got the same treatment.
- `instance/` and `checkpoints/` paths are intentionally left as CWD-relative — they're runtime artifacts tied to `tar.extractall("./")` and must stay relative to the running server's working directory.
- Adds `scripts/setup-worktree.sh`: run once after `git worktree add` to install frontend deps and symlink `.venv` from the main repo.

## Test plan

- [ ] Start the server normally from the repo root — static data loads as before
- [ ] Start the server from a different CWD (e.g. `python /path/to/worktree/main.py`) — no `FileNotFoundError` on startup
- [ ] Run `scripts/setup-worktree.sh` in a fresh worktree — frontend builds and `.venv` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `FileNotFoundError` crashes that occurred when the server was launched from outside the repo root by anchoring static-data `open()` calls to `Path(__file__)` instead of CWD. It also adds a `scripts/setup-worktree.sh` helper for initialising `git worktree` checkouts.

- **`game_engine.py`**: introduces `_DATA_DIR = Path(__file__).parent / \"static\" / \"data\"` and rewires four pickle/CSV `open()` calls to use it.
- **`__init__.py`**: introduces `_REPO_ROOT = Path(__file__).parent.parent` and anchors `admin_accounts.txt` / `players.txt` to it; `instance/` and `checkpoints/` are intentionally left CWD-relative.
- **`scripts/setup-worktree.sh`**: new script that runs `bun install` and symlinks `.venv` from the main repo; the symlink guard combines `[ ! -e ]` and `[ ! -L ]` to correctly skip creation on both valid and dangling symlinks.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the path-anchoring changes are mechanical and correct, with no behavioural impact when the server is started from the repo root.

All three files make narrow, well-scoped changes. The static-data and credential-file path fixes are straightforward substitutions that do not alter runtime behaviour for the common case. The shell script is a developer convenience tool with one non-critical edge case (running it in the main worktree) that only affects the script user, not the application.

scripts/setup-worktree.sh — the missing main-worktree guard is the only thing worth a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/game_engine.py | Introduces `_DATA_DIR = Path(__file__).parent / "static" / "data"` and replaces all four CWD-relative `open()` calls for static data files; the path is correct and idiomatic. |
| energetica/__init__.py | Adds `_REPO_ROOT = Path(__file__).parent.parent` and anchors `admin_accounts.txt` / `players.txt` reads/writes to it; correctly leaves `instance/` and `checkpoints/` as CWD-relative per intentional design. |
| scripts/setup-worktree.sh | New helper script for git worktree setup; symlink guard correctly combines `-e` and `-L` checks to handle dangling symlinks, but lacks a guard against running in the main worktree, which can produce a self-referential `.venv` symlink. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Server starts] --> B{CWD?}
    B -->|repo root| C[CWD == _REPO_ROOT / _DATA_DIR base]
    B -->|anywhere else| D[CWD != package location]
    C --> E[open static data files]
    D --> E
    E --> F["_DATA_DIR = Path(__file__).parent / static / data"]
    F --> G[industry_demand.pck]
    F --> H[industry_demand_year.pck]
    F --> I[map.csv]
    F --> J[daily_quiz_questions.csv]
    D --> K["_REPO_ROOT = Path(__file__).parent.parent"]
    K --> L[admin_accounts.txt]
    K --> M[players.txt]
    D --> N[instance/ & checkpoints/]
    N --> O[Still CWD-relative — runtime artifacts]
```

<sub>Reviews (3): Last reviewed commit: ["fix(setup-worktree): guard symlink creat..."](https://github.com/felixvonsamson/energetica/commit/12a83723e0c2f1c3841cce6e7b516d141dc86acd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31508317)</sub>

<!-- /greptile_comment -->