### PR TITLE
feat: Market Flows Sankey on electricity-markets overview

### DIFF
--- a/frontend/src/components/charts/market-flow-sankey.tsx
+++ b/frontend/src/components/charts/market-flow-sankey.tsx
@@ -1,0 +1,403 @@
+/**
+ * Sankey diagram of electricity market flows at a single tick.
+ *
+ * Visualizes sellers → Market → buyers with link widths proportional to cleared
+ * MW. Sources and sinks are grouped either by player or by facility type,
+ * controlled by `colorMode`. The center node is labeled with the clearing
+ * volume and price.
+ *
+ * Reuses the breakdown chart endpoints (market-exports / market-imports /
+ * market-generation / market-consumption) which already return per-tick
+ * pre-aggregated values, so no client-side merit-order walking is needed.
+ */
+
+import { SankeyChart } from "echarts/charts";
+import type { SankeySeriesOption } from "echarts/charts";
+import { TooltipComponent } from "echarts/components";
+import type { TooltipComponentOption } from "echarts/components";
+import type { ComposeOption } from "echarts/core";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { memo, useEffect, useMemo, useRef } from "react";
+
+import type { ColorMode } from "@/components/charts/supply-demand-chart";
+import { useAssetColorGetter } from "@/hooks/use-asset-color-getter";
+import { useChartData } from "@/hooks/use-charts";
+import { usePlayerMap } from "@/hooks/use-players";
+import { getAssetLongName } from "@/lib/assets/asset-names";
+import {
+    getHashBasedChartColor,
+    resolveColor,
+    resolveCSSVar,
+} from "@/lib/charts/color-utils";
+import { formatMoney, formatPower } from "@/lib/format-utils";
+
+echarts.use([SankeyChart, TooltipComponent, CanvasRenderer]);
+
+type ECOption = ComposeOption<SankeySeriesOption | TooltipComponentOption>;
+
+export interface MarketFlowSankeyProps {
+    marketId: number;
+    selectedTick: number;
+    colorMode: ColorMode;
+    height?: number;
+}
+
+// Slider window in supply-demand-chart.tsx is the same 360-tick window we
+// pull breakdown data over here.
+const SLIDER_RANGE = 360;
+// Suppress labels for nodes contributing less than this share of cleared volume.
+const LABEL_MIN_SHARE = 0.02;
+const MARKET_NODE_ID = "__market__";
+
+interface SideNode {
+    id: string;
+    displayName: string;
+    value: number;
+    color: string;
+}
+
+function MarketFlowSankeyInner({
+    marketId,
+    selectedTick,
+    colorMode,
+    height = 500,
+}: MarketFlowSankeyProps) {
+    const getColor = useAssetColorGetter();
+    const playerMap = usePlayerMap();
+
+    const supplyChartType =
+        colorMode === "player" ? "market-exports" : "market-generation";
+    const demandChartType =
+        colorMode === "player" ? "market-imports" : "market-consumption";
+
+    const {
+        chartData: supplyData,
+        isLoading: isLoadingSupply,
+        isError: isErrorSupply,
+    } = useChartData({
+        config: { chartType: supplyChartType, resolution: 1, marketId },
+        maxDatapoints: SLIDER_RANGE,
+    });
+    const {
+        chartData: demandData,
+        isLoading: isLoadingDemand,
+        isError: isErrorDemand,
+    } = useChartData({
+        config: { chartType: demandChartType, resolution: 1, marketId },
+        maxDatapoints: SLIDER_RANGE,
+    });
+    const { chartData: clearingData } = useChartData({
+        config: { chartType: "market-clearing", resolution: 1, marketId },
+        maxDatapoints: SLIDER_RANGE,
+    });
+
+    const isLoading = isLoadingSupply || isLoadingDemand;
+    const isError = isErrorSupply || isErrorDemand;
+
+    const chartRef = useRef<HTMLDivElement>(null);
+    const instanceRef = useRef<echarts.ECharts | null>(null);
+
+    const { sourceNodes, sinkNodes, marketQuantity, marketPrice, hasData } =
+        useMemo(() => {
+            const supplyPoint = supplyData.find(
+                (dp) => dp.tick === selectedTick,
+            );
+            const demandPoint = demandData.find(
+                (dp) => dp.tick === selectedTick,
+            );
+            const clearingPoint = clearingData.find(
+                (dp) => dp.tick === selectedTick,
+            );
+
+            const marketQuantity = clearingPoint?.quantity ?? 0;
+            const marketPrice = clearingPoint?.price ?? 0;
+
+            if (!supplyPoint || !demandPoint) {
+                return {
+                    sourceNodes: [] as SideNode[],
+                    sinkNodes: [] as SideNode[],
+                    marketQuantity,
+                    marketPrice,
+                    hasData: false,
+                };
+            }
+
+            const labelName = (key: string): string => {
+                if (colorMode === "player") {
+                    return (
+                        playerMap?.[parseInt(key)]?.username ?? `Player ${key}`
+                    );
+                }
+                return getAssetLongName(key);
+            };
+            const nodeColor = (key: string): string => {
+                if (colorMode === "player") {
+                    return resolveColor(getHashBasedChartColor(key));
+                }
+                return resolveColor(getColor(key));
+            };
+
+            const toSide = (
+                point: Record<string, unknown>,
+                sideTag: "src" | "sink",
+            ): SideNode[] =>
+                Object.entries(point)
+                    .filter(
+                        ([k, v]) =>
+                            k !== "tick" && typeof v === "number" && v > 0,
+                    )
+                    .map(([key, v]) => ({
+                        id: `${sideTag}:${key}`,
+                        displayName: labelName(key),
+                        value: v as number,
+                        color: nodeColor(key),
+                    }))
+                    .sort((a, b) => b.value - a.value);
+
+            const sourceNodes = toSide(supplyPoint, "src");
+            const sinkNodes = toSide(demandPoint, "sink");
+
+            return {
+                sourceNodes,
+                sinkNodes,
+                marketQuantity,
+                marketPrice,
+                hasData: sourceNodes.length > 0 || sinkNodes.length > 0,
+            };
+        }, [
+            supplyData,
+            demandData,
+            clearingData,
+            selectedTick,
+            colorMode,
+            playerMap,
+            getColor,
+        ]);
+
+    const totalCleared = useMemo(() => {
+        if (marketQuantity > 0) return marketQuantity;
+        return Math.max(
+            sourceNodes.reduce((s, n) => s + n.value, 0),
+            sinkNodes.reduce((s, n) => s + n.value, 0),
+        );
+    }, [marketQuantity, sourceNodes, sinkNodes]);
+
+    const displayNames = useMemo(() => {
+        const m = new Map<string, string>();
+        for (const n of sourceNodes) m.set(n.id, n.displayName);
+        for (const n of sinkNodes) m.set(n.id, n.displayName);
+        m.set(
+            MARKET_NODE_ID,
+            `Market — ${formatPower(marketQuantity)} @ ${formatMoney(marketPrice)}/MWh`,
+        );
+        return m;
+    }, [sourceNodes, sinkNodes, marketQuantity, marketPrice]);
+
+    const option = useMemo<ECOption>(() => {
+        const foreground = resolveCSSVar("--foreground");
+        const muted = resolveCSSVar("--muted-foreground");
+        const marketLabel = displayNames.get(MARKET_NODE_ID) ?? "Market";
+
+        const labelFormatterFor = (displayName: string) => () => displayName;
+
+        const data: SankeySeriesOption["data"] = [
+            ...sourceNodes.map((n) => ({
+                name: n.id,
+                value: n.value,
+                itemStyle: { color: n.color },
+                label: {
+                    show:
+                        totalCleared > 0 &&
+                        n.value / totalCleared >= LABEL_MIN_SHARE,
+                    formatter: labelFormatterFor(n.displayName),
+                    color: foreground,
+                    position: "right" as const,
+                },
+            })),
+            {
+                name: MARKET_NODE_ID,
+                itemStyle: { color: muted },
+                label: {
+                    show: true,
+                    formatter: labelFormatterFor(marketLabel),
+                    color: foreground,
+                    fontWeight: "bold",
+                    // Place the Market node's label above so it doesn't crowd
+                    // the inflow/outflow links, which are densest right at the
+                    // node's vertical centre.
+                    position: "top" as const,
+                },
+            },
+            ...sinkNodes.map((n) => ({
+                name: n.id,
+                value: n.value,
+                itemStyle: { color: n.color },
+                label: {
+                    show:
+                        totalCleared > 0 &&
+                        n.value / totalCleared >= LABEL_MIN_SHARE,
+                    formatter: labelFormatterFor(n.displayName),
+                    color: foreground,
+                    // Sink nodes sit on the chart's right edge; default label
+                    // position would push text off-canvas, so place labels to
+                    // the left of the node (i.e. inside the chart).
+                    position: "left" as const,
+                },
+            })),
+        ];
+
+        const links: SankeySeriesOption["links"] = [
+            ...sourceNodes.map((n) => ({
+                source: n.id,
+                target: MARKET_NODE_ID,
+                value: n.value,
+            })),
+            ...sinkNodes.map((n) => ({
+                source: MARKET_NODE_ID,
+                target: n.id,
+                value: n.value,
+            })),
+        ];
+
+        return {
+            animation: false,
+            tooltip: {
+                trigger: "item",
+                triggerOn: "mousemove",
+                formatter: (raw: unknown) => {
+                    const params = raw as {
+                        dataType?: string;
+                        data?: unknown;
+                        value?: number;
+                        name?: string;
+                    };
+                    if (params.dataType === "edge") {
+                        const e = params.data as {
+                            source: string;
+                            target: string;
+                            value: number;
+                        };
+                        const from = displayNames.get(e.source) ?? e.source;
+                        const to = displayNames.get(e.target) ?? e.target;
+                        const share =
+                            totalCleared > 0
+                                ? (e.value / totalCleared) * 100
+                                : 0;
+                        return `${from} → ${to}<br/>${formatPower(e.value)} (${share.toFixed(1)}%)`;
+                    }
+                    if (params.dataType === "node") {
+                        const n = params.data as { name: string };
+                        const display = displayNames.get(n.name) ?? n.name;
+                        if (n.name === MARKET_NODE_ID) {
+                            return display;
+                        }
+                        const value =
+                            typeof params.value === "number" ? params.value : 0;
+                        const share =
+                            totalCleared > 0 ? (value / totalCleared) * 100 : 0;
+                        return `${display}<br/>${formatPower(value)} (${share.toFixed(1)}%)`;
+                    }
+                    return "";
+                },
+            },
+            series: [
+                {
+                    type: "sankey",
+                    nodeAlign: "justify",
+                    // Disable node dragging: it's a neat default but adds no
+                    // value for a snapshot view (state resets on slider change)
+                    // and is awkward on touch devices.
+                    draggable: false,
+                    data,
+                    links,
+                    emphasis: { focus: "adjacency" },
+                    // Soften ECharts' default fade-on-hover: the default blur
+                    // opacity (~0.1) makes non-adjacent items nearly invisible,
+                    // which reads as flicker. Keep non-adjacent items visibly
+                    // de-emphasized but legible.
+                    blur: {
+                        itemStyle: { opacity: 0.6 },
+                        lineStyle: { opacity: 0.3 },
+                        label: { color: foreground },
+                    },
+                    lineStyle: {
+                        color: "gradient",
+                        curveness: 0.5,
+                        opacity: 0.5,
+                    },
+                    label: { color: foreground },
+                    nodeWidth: 12,
+                    nodeGap: 8,
+                    left: 10,
+                    right: 10,
+                    top: 20,
+                    bottom: 20,
+                },
+            ],
+        };
+    }, [sourceNodes, sinkNodes, totalCleared, displayNames]);
+
+    useEffect(() => {
+        if (!chartRef.current) return;
+        const chart = echarts.init(chartRef.current, undefined, {
+            renderer: "canvas",
+        });
+        instanceRef.current = chart;
+        return () => {
+            chart.dispose();
+            instanceRef.current = null;
+        };
+    }, []);
+
+    useEffect(() => {
+        instanceRef.current?.setOption(option, { notMerge: true });
+    }, [option]);
+
+    useEffect(() => {
+        const el = chartRef.current;
+        if (!el) return;
+        const observer = new ResizeObserver(() =>
+            instanceRef.current?.resize(),
+        );
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
+    const showEmpty = !isLoading && !isError && !hasData;
+
+    return (
+        <div
+            className="relative min-w-0 overflow-hidden"
+            style={{ height: `${height}px` }}
+        >
+            <div ref={chartRef} className="w-full h-full" />
+
+            {isLoading && (
+                <div className="absolute inset-0 flex items-center justify-center bg-background/80">
+                    <span className="text-muted-foreground">
+                        Loading market data…
+                    </span>
+                </div>
+            )}
+
+            {isError && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="text-destructive">
+                        Failed to load market data
+                    </span>
+                </div>
+            )}
+
+            {showEmpty && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="text-muted-foreground">
+                        No flows for this tick
+                    </span>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export const MarketFlowSankey = memo(MarketFlowSankeyInner);

--- a/frontend/src/components/charts/supply-demand-chart.tsx
+++ b/frontend/src/components/charts/supply-demand-chart.tsx
@@ -38,12 +38,8 @@ import {
     SegmentedPicker,
     SegmentedPickerOption,
 } from "@/components/ui/segmented-picker";
-import { Slider } from "@/components/ui/slider";
 import { useAssetColorGetter } from "@/hooks/use-asset-color-getter";
 import { useMarketData } from "@/hooks/use-charts";
-import { useElectricityMarket } from "@/hooks/use-electricity-markets";
-import { useGameEngine } from "@/hooks/use-game";
-import { useGameTick } from "@/hooks/use-game-tick";
 import { usePlayerMap } from "@/hooks/use-players";
 import { getAssetLongName } from "@/lib/assets/asset-names";
 import {
@@ -51,11 +47,8 @@ import {
     resolveColor,
     resolveCSSVar,
 } from "@/lib/charts/color-utils";
-import {
-    createSteppedCurve,
-    interpolateAtX,
-} from "@/lib/charts/ui-utils";
-import { formatDuration, formatMoney, formatPower } from "@/lib/format-utils";
+import { createSteppedCurve, interpolateAtX } from "@/lib/charts/ui-utils";
+import { formatMoney, formatPower } from "@/lib/format-utils";
 
 echarts.use([
     ELineChart,
@@ -145,6 +138,8 @@ function BlockTooltip({
 
 export interface MeritOrderChartProps {
     marketId: number;
+    selectedTick: number;
+    colorMode: ColorMode;
     height?: number;
 }
 
@@ -169,27 +164,14 @@ const PRICE_CAP = 2000;
 
 function MeritOrderChartInner({
     marketId,
+    selectedTick,
+    colorMode,
     height = 500,
 }: MeritOrderChartProps) {
-    const { currentTick } = useGameTick();
-    const { data: gameEngine } = useGameEngine();
     const getColor = useAssetColorGetter();
     const playerMap = usePlayerMap();
-    const marketDetails = useElectricityMarket(marketId);
-
-    // Tick selection (last 360 ticks).
-    // ticksBack=0 always shows the latest tick; increases as the slider moves left.
-    const [ticksBack, setTicksBack] = useState(0);
-    const maxTick = currentTick !== undefined ? currentTick - 1 : 0;
-    const minTick = useMemo(() => {
-        if (!currentTick) return 0;
-        const marketStart = marketDetails?.created_tick ?? 0;
-        return Math.max(marketStart, currentTick - 360);
-    }, [currentTick, marketDetails]);
-    const selectedTick = Math.max(minTick, maxTick - ticksBack);
 
     const [activeMode, setActiveMode] = useState<ActiveMode>("supply");
-    const [colorMode, setColorMode] = useState<ColorMode>("player");
 
     const {
         data: marketData,
@@ -342,10 +324,8 @@ function MeritOrderChartInner({
         // are dropped. The liveRef still holds the original blocks for the
         // tooltip/highlight so their labels remain correct.
         const span = quantityDomain[1] - quantityDomain[0];
-        const visXMin =
-            quantityDomain[0] + span * (zoomRange.start / 100);
-        const visXMax =
-            quantityDomain[0] + span * (zoomRange.end / 100);
+        const visXMin = quantityDomain[0] + span * (zoomRange.start / 100);
+        const visXMax = quantityDomain[0] + span * (zoomRange.end / 100);
         const visibleBlocks = activeBlocks
             .filter((b) => b.x2 > visXMin && b.x1 < visXMax)
             .map((b) => ({
@@ -443,8 +423,7 @@ function MeritOrderChartInner({
                             x: clippedLeft,
                             y: topLeft[1] ?? 0,
                             width: clippedRight - clippedLeft,
-                            height:
-                                (bottomRight[1] ?? 0) - (topLeft[1] ?? 0),
+                            height: (bottomRight[1] ?? 0) - (topLeft[1] ?? 0),
                         },
                         style: api.style(),
                     };
@@ -473,7 +452,10 @@ function MeritOrderChartInner({
                             name: `Clearing: ${formatPower(marketData?.market_quantity ?? 0)}`,
                         },
                         {
-                            yAxis: Math.min(marketData?.market_price ?? 0, PRICE_CAP),
+                            yAxis: Math.min(
+                                marketData?.market_price ?? 0,
+                                PRICE_CAP,
+                            ),
                             name: `Price: ${formatMoney(marketData?.market_price ?? 0)}/MWh`,
                             label: { position: "insideStartTop" },
                         },
@@ -494,7 +476,10 @@ function MeritOrderChartInner({
                             name: "clearing",
                             coord: [
                                 marketData?.market_quantity ?? 0,
-                                Math.min(marketData?.market_price ?? 0, PRICE_CAP),
+                                Math.min(
+                                    marketData?.market_price ?? 0,
+                                    PRICE_CAP,
+                                ),
                             ],
                             symbol: "circle",
                             symbolSize: 10,
@@ -741,18 +726,7 @@ function MeritOrderChartInner({
         });
     }, []);
 
-    // ── Slider label ──────────────────────────────────────────────────────────
-
-    const sliderLabel = useMemo(() => {
-        if (!currentTick || !gameEngine) return `Tick ${selectedTick}`;
-        const ticksAgo = currentTick - selectedTick;
-        if (ticksAgo <= 0) return "Current";
-        return `${formatDuration(ticksAgo, gameEngine, true)} ago`;
-    }, [selectedTick, currentTick, gameEngine]);
-
     // ── Render ────────────────────────────────────────────────────────────────
-
-    if (!currentTick) return null;
 
     const tooltipBlock = tooltipState?.block;
     const tooltipPlayerName = tooltipBlock
@@ -785,45 +759,13 @@ function MeritOrderChartInner({
                         </SegmentedPickerOption>
                     </SegmentedPicker>
                 </div>
-                <div className="flex items-center gap-3">
-                    <Label className="text-sm font-medium shrink-0">
-                        Color by
-                    </Label>
-                    <SegmentedPicker
-                        value={colorMode}
-                        onValueChange={(v) => setColorMode(v as ColorMode)}
-                    >
-                        <SegmentedPickerOption value="player">
-                            Player
-                        </SegmentedPickerOption>
-                        <SegmentedPickerOption value="type">
-                            Technology
-                        </SegmentedPickerOption>
-                    </SegmentedPicker>
-                </div>
-            </div>
-
-            {/* Tick slider */}
-            <div className="flex items-center gap-4">
-                <Label className="text-sm font-medium shrink-0 w-28 text-right">
-                    {sliderLabel}
-                </Label>
-                <div className="flex-1">
-                    <Slider
-                        min={minTick}
-                        max={maxTick}
-                        step={1}
-                        value={[selectedTick]}
-                        onValueChange={(values) =>
-                            setTicksBack(maxTick - (values[0] ?? maxTick))
-                        }
-                        disabled={minTick >= maxTick}
-                    />
-                </div>
             </div>
 
             {/* Chart */}
-            <div className="relative min-w-0 overflow-hidden" style={{ height: `${height}px` }}>
+            <div
+                className="relative min-w-0 overflow-hidden"
+                style={{ height: `${height}px` }}
+            >
                 <div ref={chartRef} className="w-full h-full" />
 
                 {/* Full-height highlight band for the hovered block column */}

--- a/frontend/src/routes/app/overviews/electricity-markets.tsx
+++ b/frontend/src/routes/app/overviews/electricity-markets.tsx
@@ -11,9 +11,10 @@ import {
     Users,
     Layers,
     BarChart2,
+    GitBranch,
     UserPlus,
 } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import {
     BreakdownMode,
@@ -21,8 +22,12 @@ import {
     MarketClearingTable,
     MarketClearingVolumeChart,
 } from "@/components/charts/market-clearing-volume-chart";
+import { MarketFlowSankey } from "@/components/charts/market-flow-sankey";
 import { MarketPriceChart } from "@/components/charts/market-price-chart";
-import { MeritOrderChart } from "@/components/charts/supply-demand-chart";
+import {
+    ColorMode,
+    MeritOrderChart,
+} from "@/components/charts/supply-demand-chart";
 import { GameLayout } from "@/components/layout/game-layout";
 import {
     Button,
@@ -40,6 +45,7 @@ import {
     SegmentedPicker,
     SegmentedPickerOption,
 } from "@/components/ui/segmented-picker";
+import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { useResolution } from "@/contexts/resolution-context";
 import { useLatestChartDataSlice } from "@/hooks/use-charts";
@@ -49,11 +55,11 @@ import {
     useElectricityMarketForPlayer,
     useElectricityMarket,
 } from "@/hooks/use-electricity-markets";
+import { useGameEngine } from "@/hooks/use-game";
 import { useGameTick } from "@/hooks/use-game-tick";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useToggleSet } from "@/hooks/use-toggle-set";
-import { formatPower } from "@/lib/format-utils";
-
+import { formatDuration, formatPower } from "@/lib/format-utils";
 
 interface MarketsSearchParams {
     marketId?: number;
@@ -69,7 +75,10 @@ export const Route = createFileRoute("/app/overviews/electricity-markets")({
             isUnlocked: (cap) =>
                 cap.has_network
                     ? { unlocked: true }
-                    : { unlocked: false, reason: "Unlock the Network achievement to access" },
+                    : {
+                          unlocked: false,
+                          reason: "Unlock the Network achievement to access",
+                      },
         },
         infoDialog: {
             contents: <MarketsOverviewHelp />,
@@ -181,6 +190,42 @@ function MarketsOverviewContent() {
         undefined,
         "energetica:chart:markets:hiddenBreakdownItems",
     );
+
+    // Snapshot controls shared by Merit Order chart and Market Flows Sankey.
+    // ticksBack=0 always shows the latest tick; increases as the slider moves left.
+    const [ticksBack, setTicksBack] = useState(0);
+    const [snapshotColorMode, setSnapshotColorMode] =
+        useLocalStorage<ColorMode>(
+            "energetica:chart:markets:snapshotColorMode",
+            "player",
+        );
+
+    // Reset the snapshot slider whenever the user switches markets so we don't
+    // carry over a tick offset that's meaningless in the new market's range.
+    // Using the "store-previous-prop" render-time reset pattern per React docs:
+    // https://react.dev/reference/react/useState#storing-information-from-previous-renders
+    const [prevSelectedMarketId, setPrevSelectedMarketId] =
+        useState(selectedMarketId);
+    if (prevSelectedMarketId !== selectedMarketId) {
+        setPrevSelectedMarketId(selectedMarketId);
+        setTicksBack(0);
+    }
+
+    const snapshotMaxTick = currentTick !== undefined ? currentTick - 1 : 0;
+    const snapshotMinTick = useMemo(() => {
+        if (!currentTick) return 0;
+        const marketStart = marketDetails?.created_tick ?? 0;
+        return Math.max(marketStart, currentTick - 360);
+    }, [currentTick, marketDetails]);
+    const selectedTick = Math.max(snapshotMinTick, snapshotMaxTick - ticksBack);
+
+    const { data: gameEngine } = useGameEngine();
+    const sliderLabel = useMemo(() => {
+        if (!currentTick || !gameEngine) return `Tick ${selectedTick}`;
+        const ticksAgo = currentTick - selectedTick;
+        if (ticksAgo <= 0) return "Current";
+        return `${formatDuration(ticksAgo, gameEngine, true)} ago`;
+    }, [selectedTick, currentTick, gameEngine]);
 
     // Handle market selection change
     const handleMarketChange = (marketId: number | undefined) => {
@@ -435,14 +480,90 @@ function MarketsOverviewContent() {
                 )}
             </ChartCard>
 
-            {/* Merit Order & Market Clearing */}
-            <ChartCard
-                icon={BarChart2}
-                iconClassName="text-primary"
-                title="Merit Order & Market Clearing"
-            >
-                <MeritOrderChart key={selectedMarketId} marketId={selectedMarketId} />
-            </ChartCard>
+            {/*
+              * Snapshot section: controls + Merit Order + Sankey. Wrapped so
+              * the controls card's `sticky top-0` is scoped to this section —
+              * it pins as you scroll between the two snapshot charts, then
+              * releases once you scroll past the section.
+              */}
+            <div className="flex flex-col gap-6">
+                {/* Snapshot controls — shared by Merit Order chart and Market Flows Sankey */}
+                <PageCard className="sticky top-0 z-10">
+                    <CardContent>
+                        <div className="space-y-4">
+                            <div className="flex flex-wrap items-center gap-6">
+                                <div className="flex items-center gap-3">
+                                    <Label className="text-sm font-medium shrink-0">
+                                        Color by
+                                    </Label>
+                                    <SegmentedPicker
+                                        value={snapshotColorMode}
+                                        onValueChange={(v) =>
+                                            setSnapshotColorMode(v as ColorMode)
+                                        }
+                                    >
+                                        <SegmentedPickerOption value="player">
+                                            Player
+                                        </SegmentedPickerOption>
+                                        <SegmentedPickerOption value="type">
+                                            Technology
+                                        </SegmentedPickerOption>
+                                    </SegmentedPicker>
+                                </div>
+                            </div>
+                            <div className="flex items-center gap-4">
+                                <Label className="text-sm font-medium shrink-0 w-28 text-right">
+                                    {sliderLabel}
+                                </Label>
+                                <div className="flex-1">
+                                    <Slider
+                                        min={snapshotMinTick}
+                                        max={snapshotMaxTick}
+                                        step={1}
+                                        value={[selectedTick]}
+                                        onValueChange={(values) =>
+                                            setTicksBack(
+                                                snapshotMaxTick -
+                                                    (values[0] ??
+                                                        snapshotMaxTick),
+                                            )
+                                        }
+                                        disabled={
+                                            snapshotMinTick >= snapshotMaxTick
+                                        }
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </CardContent>
+                </PageCard>
+
+                {/* Merit Order & Market Clearing */}
+                <ChartCard
+                    icon={BarChart2}
+                    iconClassName="text-primary"
+                    title="Merit Order & Market Clearing"
+                >
+                    <MeritOrderChart
+                        marketId={selectedMarketId}
+                        selectedTick={selectedTick}
+                        colorMode={snapshotColorMode}
+                    />
+                </ChartCard>
+
+                {/* Market Flows (Sankey) */}
+                <ChartCard
+                    icon={GitBranch}
+                    iconClassName="text-primary"
+                    title="Market Flows"
+                >
+                    <MarketFlowSankey
+                        marketId={selectedMarketId}
+                        selectedTick={selectedTick}
+                        colorMode={snapshotColorMode}
+                    />
+                </ChartCard>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Adds a 3-column Sankey (sellers → Market → buyers) alongside the existing Merit Order chart on `/app/overviews/electricity-markets`. Center node is labeled with cleared volume and price. Sources and sinks group by player or facility type via a shared Color-by control.

Restructures the page to share snapshot state between the Merit Order chart and the new Sankey:
- Lifts the tick slider and Color-by picker into a **sticky** page-level *Snapshot controls* PageCard.
- Removes them from `MeritOrderChart` (now takes `selectedTick` and `colorMode` as props; `activeMode` stays local).
- Wraps the snapshot section in a flex container so sticky controls pin while scrolling between the two charts, then release once the section exits the viewport.

Reuses the existing breakdown chart-data endpoints (`market-exports` / `market-imports` / `market-generation` / `market-consumption`) which already return per-tick pre-aggregated values, so no client-side merit-order walking is needed and slider scrubbing is in-memory free (no refetch).

## Design choices (from grilling session)

- **ECharts `SankeyChart`** rather than Mermaid — integrates with existing color tokens (`useAssetColorGetter`, `getHashBasedChartColor`), dark mode, tooltips, and ResizeObserver patterns. Zero new deps.
- **3 columns with explicit center *Market* node** rather than 2-column all-to-all — we have two independent breakdowns, not seller→buyer pairings. The center node honestly represents pool clearing and provides a natural slot for the volume + price callout.
- **Label suppression** at `<2%` share rather than Top-N + Other bucketing (deferred uniformly across player-breakdown charts in #793).
- **`draggable: false`** — node drag adds no value for a snapshot view (state resets on slider scrub) and is awkward on touch.
- **Hover blur softened** — ECharts' default emphasis blur drops non-adjacent items to ~0.1 opacity (reads as flicker); overridden to 0.6 / 0.3 so non-adjacent items stay legible.
- **Sink labels positioned `left`**, market label positioned `top` — prevents right-side overflow and avoids crowding the link fanout.

## Status

Prototype / experiment. Worth keeping behind eyes-on review before relying on this in any educational flow.

## Test plan

- [ ] Open `/app/overviews/electricity-markets` while signed in as a player whose market has multiple participants
- [ ] Scrub the slider, verify Merit Order **and** Sankey both update to the same tick
- [ ] Toggle Color-by: Player ↔ Technology — both charts should re-color in lockstep
- [ ] Scroll between Merit Order and Sankey — controls card should stay pinned within the snapshot section, release once scrolled past
- [ ] Switch markets via the selector — slider should reset to "Current"
- [ ] Hover Sankey nodes / links — tooltip shows display name + MW + share; non-adjacent items dim but stay legible (no flicker)
- [ ] Right-side (sink) labels render inside the chart, not cut off
- [ ] Sankey nodes are not draggable
- [ ] Empty markets or pre-creation ticks render "No flows for this tick" rather than crashing

## Related

- #793 — Apply Top-N + Other bucketing uniformly to player-breakdown charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)