### PR TITLE
content: update Nicolas Stocker quote and add link to his ZHAW profile

### DIFF
--- a/frontend/src/routes/for-educators.tsx
+++ b/frontend/src/routes/for-educators.tsx
@@ -222,20 +222,35 @@ function RouteComponent() {
                     </TypographyH2>
                     <div className="rounded-4xl p-8 flex flex-col gap-4 bg-card shadow-md">
                         <blockquote className="text-xl italic text-foreground leading-relaxed">
-                            "Energetica was a valuable addition to our 'Energy
-                            and Climate' module at ZHAW. Students who are
-                            usually passive became genuinely engaged. They were
-                            debating market strategies and investment trade-offs
-                            with each other without being prompted. What struck
-                            me most was how naturally the game illustrated
-                            concepts like price formation and the challenges
-                            linked to renewable intermittency that are otherwise
-                            hard to convey in a lecture. I would recommend it to
-                            any educator working on energy, climate, or
-                            economics topics."
+                            "Energetica has been a valuable addition to our 
+                            'Energy and Climate' module at ZHAW and was very 
+                            well received by our students. The game complements 
+                            the lectures effectively, integrating numerous 
+                            theoretical concepts and revealing the interactions 
+                            between elements previously considered in isolation, 
+                            such as price formation and the challenge of 
+                            balancing supply and demand in a power system. 
+                            Students experience first-hand that energy systems 
+                            and markets are more than the sum of their parts: 
+                            while the individual components can be conveyed 
+                            through theory, the resulting emergent behaviour 
+                            and complexity cannot. We frequently observed 
+                            students engaging with the game and discussing it 
+                            well beyond the scope of the lectures. I would 
+                            recommend Energetica to any educator working on 
+                            energy, climate, or economics topics."
                         </blockquote>
                         <p className="text-muted-foreground font-semibold">
-                            — Nicolas Stocker, Lecturer, ZHAW
+                            —{" "}
+                            <a
+                                href="https://www.zhaw.ch/en/about-us/person/stkk"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline hover:text-foreground transition-colors"
+                            >
+                                Nicolas Stocker
+                            </a>
+                            , Lecturer, ZHAW
                         </p>
                     </div>
                 </section>


### PR DESCRIPTION
## Summary
- Updated the Nicolas Stocker testimonial on the for-educators page with the revised quote
- Added a link to his ZHAW profile page on his name in the attribution line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Nicolas Stocker testimonial on the for-educators page with a revised quote and adds a hyperlink on his name pointing to his ZHAW staff profile.

- The blockquote text is replaced with a new, longer version of the quote covering similar themes (price formation, supply/demand balance, emergent complexity).
- His name in the attribution line is wrapped in an `<a>` tag linking to `https://www.zhaw.ch/en/about-us/person/stkk`, using `target=\"_blank\"` with `rel=\"noopener noreferrer\"` which is the correct practice for external links.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a content update with no logic changes.

The change replaces a static quote string and wraps a name in an external link. The link includes rel="noopener noreferrer", which is correct. Nothing here touches application logic, state, or data flow.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/for-educators.tsx | Updated Nicolas Stocker's testimonial quote and wrapped his name in an external link to his ZHAW profile with correct rel="noopener noreferrer" attribute. |

</details>

<sub>Reviews (1): Last reviewed commit: ["content: update Nicolas Stocker quote an..."](https://github.com/felixvonsamson/energetica/commit/16afe8537a6f37a279a3a2c74ef608856159f0b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33502791)</sub>

<!-- /greptile_comment -->