### PR TITLE
fix 699

### DIFF
--- a/frontend/src/components/charts/market-clearing-volume-chart.tsx
+++ b/frontend/src/components/charts/market-clearing-volume-chart.tsx
@@ -52,8 +52,19 @@ function useMarketClearingData(
 
     const filteredChartData = useMemo(() => {
         if (!market) return [];
+        const staticKeys = KEY_ORDER_BY_CHART_TYPE[chartType];
+        const dataKeys =
+            staticKeys.length > 0
+                ? staticKeys
+                : Array.from(
+                      new Set(
+                          chartData.flatMap((dp) =>
+                              Object.keys(dp).filter((k) => k !== "tick"),
+                          ),
+                      ),
+                  );
         const emptyDatapoint = Object.fromEntries(
-            KEY_ORDER_BY_CHART_TYPE[chartType].map((key) => [key, null]),
+            dataKeys.map((key) => [key, null]),
         );
         return chartData.map((dataPoint) =>
             dataPoint.tick <= market.created_tick


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where pre-market-creation data points were not being correctly nulled out for chart types with dynamic keys (`market-exports` and `market-imports`). Previously, `KEY_ORDER_BY_CHART_TYPE` returns an empty array for those types, so `emptyDatapoint` was `{}` and the spread produced `{ tick }` instead of `{ tick, [playerId]: null, … }`.

- When the static key list for a chart type is empty (i.e. player-breakdown modes), keys are now derived at runtime by scanning all data points in `chartData`, collected into a `Set` to deduplicate, and used to build `emptyDatapoint` with `null` values.
- Static-key chart types (`market-clearing`, `market-generation`, `market-consumption`, etc.) are unaffected by this change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, targets a well-understood gap in the static key map, and leaves all other chart types unaffected.

The fix correctly handles the two chart types whose key lists are intentionally empty (market-exports, market-imports). The fallback key discovery is derived from the same chartData array already used in the memo, the dependency array is correct, and chart types with static keys follow the unchanged code path. No logic regressions were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/charts/market-clearing-volume-chart.tsx | Fixes empty `emptyDatapoint` for dynamic-key chart types (`market-exports`/`market-imports`) by falling back to keys discovered from the actual chart data when the static key list is empty. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[filteredChartData memo] --> B{staticKeys.length > 0?}
    B -- Yes --> C["dataKeys = staticKeys\ne.g. market-clearing: price, quantity"]
    B -- No --> D["dataKeys = derived from chartData\nflatMap all keys excluding tick via Set"]
    C --> E["emptyDatapoint = all dataKeys mapped to null"]
    D --> E
    E --> F[map each dataPoint]
    F --> G{tick <= market.created_tick?}
    G -- Yes --> H["return { tick, ...emptyDatapoint }"]
    G -- No --> I[return dataPoint as-is]
```

<sub>Reviews (1): Last reviewed commit: ["fix 699"](https://github.com/felixvonsamson/energetica/commit/ba96eca90da396eb29de13bee4d5fbccd6f030f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32316378)</sub>

<!-- /greptile_comment -->