### PR TITLE
fix: cash flow overview table totals not scaled by resolution

### DIFF
--- a/frontend/src/components/charts/cash-flow-chart.tsx
+++ b/frontend/src/components/charts/cash-flow-chart.tsx
@@ -270,7 +270,7 @@ export function CashFlowOverviewTable({
             .filter((row) => row.totalRevenues > 0);
 
         return rows;
-    }, [chartData]);
+    }, [chartData, resolution]);
 
     // Sort facility rows
     const sortedRows = useMemo(() => {

--- a/frontend/src/components/charts/cash-flow-chart.tsx
+++ b/frontend/src/components/charts/cash-flow-chart.tsx
@@ -164,6 +164,8 @@ export function CashFlowChart({
 interface CashFlowOverviewTableProps {
     /** Chart data with time series for each facility type */
     chartData: Array<Record<string, number>>;
+    /** Number of ticks per data point (chart resolution) */
+    resolution: number;
     /** Type of revenue to display */
     revenueType: CashFlowType;
     /** Set of hidden facility types */
@@ -181,6 +183,7 @@ type SortDirection = "asc" | "desc";
 
 export function CashFlowOverviewTable({
     chartData,
+    resolution,
     revenueType,
     hiddenFacilities,
     onToggleFacility,
@@ -255,7 +258,7 @@ export function CashFlowOverviewTable({
             .map((facilityType) => {
                 // Sum all revenue values
                 const totalRevenues = chartData.reduce((sum, dataPoint) => {
-                    return sum + (dataPoint[facilityType] || 0);
+                    return sum + (dataPoint[facilityType] || 0) * resolution;
                 }, 0);
 
                 return {

--- a/frontend/src/routes/app/overviews/cash-flow.tsx
+++ b/frontend/src/routes/app/overviews/cash-flow.tsx
@@ -381,6 +381,7 @@ function RevenuesOverviewContent() {
 
                 <CashFlowOverviewTable
                     chartData={filteredChartData}
+                    resolution={selectedResolution.resolution}
                     revenueType={revenueType}
                     hiddenFacilities={hiddenFacilities}
                     onToggleFacility={toggleFacility}


### PR DESCRIPTION
Fixes #764

## Summary
- Chart data values are rates ($/tick); each data point aggregates `resolution` ticks
- `CashFlowOverviewTable` was summing raw per-tick values, ignoring the time scale
- Added `resolution` prop and multiply each data point's value by it before summing, matching the pattern already used in `PowerOverviewTable` for the "Generated" column

## Test plan
- [x] Open Cash Flow Overview, change the time resolution and verify the Revenues/Expenses totals in the table scale proportionally
- [x] Confirm values match expectations (e.g. at resolution 10× higher, totals should be 10× larger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `CashFlowOverviewTable` totals being under-reported at higher time resolutions by multiplying each data-point value by `resolution` before summing, matching the pattern already used in `PowerOverviewTable`. The `resolution` prop is threaded from the parent and correctly added to the `useMemo` dependency array.

- **`cash-flow-chart.tsx`**: Adds a `resolution: number` prop; the totals `useMemo` now computes `(dataPoint[facilityType] || 0) * resolution` and lists `resolution` in its deps.
- **`cash-flow.tsx`**: Passes `selectedResolution.resolution` to `CashFlowOverviewTable` — the only call-site change required.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, correctly scoped, and addresses the root cause.

The change multiplies per-tick values by resolution before summing, which is exactly what the analogous PowerOverviewTable does. The resolution prop is correctly plumbed from the parent and added to the useMemo dependency array, so stale-memo issues are avoided. No other code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/components/charts/cash-flow-chart.tsx | Adds `resolution` prop and multiplies each data point by it in the totals `useMemo`; dependency array correctly updated to include `resolution`. |
| frontend/src/routes/app/overviews/cash-flow.tsx | Passes `selectedResolution.resolution` down to `CashFlowOverviewTable` — the only change needed at the call site. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[selectedResolution.resolution] -->|prop| B[CashFlowOverviewTable]
    C[filteredChartData] -->|prop| B
    B --> D["useMemo: facilityRows"]
    D --> E["chartData.reduce: sum + (dataPoint[facilityType] || 0) * resolution"]
    E --> F[totalRevenues per facility]
    F --> G[Rendered table rows]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/components/charts/cash-flow-chart.tsx`, line 273 ([link](https://github.com/felixvonsamson/energetica/blob/7c224f1d5fc4776c2185903146d7df83293969e5/frontend/src/components/charts/cash-flow-chart.tsx#L273)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `resolution` is used inside this `useMemo` but is absent from the dependency array. If the user switches the time resolution without the `chartData` reference changing, the memoized totals will remain stale — exactly the bug this PR is trying to fix. Compare the analogous `PowerOverviewTable` which correctly lists `[chartData, resolution, ...]` in its deps.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix lint"](https://github.com/felixvonsamson/energetica/commit/9259bf9b68385119cb7bb2b82ea580031828a97a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33588429)</sub>

<!-- /greptile_comment -->