### PR TITLE
Fix construction pollution display for functional facilities

### DIFF
--- a/energetica/technology_effects.py
+++ b/energetica/technology_effects.py
@@ -892,7 +892,7 @@ def package_functional_facilities(player: Player) -> list[dict]:
         | {
             "construction_pollution": const_config_assets[functional_facility]["base_construction_pollution"]
             * const_config_assets[functional_facility]["price_multiplier"]
-            ** player.functional_facility_lvl[FunctionalFacilityType.INDUSTRY],
+            ** player.get_level(functional_facility),
         }
         | special_keys[functional_facility]
         for functional_facility in FunctionalFacilityType


### PR DESCRIPTION
The dialog was using `player.functional_facility_lvl[INDUSTRY]` as the level exponent for **all** functional facilities, instead of each facility's own level. This made the displayed total CO₂ wrong whenever a facility's level differed from the player's industry level.

Fixed by using `player.get_level(functional_facility)`, consistent with how `construction_pollution_per_tick` computes the actual emission.

Closes #474

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the construction pollution displayed in the facility upgrade dialog was computed using the player's **industry** level for every functional facility, instead of each facility's own level. The fix aligns the display formula with the runtime `construction_pollution_per_tick` function, which already called `player.get_level(project_type)` correctly.

- **Bug fix**: `player.functional_facility_lvl[FunctionalFacilityType.INDUSTRY]` replaced with `player.get_level(functional_facility)` in `package_functional_facilities`, so the shown CO₂ now matches the actual emission for each facility type.
- **Consistency**: The corrected formula is now identical in structure to `construction_pollution_per_tick` (line 474), removing the discrepancy between the displayed total and the computed per-tick value.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted correction to the display formula with no side effects on game logic.

The change is a single-line fix in the UI data-packaging function. `player.get_level(functional_facility)` is well-defined for every `FunctionalFacilityType` (it directly indexes `functional_facility_lvl`), and the new formula is structurally identical to the already-correct `construction_pollution_per_tick`. There are no edge cases introduced, no data mutations, and no other callers affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/technology_effects.py | Single-line fix replacing the hardcoded `FunctionalFacilityType.INDUSTRY` level with `player.get_level(functional_facility)` so each facility uses its own level when computing the displayed construction pollution. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Frontend Dialog
    participant PFF as package_functional_facilities()
    participant GL as player.get_level(facility)
    participant CPPT as construction_pollution_per_tick()

    UI->>PFF: request construction data
    loop for each FunctionalFacilityType
        PFF->>GL: get_level(functional_facility)
        GL-->>PFF: functional_facility_lvl[functional_facility]
        PFF->>PFF: "base_pollution * price_multiplier ** level"
    end
    PFF-->>UI: construction_pollution per facility

    Note over CPPT: Runtime emission calculation
    CPPT->>GL: get_level(project_type)
    GL-->>CPPT: functional_facility_lvl[project_type]
    CPPT->>CPPT: "base_pollution / construction_time * price_multiplier ** level"
```

<sub>Reviews (1): Last reviewed commit: ["fix 474"](https://github.com/felixvonsamson/energetica/commit/2535ca807742e53c3098dd167cb7de7a2e89864a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32319431)</sub>

<!-- /greptile_comment -->