### PR TITLE
chore: remove deprecated tsconfig options

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,7 +6,6 @@
         "types": ["vite/client"],
         "allowJs": false,
         "skipLibCheck": true,
-        "esModuleInterop": false,
         "allowSyntheticDefaultImports": true,
         "strict": true,
         "forceConsistentCasingInFileNames": true,
@@ -20,7 +19,6 @@
         "isolatedModules": true,
         "noEmit": true,
         "jsx": "react-jsx",
-        "baseUrl": ".",
         "paths": { "@/*": ["./src/*"] }
     },
     "include": ["src"],


### PR DESCRIPTION
## Summary

- Remove `esModuleInterop: false` — already the default, explicit value was redundant
- Remove `baseUrl: "."` — no longer required when `paths` entries use relative `./` prefixes (TypeScript 5.0+)

Both were flagged by VSCode's TypeScript deprecation warnings.

## Test plan

- [x] `bun run typecheck` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

PR #785 removes two redundant TypeScript compiler options from `frontend/tsconfig.json`: `esModuleInterop: false` (already the default) and `baseUrl: "."` (unnecessary with relative `./` path prefixes in TypeScript 5+). No behavioral changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes two redundant options that were already matching their defaults, with no change to type-checking or module resolution behavior.

Both removed options were genuinely no-ops: `esModuleInterop` defaults to `false` in TypeScript, and `baseUrl` is not needed when every `paths` value already starts with `./`. The `moduleResolution: "bundler"` setting and the relative `"@/*": ["./src/*"]` alias continue to work identically without `baseUrl`.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/tsconfig.json | Removes two redundant compiler options: `esModuleInterop: false` (TypeScript default) and `baseUrl: "."` (unnecessary when all `paths` entries use relative `./` prefixes under TypeScript 5+/`moduleResolution: "bundler"`). No behavioral change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove deprecated tsconfig option..."](https://github.com/felixvonsamson/energetica/commit/b0d6afc1846135e268496b5c17a375db8a4048a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33330788)</sub>

<!-- /greptile_comment -->