### PR TITLE
docs: server-wide accounts and per-season visibility/access

### DIFF
--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -367,15 +367,18 @@ No service restart — landing is pure static. `seasons.json` and `seasons/` are
 
 ### `migrate-to-server-accounts.py` flow
 
-Run once per VPS, before the first deploy that ships server-wide accounts. Idempotent guard: skips any `User` row that already carries an `account_id` (per-user check, not a whole-DB check), so a partial failure can be recovered by simply re-running the script.
+Run once per VPS, before the first deploy that ships server-wide accounts. Safely re-runnable: a partial failure (e.g. crash after some SQLite inserts but before the pickle is saved) is recovered by re-running the script.
 
 1. Stop the season service (`systemctl stop energetica-{season}`) to prevent concurrent pickle mutation
 2. Load the existing engine pickle (`/var/www/energetica-{season}/instance/engine_data.pck`)
-3. For each `User` in the engine's user table:
-   - Insert a row into `accounts.db`: `(username, pwhash, NULL, now())` → returns `account_id`
+3. For each `User` in the engine's user table whose `account_id` is unset:
+   - `INSERT OR IGNORE INTO accounts (username, pwhash, email, created_at) VALUES (?, ?, NULL, ?)` — `OR IGNORE` so an already-inserted row from a previous partial run is not treated as an error
+   - `SELECT account_id FROM accounts WHERE username = ?` — retrieves the `account_id` whether the row was just inserted or already existed
    - Write `account_id` back into the pickle `User`
 4. Save the modified pickle
 5. Restart the season service
+
+The combination of (in-memory) per-user `account_id` guard and (on-disk) `INSERT OR IGNORE` + `SELECT` covers both failure modes: an interrupted run that didn't save the pickle, and an interrupted run that did. In both cases, re-running reaches the same end state.
 
 Today there is exactly one season per VPS, so no cross-season username collisions are possible during migration. If multiple seasons ever exist before this migration runs (e.g. on a new server that bootstrapped multi-season before accounts were unified), the script must be re-thought.
 

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -17,6 +17,9 @@ FastAPI currently serves all static files (React bundles, images, game data) by 
 - Split the frontend into two independent bundles: **landing** (public marketing) and **app** (game)
 - Support multiple game seasons per server via subdomains
 - Formalise server/season terminology and tooling
+- Server-wide accounts: one set of credentials works on every season on a given server
+- Per-season visibility and access policy: some seasons are publicly advertised, others are private (unlisted and/or allowlist-gated)
+- No singleton backend on the apex domain — the landing remains pure-static
 
 ---
 
@@ -32,6 +35,8 @@ Game seasons could have been deployed at subpaths (`energetica-game.org/autumn-2
 
 Subdomains also require less build configuration: subpaths need a per-season Vite `base`, TanStack Router `basepath`, and FastAPI `root_path` — all three layers needing to agree per season. Subdomains need only a new Apache vhost; one build works for all seasons.
 
+> **On shared credentials.** Server-wide accounts (introduced in [Server-Wide Accounts](#server-wide-accounts)) do **not** undo the cookie-isolation argument above. Credentials are shared via a server-side SQLite file; sessions are still per-subdomain. A user re-enters their password on each season they visit and gets an independent session cookie for that origin. The cookie-leak class of bug remains structurally impossible.
+
 ---
 
 ## Terminology
@@ -40,6 +45,9 @@ Subdomains also require less build configuration: subpaths need a per-season Vit
 |------|------------|
 | **Server** | A VPS, identified by its SSH alias (e.g. `energetica-game`, `energetica-edu`, `energetica-ethz`) |
 | **Season** | A single running game deployment on a server, identified by a kebab-case slug (e.g. `autumn-2025`, `spring-2026`). Also used for private university or business deployments. |
+| **Account** | A server-wide identity. One row in the server's `accounts.db` SQLite file, keyed by `account_id`. Holds credentials (`username`, `pwhash`, optional `email`). Independent of any season. |
+| **User** (pickle) | A per-season record in the engine pickle (`energetica/database/user.py`), keyed by a local AutoIDDict id. Carries `account_id` as a foreign key to the server-wide account. Auto-provisioned on first successful login to a season. |
+| **Player** | The game-side state of a user who has completed the settle flow. Distinct from `User`: a `User` may exist without a `Player`. |
 
 Subdomain pattern: `{season}.{server-domain}` — e.g. `autumn-2025.energetica-game.org`.
 
@@ -50,6 +58,10 @@ The **apex domain always serves the landing page**, never a season directly.
 ### Season name constraints
 - Lowercase kebab-case only (`[a-z0-9][a-z0-9-]*[a-z0-9]`)
 - Reserved names: **`landing`** (used for the landing site directory)
+
+### Username constraints
+- Globally unique per server (enforced by `accounts.username UNIQUE` in SQLite)
+- Per-server scope only; the same username on `energetica-game` and `energetica-edu` are unrelated accounts
 
 ### Season discovery
 Canonical source of truth is systemd: `systemctl list-units 'energetica-*.service'`. Filesystem enumeration of `/var/www/energetica-*/` is avoided since it would accidentally include `energetica-landing`.
@@ -78,10 +90,14 @@ autumn-2025.energetica-game.org
 
 ```
 energetica-game.org  (landing — DocumentRoot /var/www/energetica-landing/, no game backend)
-└── /*  → FallbackResource → index.html  (SPA routing for /landing-page, /about, /for-educators, /wiki/*, /changelog)
+├── /seasons.json         → Apache serves /var/www/energetica-landing/seasons.json  (manifest, Cache-Control: max-age=60)
+├── /seasons/{slug}.json  → Apache serves /var/www/energetica-landing/seasons/{slug}.json  (per-season public fragment)
+└── /*                    → FallbackResource → index.html  (SPA routing for /landing-page, /about, /for-educators, /wiki/*, /changelog)
 ```
 
 The landing vhost uses `DocumentRoot /var/www/energetica-landing/`. With `base: "/"`, Vite emits assets at `/assets/index-abc123.js`; Apache serves them directly from DocumentRoot. No Alias needed.
+
+The `seasons.json` manifest and `seasons/` fragment directory are populated by the season backends themselves (see [Season Visibility & Access](#season-visibility--access)); the apex domain hosts no application logic.
 
 ### What FastAPI keeps
 
@@ -92,6 +108,115 @@ The landing vhost uses `DocumentRoot /var/www/energetica-landing/`. With `base: 
 Everything else (`StaticFiles` mount, all `FileResponse` page handlers) is removed from FastAPI.
 
 `energetica/static/apple-app-site-association` is also removed — it is legacy and no longer used.
+
+### What FastAPI gains
+
+- Reads `/var/lib/energetica/accounts.db` (shared SQLite) on signup, login, and password change.
+- Reads its own `/var/www/energetica-{season}/season.json` on every login attempt for access-policy enforcement (no in-memory cache — admin edits take effect on the next login).
+- Writes its own sanitised fragment to `/var/www/energetica-landing/seasons/{slug}.json` on process start and whenever `season.json` is reloaded (see [Season Visibility & Access](#season-visibility--access)). Writes are atomic (write-to-tmp + rename).
+
+---
+
+## Server-Wide Accounts
+
+### Model
+
+Credentials are server-wide; sessions remain per-subdomain. One physical SQLite file on the VPS holds the canonical identity:
+
+```
+/var/lib/energetica/accounts.db
+
+  accounts(
+    account_id   INTEGER PRIMARY KEY,
+    username     TEXT    NOT NULL UNIQUE,
+    email        TEXT             UNIQUE,   -- nullable for now; not yet collected in the signup form
+    pwhash       TEXT    NOT NULL,
+    created_at   TEXT    NOT NULL           -- ISO-8601 UTC
+  )
+```
+
+The pickle `User` (`energetica/database/user.py`) gains an `account_id: int` field, used as the foreign key back to SQLite. The pickle keeps its own local AutoIDDict id; the two ids differ and must not be conflated.
+
+SQLite is opened by every season backend with WAL mode (concurrent readers, serialised writers). Writes are infrequent (signup, password change) and short.
+
+### Flows
+
+**Signup.** Only available on season subdomains, never on the apex. The landing's signup CTA links to the latest advertised season's `/app/sign-up` (selection rule: filename-sorted first entry in `seasons.json`; revisited when a richer picker UI lands — see [Deferred / Out of Scope](#deferred--out-of-scope)). Signup writes one row to SQLite `accounts` and one row to that season's pickle `User`, in a single logical transaction (SQLite first; on failure of the pickle write, the SQLite row is rolled back).
+
+**Login on the original signup season.** Backend looks up `accounts` by `username`, verifies `pwhash`. On success, finds the matching pickle `User` by `account_id` and sets the session cookie.
+
+**Login on a different season (first time).** Same SQLite check. Then the season's access policy is consulted (see below). If allowed, the backend auto-provisions a pickle `User(account_id, role="player", player=None)` in its own engine and proceeds. No `Player` is created — that still happens at the settle page, which serves as the real "join this season" confirmation.
+
+**Logout.** Unchanged; clears the session cookie for the current subdomain only.
+
+**Password change.** Writes the new `pwhash` to SQLite. Other seasons see the change on their next login attempt automatically (they read SQLite, not their pickle, for credentials).
+
+### Why credentials shared but sessions not
+
+Per-subdomain cookie isolation is preserved as a security property (see [Rationale: Subdomains vs Subpaths](#rationale-subdomains-vs-subpaths)). Sharing the *credentials store* is what users actually want ("one account on the site"); sharing *sessions* across subdomains would require a parent-domain cookie and reintroduce the cross-season cookie-leak class of bug. The cost of the chosen design is a second password prompt when a user first visits a new season — accepted as worth the security simplification.
+
+---
+
+## Season Visibility & Access
+
+Two independent axes per season:
+
+- **Advertised vs unadvertised.** Whether the landing's season picker lists it.
+- **Public vs private.** Whether any server-wide account may log in, or only those on an allowlist.
+
+Both axes are declared per-season in a single file the season backend owns:
+
+```
+/var/www/energetica-{slug}/season.json
+
+  Public + advertised:
+    { "name": "Autumn 2025", "advertised": true,  "access": { "policy": "public" } }
+
+  Private (allowlist-gated) + unadvertised:
+    { "name": "ETHZ Spring 2026", "advertised": false,
+      "access": { "policy": "private", "allowed_usernames": ["alice", "bob"] } }
+```
+
+`slug` is **not** stored in the file — it is the deploy directory name (canonical per [Season discovery](#season-discovery)). Subdomain is **not** stored either — the landing composes `${slug}.${apex}` at render time, where `apex` is a Vite build-time constant.
+
+The file is re-read on every login attempt. There is no in-memory cache. Admin edits take effect on the next login with no restart and no SIGHUP.
+
+### Publication to the landing
+
+Each season process, on start and whenever it reloads `season.json`, writes a **sanitised fragment** to the landing dir:
+
+```
+/var/www/energetica-landing/seasons/{slug}.json
+
+  { "slug": "autumn-2025", "name": "Autumn 2025", "advertised": true }
+```
+
+The `access` block (including `allowed_usernames`) is **stripped before write** — the landing dir is served statically by Apache, and any allowlist that reached it would leak to the internet.
+
+Writes are atomic: write to `{slug}.json.tmp` then `rename(2)` over the target. No locking required across season processes since each writes to a unique filename.
+
+After writing its fragment, the season process runs the inline aggregation step:
+
+```bash
+jq -s '{seasons: .}' /var/www/energetica-landing/seasons/*.json \
+  > /var/www/energetica-landing/seasons.json.tmp \
+  && mv /var/www/energetica-landing/seasons.json.tmp \
+        /var/www/energetica-landing/seasons.json
+```
+
+Two concurrent aggregations may interleave; last-writer-wins is harmless because every aggregator reads the same fragment dir and produces a complete snapshot. The atomic rename guarantees readers never see a partial file.
+
+### Frontend consumption
+
+The landing fetches `/seasons.json` and renders advertised entries. Apache serves it with `Cache-Control: max-age=60` so admin changes propagate within a minute without explicit cache-busting.
+
+Unadvertised seasons that are public are reachable by direct URL — a user who knows the subdomain may sign up and play. Unadvertised + private seasons are reachable only by URL *and* require allowlisted credentials.
+
+### Operational notes
+
+- The landing's `seasons/` subdirectory must be writable by every season's systemd unit. Cleanest: create a shared group `energetica`, `chmod g+ws /var/www/energetica-landing/seasons/`, and run each `energetica-{slug}.service` as a user in that group. Setgid ensures new fragment files inherit group ownership.
+- A season going down does not currently remove its fragment. If permanent removal is desired, `teardown-season.sh` deletes the fragment and re-runs the aggregation. Stale fragments for stopped-but-not-removed seasons are tolerated — the landing UI can surface `status` later (deferred per [7a](#deferred--out-of-scope)).
+- No cross-season reads. Each season reads only its own `season.json`. The aggregation step reads only files inside the landing-owned `seasons/` dir.
 
 ---
 
@@ -168,15 +293,22 @@ Both build outputs are **gitignored** and deployed via rsync:
 ```
 scripts/
   infra/
-    setup-base.sh             ← run once per server; installs Apache, Python, certbot, firewall, modules
-    setup-landing.sh          ← run once per server; creates /var/www/energetica-landing/, main domain vhost
-    setup-season.sh           ← run per season; usage: setup-season.sh <season> <port>
+    setup-base.sh             ← run once per server; installs Apache, Python, certbot, firewall, modules;
+                                creates /var/lib/energetica/ and accounts.db; creates `energetica` group
+    setup-landing.sh          ← run once per server; creates /var/www/energetica-landing/, main domain vhost;
+                                creates /var/www/energetica-landing/seasons/ with setgid `energetica`
+    setup-season.sh           ← run per season; usage: setup-season.sh <season> <port>;
+                                also writes initial season.json
     apache-main.conf          ← main domain vhost template (static landing, no proxy)
     apache-season.conf        ← season vhost template (app static + API proxy)
-    energetica.service        ← systemd service template
+    energetica.service        ← systemd service template (runs as user in `energetica` group)
+    season.json.tmpl          ← initial per-season config; default policy is public, advertised true
   deploy-landing.sh           ← build:landing → rsync dist-landing/ → server:/var/www/energetica-landing/
-  deploy-season.sh            ← usage: --server <server> --season <season>
+  deploy-season.sh            ← usage: --server <server> --season <season>;
+                                rsyncs season.json if changed; restart triggers fragment + aggregation rewrite
   list-seasons.sh             ← usage: --server <server>; queries systemd, prints name/port/status table
+  migrate-to-server-accounts.py  ← one-time per VPS; backfills accounts.db from the existing season's pickle
+                                   and writes account_id into each pickle User row
 ```
 
 `scripts/vps-setup.sh` is superseded by the three `infra/setup-*.sh` scripts and will be removed.
@@ -185,25 +317,26 @@ scripts/
 
 1. Create `/var/www/energetica-{season}/` directory structure
 2. Clone repo (or symlink shared code — TBD)
-3. Create and enable Apache vhost from `apache-season.conf` template
-4. Reload Apache (HTTP only at this point)
-5. Obtain TLS certificate: `certbot certonly --webroot -w /var/www/energetica-{season}/ -d {season}.{domain}` — the season directory (created in step 1) is already the Apache DocumentRoot, so ACME challenge files are reachable there
-6. Update vhost with SSL directives, reload Apache
-7. Install certbot deploy hook to reload Apache on certificate renewal
-8. Create and enable `energetica-{season}.service` systemd unit
-9. `pip install -r requirements.txt`, start service
+3. Render `season.json.tmpl` into `/var/www/energetica-{season}/season.json` (defaults: `name = {slug titlecased}`, `advertised = true`, `access.policy = "public"` — admin edits before going live for private seasons)
+4. Create and enable Apache vhost from `apache-season.conf` template
+5. Reload Apache (HTTP only at this point)
+6. Obtain TLS certificate: `certbot certonly --webroot -w /var/www/energetica-{season}/ -d {season}.{domain}` — the season directory (created in step 1) is already the Apache DocumentRoot, so ACME challenge files are reachable there
+7. Update vhost with SSL directives, reload Apache
+8. Install certbot deploy hook to reload Apache on certificate renewal
+9. Create and enable `energetica-{season}.service` systemd unit (runs as a user in group `energetica` so it can write fragments to the landing's `seasons/` dir)
+10. `pip install -r requirements.txt`, start service — on startup the season writes its sanitised fragment to `/var/www/energetica-landing/seasons/{season}.json` and runs the aggregation step
 
-TLS provisioning (steps 5–7) requires the DNS record for `{season}.{domain}` to already resolve to the server before running.
+TLS provisioning (steps 6–8) requires the DNS record for `{season}.{domain}` to already resolve to the server before running.
 
 ### `deploy-season.sh` flow
 
 1. Build app bundle (`bun run build`)
 2. Confirm deployment summary (skipped with `--yes`)
-3. `rsync` Python backend code to server (excluding `.venv`, `season/`, build artifacts)
+3. `rsync` Python backend code to server (excluding `.venv`, `season/`, build artifacts, and `season.json` — that file is admin-owned on the server and must not be overwritten by deploys)
 4. `rsync` app bundle to server (`energetica/static/app/`)
 5. `rsync` service worker to server (`energetica/static/service-worker.js` — built separately by `build:sw`, lives outside the app bundle directory)
 6. `pip install -r requirements.txt` on server if dependencies changed
-7. `systemctl restart energetica-{season}`
+7. `systemctl restart energetica-{season}` — on restart the season re-publishes its fragment and re-runs aggregation, picking up any admin edits to `season.json` made since the last start
 8. Health check
 
 Scripts accept all inputs via arguments or env vars and support `--yes` to suppress confirmation prompts, making them callable from a CI job without modification. No commitment to a CI platform is made here.
@@ -213,7 +346,21 @@ Scripts accept all inputs via arguments or env vars and support `--yes` to suppr
 1. Build landing bundle (`bun run build:landing`)
 2. `rsync dist-landing/` to `server:/var/www/energetica-landing/`
 
-No service restart — landing is pure static.
+No service restart — landing is pure static. `seasons.json` and `seasons/` are not touched — they are owned by the season backends and must not be overwritten.
+
+### `migrate-to-server-accounts.py` flow
+
+Run once per VPS, before the first deploy that ships server-wide accounts. Idempotent guard: skips servers whose `accounts.db` is already populated.
+
+1. Stop the season service (`systemctl stop energetica-{season}`) to prevent concurrent pickle mutation
+2. Load the existing engine pickle (`/var/www/energetica-{season}/instance/engine_data.pck`)
+3. For each `User` in the engine's user table:
+   - Insert a row into `accounts.db`: `(username, pwhash, NULL, now())` → returns `account_id`
+   - Write `account_id` back into the pickle `User`
+4. Save the modified pickle
+5. Restart the season service
+
+Today there is exactly one season per VPS, so no cross-season username collisions are possible during migration. If multiple seasons ever exist before this migration runs (e.g. on a new server that bootstrapped multi-season before accounts were unified), the script must be re-thought.
 
 ---
 
@@ -223,3 +370,8 @@ No service restart — landing is pure static.
 - **Admin dashboard** — currently stubbed. The server-side role gate in `templates.py` will be dropped along with all other `FileResponse` handlers. A proper frontend route guard and admin UI are a separate workstream.
 - **Landing images on multi-server** — landing pages reference images at `/static/images/`. On a server with no game instance (pure landing server), these paths would break. To be addressed when a second server deployment is made.
 - **Service worker on multiple seasons** — currently scoped to `/`. Per-season scoping implications (e.g. `autumn-2025.energetica-game.org/service-worker.js`) are not an architectural concern but should be tested when the first subdomain season goes live.
+- **`seasons.json` schema expansion** — current minimum is `{slug, name, advertised}`. Fields like `description`, `status`, `starts_at`, `ends_at`, `thumbnail` will be added when a season-picker UI needs them (YAGNI until then).
+- **Season-picker UI** — landing currently sends the signup CTA to the latest advertised season. Lateral navigation between active seasons (a picker page or persistent header element — UI form factor TBD) is a frontend workstream that consumes the existing `seasons.json` data and may motivate schema additions above.
+- **Password reset via email** — `accounts.email` is in the SQLite schema (nullable, unique) but not yet collected at signup. Adding the signup field and the reset-by-email flow (which requires an SMTP/transactional-mail dependency the project does not yet have) is a follow-up.
+- **`teardown-season.sh`** — removing a season cleanly (delete vhost, disable service, delete fragment, re-aggregate, optionally archive pickle) is not yet scripted. Stale fragments for stopped seasons are tolerated until then.
+- **Cross-server accounts** — accounts are scoped to a single VPS. The same username on `energetica-game` and `energetica-edu` are unrelated. Unifying identity across servers would require either a remote auth service or replication and is explicitly out of scope.

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -293,7 +293,7 @@ Both build outputs are **gitignored** and deployed via rsync:
 ```
 scripts/
   infra/
-    setup-base.sh             ← run once per server; installs Apache, Python, certbot, firewall, modules;
+    setup-base.sh             ← run once per server; installs Apache, Python, certbot, firewall, modules, jq;
                                 creates /var/lib/energetica/ and accounts.db; creates `energetica` group
     setup-landing.sh          ← run once per server; creates /var/www/energetica-landing/, main domain vhost;
                                 creates /var/www/energetica-landing/seasons/ with setgid `energetica`

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -350,7 +350,7 @@ No service restart — landing is pure static. `seasons.json` and `seasons/` are
 
 ### `migrate-to-server-accounts.py` flow
 
-Run once per VPS, before the first deploy that ships server-wide accounts. Idempotent guard: skips servers whose `accounts.db` is already populated.
+Run once per VPS, before the first deploy that ships server-wide accounts. Idempotent guard: skips any `User` row that already carries an `account_id` (per-user check, not a whole-DB check), so a partial failure can be recovered by simply re-running the script.
 
 1. Stop the season service (`systemctl stop energetica-{season}`) to prevent concurrent pickle mutation
 2. Load the existing engine pickle (`/var/www/energetica-{season}/instance/engine_data.pck`)

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -112,7 +112,7 @@ Everything else (`StaticFiles` mount, all `FileResponse` page handlers) is remov
 ### What FastAPI gains
 
 - Reads `/var/lib/energetica/accounts.db` (shared SQLite) on signup, login, and password change.
-- Reads its own `/var/www/energetica-{season}/season.json` on every login attempt for access-policy enforcement (no in-memory cache — admin edits take effect on the next login).
+- Reads its own `/etc/energetica/{season}/season.json` on every login attempt for access-policy enforcement (no in-memory cache — admin edits take effect on the next login). The file lives **outside the vhost DocumentRoot** so Apache cannot serve it as static — see [Season Visibility & Access](#season-visibility--access) for rationale.
 - Writes its own sanitised fragment to `/var/www/energetica-landing/seasons/{slug}.json` on process start and whenever `season.json` is reloaded (see [Season Visibility & Access](#season-visibility--access)). Writes are atomic (write-to-tmp + rename).
 
 ---
@@ -141,7 +141,7 @@ SQLite is opened by every season backend with WAL mode (concurrent readers, seri
 
 ### Flows
 
-**Signup.** Only available on season subdomains, never on the apex. The landing's signup CTA links to the latest advertised season's `/app/sign-up` (selection rule: filename-sorted first entry in `seasons.json`; revisited when a richer picker UI lands — see [Deferred / Out of Scope](#deferred--out-of-scope)). Signup writes one row to SQLite `accounts` and one row to that season's pickle `User`, in a single logical transaction (SQLite first; on failure of the pickle write, the SQLite row is rolled back).
+**Signup.** Only available on season subdomains, never on the apex. The landing's signup CTA links to the latest advertised season's `/app/sign-up`. Selection rule: `seasons.json` is already sorted by `starts_at` descending (see [Publication to the landing](#publication-to-the-landing)), so the CTA target is the first entry with `advertised: true`. Revisited when a richer picker UI lands — see [Deferred / Out of Scope](#deferred--out-of-scope). Signup writes one row to SQLite `accounts` and one row to that season's pickle `User`, in a single logical transaction (SQLite first; on failure of the pickle write, the SQLite row is rolled back).
 
 **Login on the original signup season.** Backend looks up `accounts` by `username`, verifies `pwhash`. On success, finds the matching pickle `User` by `account_id` and sets the session cookie.
 
@@ -149,7 +149,7 @@ SQLite is opened by every season backend with WAL mode (concurrent readers, seri
 
 **Logout.** Unchanged; clears the session cookie for the current subdomain only.
 
-**Password change.** Writes the new `pwhash` to SQLite. Other seasons see the change on their next login attempt automatically (they read SQLite, not their pickle, for credentials).
+**Password change.** Writes the new `pwhash` to SQLite. Other seasons see the change on their next login attempt automatically (they read SQLite, not their pickle, for credentials). **Known limitation:** existing session cookies on other season subdomains remain valid until they expire or the user explicitly logs out — `itsdangerous`-signed session tokens carry no reference to the current `pwhash`. If a password is changed as a security response (suspected compromise), the user must log out of each season manually. Cross-season session invalidation is listed under [Deferred / Out of Scope](#deferred--out-of-scope).
 
 ### Why credentials shared but sessions not
 
@@ -167,19 +167,30 @@ Two independent axes per season:
 Both axes are declared per-season in a single file the season backend owns:
 
 ```
-/var/www/energetica-{slug}/season.json
+/etc/energetica/{slug}/season.json
 
   Public + advertised:
-    { "name": "Autumn 2025", "advertised": true,  "access": { "policy": "public" } }
+    { "name": "Autumn 2025",
+      "advertised": true,
+      "starts_at": "2025-09-15T00:00:00Z",
+      "access": { "policy": "public" } }
 
   Private (allowlist-gated) + unadvertised:
-    { "name": "ETHZ Spring 2026", "advertised": false,
+    { "name": "ETHZ Spring 2026",
+      "advertised": false,
+      "starts_at": "2026-03-01T00:00:00Z",
       "access": { "policy": "private", "allowed_usernames": ["alice", "bob"] } }
 ```
 
-`slug` is **not** stored in the file — it is the deploy directory name (canonical per [Season discovery](#season-discovery)). Subdomain is **not** stored either — the landing composes `${slug}.${apex}` at render time, where `apex` is a Vite build-time constant.
+`slug` is **not** stored in the file — it is the directory name under `/etc/energetica/`, mirroring the canonical slug from [Season discovery](#season-discovery). Subdomain is **not** stored either — the landing composes `${slug}.${apex}` at render time, where `apex` is a Vite build-time constant.
+
+`starts_at` is the season's real start time (ISO-8601 UTC), exposed to players as "running since X" and used by the landing to sort the season list.
 
 The file is re-read on every login attempt. There is no in-memory cache. Admin edits take effect on the next login with no restart and no SIGHUP.
+
+### Why outside the vhost DocumentRoot
+
+`season.json` carries `allowed_usernames` for private seasons. The vhost DocumentRoot is `/var/www/energetica-{slug}/`, and Apache has no catch-all deny rule for unlisted files — placing `season.json` there would let a plain `GET https://{slug}.{apex}/season.json` return the allowlist to anyone who guesses the URL. Moving the file to `/etc/energetica/{slug}/season.json` makes that class of exposure structurally impossible: the file is not under any DocumentRoot, so no vhost configuration error can leak it.
 
 ### Publication to the landing
 
@@ -188,17 +199,21 @@ Each season process, on start and whenever it reloads `season.json`, writes a **
 ```
 /var/www/energetica-landing/seasons/{slug}.json
 
-  { "slug": "autumn-2025", "name": "Autumn 2025", "advertised": true }
+  { "slug": "autumn-2025",
+    "name": "Autumn 2025",
+    "advertised": true,
+    "starts_at": "2025-09-15T00:00:00Z" }
 ```
 
-The `access` block (including `allowed_usernames`) is **stripped before write** — the landing dir is served statically by Apache, and any allowlist that reached it would leak to the internet.
+The `access` block (including `allowed_usernames`) is **stripped before write** — the landing dir is served statically by Apache, and any allowlist that reached it would leak to the internet. `starts_at` is preserved (it is public information).
 
 Writes are atomic: write to `{slug}.json.tmp` then `rename(2)` over the target. No locking required across season processes since each writes to a unique filename.
 
-After writing its fragment, the season process runs the inline aggregation step:
+After writing its fragment, the season process runs the inline aggregation step, sorting by `starts_at` descending so the most recent season appears first:
 
 ```bash
-jq -s '{seasons: .}' /var/www/energetica-landing/seasons/*.json \
+jq -s 'sort_by(.starts_at) | reverse | {seasons: .}' \
+  /var/www/energetica-landing/seasons/*.json \
   > /var/www/energetica-landing/seasons.json.tmp \
   && mv /var/www/energetica-landing/seasons.json.tmp \
         /var/www/energetica-landing/seasons.json
@@ -215,8 +230,9 @@ Unadvertised seasons that are public are reachable by direct URL — a user who 
 ### Operational notes
 
 - The landing's `seasons/` subdirectory must be writable by every season's systemd unit. Cleanest: create a shared group `energetica`, `chmod g+ws /var/www/energetica-landing/seasons/`, and run each `energetica-{slug}.service` as a user in that group. Setgid ensures new fragment files inherit group ownership.
+- `/etc/energetica/{slug}/` is admin-owned (root:energetica, mode `0750`) so the season unit can read but not modify its own policy. Admins edit `season.json` via `sudo`.
 - A season going down does not currently remove its fragment. If permanent removal is desired, `teardown-season.sh` deletes the fragment and re-runs the aggregation. Stale fragments for stopped-but-not-removed seasons are tolerated — the landing UI can surface `status` later (deferred per [7a](#deferred--out-of-scope)).
-- No cross-season reads. Each season reads only its own `season.json`. The aggregation step reads only files inside the landing-owned `seasons/` dir.
+- No cross-season reads. Each season reads only its own `season.json` under `/etc/energetica/{own-slug}/`. The aggregation step reads only files inside the landing-owned `seasons/` dir.
 
 ---
 
@@ -294,11 +310,12 @@ Both build outputs are **gitignored** and deployed via rsync:
 scripts/
   infra/
     setup-base.sh             ← run once per server; installs Apache, Python, certbot, firewall, modules, jq;
-                                creates /var/lib/energetica/ and accounts.db; creates `energetica` group
+                                creates /var/lib/energetica/ and accounts.db; creates /etc/energetica/;
+                                creates `energetica` group
     setup-landing.sh          ← run once per server; creates /var/www/energetica-landing/, main domain vhost;
                                 creates /var/www/energetica-landing/seasons/ with setgid `energetica`
     setup-season.sh           ← run per season; usage: setup-season.sh <season> <port>;
-                                also writes initial season.json
+                                creates /etc/energetica/{season}/ and writes initial season.json there
     apache-main.conf          ← main domain vhost template (static landing, no proxy)
     apache-season.conf        ← season vhost template (app static + API proxy)
     energetica.service        ← systemd service template (runs as user in `energetica` group)
@@ -317,7 +334,7 @@ scripts/
 
 1. Create `/var/www/energetica-{season}/` directory structure
 2. Clone repo (or symlink shared code — TBD)
-3. Render `season.json.tmpl` into `/var/www/energetica-{season}/season.json` (defaults: `name = {slug titlecased}`, `advertised = true`, `access.policy = "public"` — admin edits before going live for private seasons)
+3. Create `/etc/energetica/{season}/` (mode `0750`, owned by `root:energetica`) and render `season.json.tmpl` into `/etc/energetica/{season}/season.json` (defaults: `name = {slug titlecased}`, `advertised = true`, `starts_at = now (UTC)`, `access.policy = "public"` — admin edits before going live for private seasons)
 4. Create and enable Apache vhost from `apache-season.conf` template
 5. Reload Apache (HTTP only at this point)
 6. Obtain TLS certificate: `certbot certonly --webroot -w /var/www/energetica-{season}/ -d {season}.{domain}` — the season directory (created in step 1) is already the Apache DocumentRoot, so ACME challenge files are reachable there
@@ -332,7 +349,7 @@ TLS provisioning (steps 6–8) requires the DNS record for `{season}.{domain}` t
 
 1. Build app bundle (`bun run build`)
 2. Confirm deployment summary (skipped with `--yes`)
-3. `rsync` Python backend code to server (excluding `.venv`, `season/`, build artifacts, and `season.json` — that file is admin-owned on the server and must not be overwritten by deploys)
+3. `rsync` Python backend code to server (excluding `.venv`, `season/`, build artifacts). `season.json` lives outside the deploy dir (`/etc/energetica/{season}/`) and is admin-owned, so it is never touched by deploys.
 4. `rsync` app bundle to server (`energetica/static/app/`)
 5. `rsync` service worker to server (`energetica/static/service-worker.js` — built separately by `build:sw`, lives outside the app bundle directory)
 6. `pip install -r requirements.txt` on server if dependencies changed
@@ -370,8 +387,9 @@ Today there is exactly one season per VPS, so no cross-season username collision
 - **Admin dashboard** — currently stubbed. The server-side role gate in `templates.py` will be dropped along with all other `FileResponse` handlers. A proper frontend route guard and admin UI are a separate workstream.
 - **Landing images on multi-server** — landing pages reference images at `/static/images/`. On a server with no game instance (pure landing server), these paths would break. To be addressed when a second server deployment is made.
 - **Service worker on multiple seasons** — currently scoped to `/`. Per-season scoping implications (e.g. `autumn-2025.energetica-game.org/service-worker.js`) are not an architectural concern but should be tested when the first subdomain season goes live.
-- **`seasons.json` schema expansion** — current minimum is `{slug, name, advertised}`. Fields like `description`, `status`, `starts_at`, `ends_at`, `thumbnail` will be added when a season-picker UI needs them (YAGNI until then).
-- **Season-picker UI** — landing currently sends the signup CTA to the latest advertised season. Lateral navigation between active seasons (a picker page or persistent header element — UI form factor TBD) is a frontend workstream that consumes the existing `seasons.json` data and may motivate schema additions above.
+- **`seasons.json` schema expansion** — current schema is `{slug, name, advertised, starts_at}`. Fields like `description`, `status`, `ends_at`, `thumbnail` will be added when a season-picker UI needs them (YAGNI until then).
+- **Season-picker UI** — landing currently sends the signup CTA to the most recent advertised season (`seasons.json` is sorted by `starts_at` desc; first `advertised: true` entry wins). Lateral navigation between active seasons (a picker page or persistent header element — UI form factor TBD) is a frontend workstream that consumes the existing `seasons.json` data and may motivate schema additions above.
 - **Password reset via email** — `accounts.email` is in the SQLite schema (nullable, unique) but not yet collected at signup. Adding the signup field and the reset-by-email flow (which requires an SMTP/transactional-mail dependency the project does not yet have) is a follow-up.
+- **Cross-season session invalidation on password change** — changing the password updates `pwhash` in SQLite but does not invalidate session cookies already issued by other season subdomains (see [Password change](#flows) flow). Fixing this would require either a `session_version` column on `accounts` (bumped on password change, checked on every request) or a short server-issued session-validity window combined with a periodic re-check against SQLite. Deferred until there is a concrete security-response use case driving the cost.
 - **`teardown-season.sh`** — removing a season cleanly (delete vhost, disable service, delete fragment, re-aggregate, optionally archive pickle) is not yet scripted. Stale fragments for stopped seasons are tolerated until then.
 - **Cross-server accounts** — accounts are scoped to a single VPS. The same username on `energetica-game` and `energetica-edu` are unrelated. Unifying identity across servers would require either a remote auth service or replication and is explicitly out of scope.

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -322,7 +322,8 @@ scripts/
     season.json.tmpl          ← initial per-season config; default policy is public, advertised true
   deploy-landing.sh           ← build:landing → rsync dist-landing/ → server:/var/www/energetica-landing/
   deploy-season.sh            ← usage: --server <server> --season <season>;
-                                rsyncs season.json if changed; restart triggers fragment + aggregation rewrite
+                                does not touch /etc/energetica/{season}/season.json (admin-owned);
+                                restart triggers fragment + aggregation rewrite
   list-seasons.sh             ← usage: --server <server>; queries systemd, prints name/port/status table
   migrate-to-server-accounts.py  ← one-time per VPS; backfills accounts.db from the existing season's pickle
                                    and writes account_id into each pickle User row


### PR DESCRIPTION
## Summary

Extends the existing static-serving / multi-season RFC (`docs/architecture/static-serving-and-deployment.md`) with two related refinements decided in a grilling session:

- **Server-wide accounts.** Credentials are shared across all seasons on a VPS via a single SQLite file (`/var/lib/energetica/accounts.db`); sessions remain per-subdomain, preserving the cookie-isolation argument the original RFC was built on. Pickle `User` gains an `account_id` FK; signup happens on season subdomains only; first login to a new season auto-provisions a pickle `User` (no `Player` until settle).
- **Per-season visibility & access.** Each season owns a `season.json` declaring `name`, `advertised`, and an `access` policy (`public` or `private` with `allowed_usernames`). The season backend re-reads it on every login attempt and publishes a sanitised fragment (no allowlist) into the landing's static `seasons/` dir; the season also runs an inline `jq` aggregation step to refresh `seasons.json` on the apex. No backend on the apex domain.

Other doc changes:

- Adds `Account` and clarifies `User` vs `Player` in the terminology table.
- Documents `accounts.db` schema (with `email` nullable+unique, deferred from the signup form for now).
- Updates `setup-base`, `setup-landing`, `setup-season`, `deploy-season` flows; adds `season.json.tmpl` and `migrate-to-server-accounts.py`.
- Notes the `energetica` group / setgid pattern for letting season units write fragments into the landing dir.
- Extends `Deferred / Out of Scope` with: schema expansion, season-picker UI, password reset via email, `teardown-season.sh`, cross-server accounts.

## Test plan

- [ ] Read through the diff end-to-end; confirm flows, schemas, and operational notes match the discussed design
- [ ] Decide on fragment-write trigger semantics (process start + SIGHUP vs. re-publish on every `season.json` reload) before implementation begins
- [ ] Consider follow-up ADRs for: shared-credentials-not-sessions, SQLite as shared store, per-season config file + fragment publication

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the static-serving/multi-season RFC with two architectural additions: server-wide accounts backed by a shared SQLite file (`accounts.db`), and per-season visibility/access control via a `season.json` config file stored outside the vhost DocumentRoot. It also updates infra-script flows, adds a `migrate-to-server-accounts.py` spec, and revises the terminology table.

- **Server-wide accounts:** credentials are shared across seasons via SQLite; sessions remain per-subdomain (preserving cookie isolation). The pickle `User` gains an `account_id` FK; first login to a new season auto-provisions a `User` with no `Player` until settle.
- **Per-season visibility/access:** `season.json` declares `advertised`, `starts_at`, and an `access` policy; a sanitised fragment (no allowlist) is published atomically to the landing's `seasons/` dir and aggregated into `seasons.json` via `jq`.
- **Migration:** `migrate-to-server-accounts.py` uses `INSERT OR IGNORE` + `SELECT` to be safely re-runnable across partial failures, addressing the idempotency concern raised in earlier review rounds.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no runtime code is modified. The design is well-reasoned and previous review concerns have been thoroughly addressed.

All prior blocking concerns — season.json Apache exposure, migration idempotency across partial failures, jq missing from setup-base, alphabetical vs chronological sorting of seasons.json — are addressed in this revision. The remaining open points are documentation gaps the author explicitly acknowledges as pre-implementation decisions, not defects in the described design. The change does not touch any executable code.

No files require special attention beyond the two documentation gaps noted in inline comments.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/architecture/static-serving-and-deployment.md | Extends the static-serving RFC with server-wide accounts (shared SQLite), per-season visibility/access via season.json, updated infra-script flows, and a migration script. Previous review concerns (jq dependency, Apache season.json exposure, migration idempotency) are all addressed in this revision; two minor documentation gaps remain around fragment-write trigger semantics and the signup CTA fallback. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant S1 as Season-A backend
    participant S2 as Season-B backend
    participant DB as accounts.db (SQLite)
    participant LP as Landing (static)

    Note over U,LP: Signup (Season-A)
    U->>S1: POST /app/sign-up
    S1->>DB: INSERT INTO accounts (username, pwhash)
    DB-->>S1: account_id
    S1->>S1: Write pickle User(account_id)
    S1-->>U: session cookie (season-A origin)

    Note over U,LP: First login to Season-B
    U->>S2: POST /app/login
    S2->>DB: "SELECT pwhash WHERE username=?"
    DB-->>S2: account_id, pwhash
    S2->>S2: Read /etc/energetica/season-b/season.json (access policy)
    S2->>S2: "Auto-provision pickle User(account_id, role=player)"
    S2-->>U: session cookie (season-B origin)

    Note over S1,LP: Fragment publication (on start / reload)
    S1->>LP: write seasons/season-a.json (sanitised, no allowlist)
    S1->>LP: jq aggregate → seasons.json.tmp → rename seasons.json
    S2->>LP: write seasons/season-b.json
    S2->>LP: jq aggregate → seasons.json.tmp → rename seasons.json
    LP-->>U: "GET /seasons.json (Cache-Control: max-age=60)"
```

<sub>Reviews (5): Last reviewed commit: ["docs: fix contradictory deploy-season.sh..."](https://github.com/felixvonsamson/energetica/commit/7026f28ece28a9d29f1c2dd5b85d2928cc51e45d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33356610)</sub>

<!-- /greptile_comment -->