### PR TITLE
Prevent storage price inversions in priority list

### DIFF
--- a/energetica/database/network_prices.py
+++ b/energetica/database/network_prices.py
@@ -97,6 +97,12 @@ class NetworkPrices:
         updated_bids: dict[BidType, float],
     ) -> None:
         """Update the prices of the player for each facility type."""
+        merged_asks = {**self.ask_prices, **updated_asks}
+        merged_bids = {**self.bid_prices, **updated_bids}
+        for storage_type in StorageFacilityType:
+            if storage_type in merged_asks and storage_type in merged_bids:
+                if merged_asks[storage_type] < merged_bids[storage_type]:
+                    raise GameError(GameExceptionType.STORAGE_PRICE_INVERSION)
         self.bid_prices |= updated_bids
         self.ask_prices |= updated_asks
 
@@ -173,12 +179,7 @@ class NetworkPrices:
         player.invalidate_queries(["power-priorities"], ["facilities"])
 
     def change_facility_priority(self, player: Player, new_priority: list[PowerPriorityItem]) -> None:
-        """
-        Reassign the selling prices of the facilities according to the new priority order.
-
-        Executed when the facilities priority is changed by changing the order in the interactive table for players
-        that are not in a network.
-        """
+        """Reassign the selling prices of the facilities according to the new priority order."""
         # Check if the new priority list is valid, i.e. contains the same elements as the old one
         old_priority = self.get_facility_priorities(player)
         if set(old_priority) != set(new_priority):

--- a/energetica/game_error.py
+++ b/energetica/game_error.py
@@ -41,6 +41,7 @@ class GameExceptionType(StrEnum):
     INVALID_MULTIPLIER = "InvalidMultiplier"
     # network prices
     MALFORMED_REQUEST = "malformedRequest"
+    STORAGE_PRICE_INVERSION = "storagePriceInversion"
     # Project
     PROJECT_NOT_FOUND = "Project not found"
     CANNOT_DECREASE_PRIORITY_OF_LAST_PROJECT = "CannotDecreasePriorityOfLastProject"

--- a/frontend/src/components/power-priorities/price-input.tsx
+++ b/frontend/src/components/power-priorities/price-input.tsx
@@ -11,8 +11,8 @@ import { Input } from "@/components/ui/input";
 interface PriceInputProps {
     /** Current price value from server */
     value: number;
-    /** Called with the committed price on blur / Enter */
-    onCommit: (newPrice: number) => void;
+    /** Called with the committed price on blur / Enter; should reject on failure */
+    onCommit: (newPrice: number) => Promise<void>;
     /** Disable interaction while a mutation is in flight */
     disabled?: boolean;
 }
@@ -25,10 +25,14 @@ export function PriceInput({ value, onCommit, disabled = false }: PriceInputProp
         setLocalValue(value.toFixed(2));
     }, [value]);
 
-    const commit = () => {
+    const commit = async () => {
         const parsed = parseFloat(localValue);
         if (!isNaN(parsed)) {
-            onCommit(parsed);
+            try {
+                await onCommit(parsed);
+            } catch {
+                setLocalValue(value.toFixed(2));
+            }
         } else {
             setLocalValue(value.toFixed(2)); // reset on invalid input
         }

--- a/frontend/src/lib/game-messages.ts
+++ b/frontend/src/lib/game-messages.ts
@@ -83,6 +83,8 @@ export const GAME_ERROR_MESSAGES: Record<GameExceptionType, string> = {
     notInNetwork: "You are not a member of this market.",
     noSuchNetwork: "This electricity market does not exist.",
     malformedRequest: "Invalid request. Please check your input.",
+    storagePriceInversion:
+        "Invalid reorder: a storage facility's discharge price must be higher than its charge price.",
 
     // --- Resource market ---
     notEnoughResource: "You don't have enough of this resource.",

--- a/frontend/src/lib/game-messages.ts
+++ b/frontend/src/lib/game-messages.ts
@@ -84,7 +84,7 @@ export const GAME_ERROR_MESSAGES: Record<GameExceptionType, string> = {
     noSuchNetwork: "This electricity market does not exist.",
     malformedRequest: "Invalid request. Please check your input.",
     storagePriceInversion:
-        "Invalid reorder: a storage facility's discharge price must be higher than its charge price.",
+        "Invalid order: a storage facility's discharge price must be higher than its charge price.",
 
     // --- Resource market ---
     notEnoughResource: "You don't have enough of this resource.",

--- a/frontend/src/lib/power-priorities-utils.ts
+++ b/frontend/src/lib/power-priorities-utils.ts
@@ -13,11 +13,15 @@ const STORAGE_FACILITY_TYPES = [
 ] as const;
 
 /**
- * Validates that battery discharge (ask) is not placed below battery charge
- * (bid) in the unified priority list.
+ * Validates that no storage facility has its discharge price below its charge
+ * price in the unified priority list.
+ *
+ * In the unified list, lower index = lower price. A discharge (ask) item placed
+ * before a charge (bid) item of the same type would receive a lower price,
+ * meaning the facility sells for less than it buys — an economic loss.
  *
  * @param priorities - The unified priority array
- * @returns True if valid, false if any battery has discharge below charge
+ * @returns True if valid, false if any storage type has discharge before charge
  */
 export function validateBatteryOrder(priorities: PowerPriorityItem[]): boolean {
     for (const storageType of STORAGE_FACILITY_TYPES) {
@@ -28,12 +32,12 @@ export function validateBatteryOrder(priorities: PowerPriorityItem[]): boolean {
             (p) => p.type === storageType && p.side === "bid",
         );
 
-        // Invalid: discharge (ask) must not be AFTER charge (bid) in priority list
-        // Lower index = higher priority
+        // Invalid: discharge (ask) must not be BEFORE charge (bid) in priority list,
+        // as that would assign a lower sell price than buy price.
         if (
             dischargeIdx !== -1 &&
             chargeIdx !== -1 &&
-            dischargeIdx > chargeIdx
+            dischargeIdx < chargeIdx
         ) {
             return false;
         }

--- a/frontend/src/lib/power-priorities-utils.ts
+++ b/frontend/src/lib/power-priorities-utils.ts
@@ -13,40 +13,6 @@ const STORAGE_FACILITY_TYPES = [
 ] as const;
 
 /**
- * Validates that no storage facility has its discharge price below its charge
- * price in the unified priority list.
- *
- * In the unified list, lower index = lower price. A discharge (ask) item placed
- * before a charge (bid) item of the same type would receive a lower price,
- * meaning the facility sells for less than it buys — an economic loss.
- *
- * @param priorities - The unified priority array
- * @returns True if valid, false if any storage type has discharge before charge
- */
-export function validateBatteryOrder(priorities: PowerPriorityItem[]): boolean {
-    for (const storageType of STORAGE_FACILITY_TYPES) {
-        const dischargeIdx = priorities.findIndex(
-            (p) => p.type === storageType && p.side === "ask",
-        );
-        const chargeIdx = priorities.findIndex(
-            (p) => p.type === storageType && p.side === "bid",
-        );
-
-        // Invalid: discharge (ask) must not be BEFORE charge (bid) in priority list,
-        // as that would assign a lower sell price than buy price.
-        if (
-            dischargeIdx !== -1 &&
-            chargeIdx !== -1 &&
-            dischargeIdx < chargeIdx
-        ) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/**
  * Gets the display name for a power priority item. Handles special cases like
  * transport/construction/research and storage suffixes.
  *

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -4887,6 +4887,7 @@ export interface components {
             | "OLD_PASSWORD_INCORRECT"
             | "InvalidMultiplier"
             | "malformedRequest"
+            | "storagePriceInversion"
             | "Project not found"
             | "CannotDecreasePriorityOfLastProject"
             | "CannotIncreasePriorityOfFirstProject"


### PR DESCRIPTION
Fixes #306.

## Summary

- **Backend validation**: `NetworkPrices.update()` now checks that no storage facility ends up with a discharge (ask) price lower than its charge (bid) price before applying any price change. Merging current prices with the incoming update before checking correctly handles partial updates (e.g. only changing the ask side). Raises a new `storagePriceInversion` error, which surfaces as a toast.
- **Bug fix**: `validateBatteryOrder` had its condition inverted — it was marking the valid default state (discharge price ~800, charge price ~200) as invalid. Fixed.
- **UX fix**: `PriceInput` now awaits the async `onCommit` and resets to the last valid value if the mutation rejects, instead of leaving the rejected value in the field until a page refresh.

## Test plan

- [ ] Try moving a storage discharge row above its charge row via bump buttons → toast appears, order unchanged
- [ ] Try typing a discharge price lower than the current charge price → toast appears, input reverts to previous value
- [ ] Try typing a charge price higher than the current discharge price → same
- [ ] Valid price changes and reorders still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes #306 by moving storage price-inversion enforcement from a broken frontend utility to a correct backend validation in `NetworkPrices.update()`, and fixes the `PriceInput` component to revert on rejected mutations.

- **Backend guard**: `NetworkPrices.update()` merges current prices with the incoming partial update before checking every `StorageFacilityType`; raises `STORAGE_PRICE_INVERSION` if any discharge (ask) price would end up below its charge (bid) price. Both reorder bumps and direct price edits flow through `update()`, so the constraint is enforced uniformly.
- **Bug fix**: `validateBatteryOrder` in `power-priorities-utils.ts` had its condition inverted — `dischargeIdx > chargeIdx` is the *valid* state in an ascending-price list, but the function returned `false` for it. The function is removed entirely; the server is now the single source of truth.
- **UX fix**: `PriceInput.commit` now `await`s the async `onCommit` and resets `localValue` to the last server-provided `value` when the promise rejects, so a rejected price change no longer persists in the field until a page refresh.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure addition of a new constraint that prevents an invalid game state, with no modifications to existing happy-path logic.

The backend guard is atomic (validation happens before mutation), the error propagation chain from Python through FastAPI to the React toast and field-reset is complete and correct, and the removed frontend function had an inverted condition so its deletion is strictly an improvement. No existing paths are affected when prices are valid.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/network_prices.py | Adds storage price inversion guard to `update()` using merged ask/bid dicts so partial updates are validated correctly; `change_facility_priority` inherits the check by calling `update()` |
| energetica/game_error.py | Adds `STORAGE_PRICE_INVERSION = "storagePriceInversion"` enum value; strings match the frontend message key and generated API type exactly |
| frontend/src/components/power-priorities/price-input.tsx | Makes `onCommit` async and wraps the call in try/catch; on rejection resets localValue to the server-provided `value` prop — correct because value hasn't changed if the mutation was rejected |
| frontend/src/lib/game-messages.ts | Adds user-facing message for the new error key |
| frontend/src/lib/power-priorities-utils.ts | Removes `validateBatteryOrder`, which had an inverted condition (was treating the valid state as invalid); validation is now fully server-side |
| frontend/src/types/api.generated.ts | Adds `storagePriceInversion` to the generated `GameExceptionType` union, keeping backend and frontend error-type contracts in sync |

</details>

<sub>Reviews (3): Last reviewed commit: ["Removed dead code"](https://github.com/felixvonsamson/energetica/commit/21b67ff1cc478bfdcfd9e44bc10879ea2b856126) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32374645)</sub>

<!-- /greptile_comment -->