### PR TITLE
feat: improve electricity market UI and add cross-page navigation

### DIFF
--- a/frontend/src/components/electricity-markets/market-detail-dialog.tsx
+++ b/frontend/src/components/electricity-markets/market-detail-dialog.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Users, Check, BarChart2 } from "lucide-react";
+import { PlugZap, Check, BarChart2 } from "lucide-react";
 
 import { CardContent, Button, Money } from "@/components/ui";
 import {
@@ -95,7 +95,7 @@ function MarketContent({
                             isCurrentMarket ? "bg-brand/20" : "bg-muted/50",
                         )}
                     >
-                        <Users
+                        <PlugZap
                             className={cn(
                                 "w-16 h-16",
                                 isCurrentMarket
@@ -129,7 +129,7 @@ function MarketContent({
                             <div className="text-sm text-muted-foreground mb-1">
                                 Members
                             </div>
-                            <div className="text-xl font-semibold">
+                            <div className="text-xl font-semibold font-mono">
                                 {market.member_ids.length}
                             </div>
                         </div>
@@ -152,8 +152,8 @@ function MarketContent({
                                 Volume
                             </div>
                             <div className="text-xl font-semibold font-mono">
-                                {marketData.volume !== undefined ? (
-                                    formatPower(marketData.volume)
+                                {marketData.quantity !== undefined ? (
+                                    formatPower(marketData.quantity)
                                 ) : (
                                     <span className="text-muted-foreground">
                                         N/A
@@ -190,7 +190,7 @@ function MarketContent({
                         {market.member_ids.map((memberId) => (
                             <div
                                 key={memberId}
-                                className="px-3 py-2 bg-muted/30 rounded text-sm"
+                                className="px-3 py-2 bg-card rounded text-sm"
                             >
                                 {playerMap[memberId] ? (
                                     <PlayerName player={playerMap[memberId]} />

--- a/frontend/src/components/electricity-markets/market-item.tsx
+++ b/frontend/src/components/electricity-markets/market-item.tsx
@@ -1,4 +1,4 @@
-import { Users, Check } from "lucide-react";
+import { PlugZap, Check } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { useMyMarket } from "@/hooks/use-electricity-markets";
@@ -24,7 +24,7 @@ export function MarketItem({ market, onClick }: MarketItemProps) {
                 "cursor-pointer transition-all duration-200",
                 "hover:border-brand-green hover:scale-105",
                 "flex flex-col h-full relative",
-                isCurrentMarket && "border-brand-green bg-brand/5",
+                isCurrentMarket && "border-brand-green bg-muted",
             )}
             onClick={onClick}
         >
@@ -43,7 +43,7 @@ export function MarketItem({ market, onClick }: MarketItemProps) {
                         isCurrentMarket ? "bg-brand/20" : "bg-muted/50",
                     )}
                 >
-                    <Users
+                    <PlugZap
                         className={cn(
                             "w-10 h-10",
                             isCurrentMarket
@@ -58,7 +58,7 @@ export function MarketItem({ market, onClick }: MarketItemProps) {
             <CardHeader className="text-center">
                 <CardTitle className="text-base">{market.name}</CardTitle>
                 <div className="flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
-                    <Users className="w-4 h-4" />
+                    <PlugZap className="w-4 h-4" />
                     <span>
                         {market.member_ids.length}{" "}
                         {market.member_ids.length === 1 ? "member" : "members"}

--- a/frontend/src/lib/nav-config.ts
+++ b/frontend/src/lib/nav-config.ts
@@ -121,7 +121,7 @@ export const navConfig: NavItemConfig[] = [
     {
         type: "dropdown",
         label: "Community",
-        icon: lucideReact.Globe,
+        icon: lucideReact.Users,
         children: [
             {
                 type: "link",

--- a/frontend/src/routes/app/community/electricity-markets.tsx
+++ b/frontend/src/routes/app/community/electricity-markets.tsx
@@ -3,7 +3,7 @@ import {
     useNavigate,
     useSearch,
 } from "@tanstack/react-router";
-import { Plus, Users } from "lucide-react";
+import { Plus, PlugZap } from "lucide-react";
 import { useCallback } from "react";
 
 import { CreateMarketDialog } from "@/components/electricity-markets/create-market-dialog";
@@ -70,7 +70,7 @@ function ElectricityMarketsHelp() {
             </p>
             <ul className="list-none space-y-1 ml-4">
                 <li className="flex items-center gap-2">
-                    <Users className="w-4 h-4 shrink-0" />
+                    <PlugZap className="w-4 h-4 shrink-0" />
                     <span>
                         <b>Join a Market:</b> Click "Join" to participate in an
                         existing market and trade with its members

--- a/frontend/src/routes/app/overviews/electricity-markets.tsx
+++ b/frontend/src/routes/app/overviews/electricity-markets.tsx
@@ -7,7 +7,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import {
     TrendingUp,
     Activity,
-    Network as NetworkIcon,
+    PlugZap,
     Users,
     Layers,
     BarChart2,
@@ -103,7 +103,7 @@ function MarketsOverviewHelp() {
                     </span>
                 </li>
                 <li className="flex items-center gap-2">
-                    <NetworkIcon className="w-4 h-4 shrink-0" />
+                    <PlugZap className="w-4 h-4 shrink-0" />
                     <span>
                         Use the market selector to view different electricity
                         markets
@@ -265,8 +265,8 @@ function MarketsOverviewContent() {
             <PageCard>
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
-                        <NetworkIcon className="w-6 h-6 text-primary" />
-                        {selectedMarket?.name ?? "Market"} - Current Values
+                        <PlugZap className="w-6 h-6 text-primary" />
+                        {selectedMarket?.name ?? "Market"} - Overview
                     </CardTitle>
                     {playerMarket !== undefined &&
                         playerMarket?.id !== selectedMarketId && (
@@ -286,7 +286,7 @@ function MarketsOverviewContent() {
 
                 <CardContent>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div className="bg-muted text-muted-foreground p-4 rounded-lg border border-border">
+                        <div className="bg-muted text-muted-foreground p-4 rounded-lg border border-border text-center">
                             <div className="text-sm mb-1">Market Price</div>
                             <div className="text-2xl font-bold">
                                 {isLatestLoading ? (
@@ -299,7 +299,7 @@ function MarketsOverviewContent() {
                                 )}
                             </div>
                         </div>
-                        <div className="bg-muted text-muted-foreground p-4 rounded-lg border border-border">
+                        <div className="bg-muted text-muted-foreground p-4 rounded-lg border border-border text-center">
                             <div className="text-sm mb-1">Clearing Volume</div>
                             <div className="text-2xl font-bold">
                                 {isLatestLoading ? (
@@ -311,6 +311,17 @@ function MarketsOverviewContent() {
                                 )}
                             </div>
                         </div>
+                    </div>
+                    <div className="flex justify-center mt-4">
+                        <Link
+                            to="/app/community/electricity-markets"
+                            search={{ market: selectedMarketId }}
+                        >
+                            <Button variant="outline">
+                                <PlugZap className="w-4 h-4" />
+                                Electricity Market Page
+                            </Button>
+                        </Link>
                     </div>
                 </CardContent>
             </PageCard>

--- a/frontend/src/routes/app/overviews/electricity-markets.tsx
+++ b/frontend/src/routes/app/overviews/electricity-markets.tsx
@@ -12,6 +12,7 @@ import {
     Layers,
     BarChart2,
     UserPlus,
+    LogOut,
 } from "lucide-react";
 import { useMemo } from "react";
 
@@ -268,20 +269,26 @@ function MarketsOverviewContent() {
                         <PlugZap className="w-6 h-6 text-primary" />
                         {selectedMarket?.name ?? "Market"} - Overview
                     </CardTitle>
-                    {playerMarket !== undefined &&
-                        playerMarket?.id !== selectedMarketId && (
-                            <CardAction>
-                                <Link
-                                    to="/app/community/electricity-markets"
-                                    search={{ market: selectedMarketId }}
-                                >
-                                    <Button variant="outline" size="sm">
+                    <CardAction>
+                        <Link
+                            to="/app/community/electricity-markets"
+                            search={{ market: selectedMarketId }}
+                        >
+                            <Button variant="outline" size="sm">
+                                {playerMarket?.id === selectedMarketId ? (
+                                    <>
+                                        <LogOut className="w-4 h-4" />
+                                        Leave Market
+                                    </>
+                                ) : (
+                                    <>
                                         <UserPlus className="w-4 h-4" />
                                         Join Market
-                                    </Button>
-                                </Link>
-                            </CardAction>
-                        )}
+                                    </>
+                                )}
+                            </Button>
+                        </Link>
+                    </CardAction>
                 </CardHeader>
 
                 <CardContent>
@@ -312,17 +319,7 @@ function MarketsOverviewContent() {
                             </div>
                         </div>
                     </div>
-                    <div className="flex justify-center mt-4">
-                        <Link
-                            to="/app/community/electricity-markets"
-                            search={{ market: selectedMarketId }}
-                        >
-                            <Button variant="outline">
-                                <PlugZap className="w-4 h-4" />
-                                Electricity Market Page
-                            </Button>
-                        </Link>
-                    </div>
+
                 </CardContent>
             </PageCard>
 


### PR DESCRIPTION
Closes #585

## Summary
- Added "Electricity Market Page" button on the market overview page linking back to the community page with the market dialog open
- Renamed the "Current Values" card section to "Overview" and centered the stat values
- Replaced `Users`/`Network` icons with `PlugZap` throughout all market components; moved `Users` icon to the Community nav item (replacing `Globe`)
- Fixed broken volume field (`volume` → `quantity`) in the market detail dialog
- Unified font styling (font-mono) for numeric values in the market detail dialog

## Test plan
- [ ] Open the Markets Overview page — verify the Overview card shows "Electricity Market Page" button, stats are centered, and `PlugZap` icon is used
- [ ] Click "Electricity Market Page" — verify it navigates to the community page with the correct market dialog open
- [ ] Open the market detail dialog on the community page — verify volume displays correctly (not N/A)
- [ ] Check Community nav item uses `Users` icon instead of `Globe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before:
<img width="2050" height="334" alt="image" src="https://github.com/user-attachments/assets/b1dc2847-1ba5-40d1-8f0b-bd75d51bff15" />

After:
<img width="2050" height="415" alt="image" src="https://github.com/user-attachments/assets/8db6aa19-8487-4b30-9990-2cc76e6a2a91" />

Before:
<img width="1376" height="1187" alt="image" src="https://github.com/user-attachments/assets/9f8f9906-3ec5-40c5-af23-cf13c30ce9d5" />

After:
<img width="1376" height="1187" alt="image" src="https://github.com/user-attachments/assets/dee620e6-f116-41e2-808a-697aa6b5ecda" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a focused set of UI improvements to the electricity market experience: it fixes a data field name mismatch that caused volume to always show as N/A in the market detail dialog, unifies the icon language across all market components, and refactors the overview-page action button so it is always visible (showing "Join Market" or "Leave Market" depending on membership state) instead of only appearing for members of other markets.

- **Bug fix**: `marketData.volume` → `marketData.quantity` in `market-detail-dialog.tsx` corrects the volume stat that was always displaying "N/A".
- **Icon consolidation**: Replaces `Users`/`Network` icons with `PlugZap` throughout market components, while moving `Users` to the Community nav dropdown.
- **Button availability**: The "Join Market" / "Leave Market" link in the overview card is now always rendered (including for players not yet in any market), providing a consistent entry point to the community page's market dialog.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to UI layout, icon swaps, and a clear data-field name correction.

The bug fix (volume field name) is straightforward and verifiable. The refactored CardAction button always links to the community page rather than executing any action directly, so there is no risk of unintended mutations. Icon swaps and centering/font changes are purely visual. No logic paths were added that could cause incorrect data writes or broken navigation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/electricity-markets/market-detail-dialog.tsx | Bug fix: `marketData.volume` → `marketData.quantity` corrects always-N/A volume stat; also swaps icon (Users→PlugZap), adds font-mono, changes member background color. |
| frontend/src/components/electricity-markets/market-item.tsx | Icon swap Users→PlugZap and current-market background change (bg-brand/5 → bg-muted); no logic changes. |
| frontend/src/lib/nav-config.ts | Single-line change: Community nav icon swapped from Globe to Users. |
| frontend/src/routes/app/community/electricity-markets.tsx | Icon swap Users→PlugZap in the help section; no logic changes. |
| frontend/src/routes/app/overviews/electricity-markets.tsx | CardAction refactored to always render a "Join/Leave Market" navigation link; section renamed "Overview"; stat cells centered; icon swapped NetworkIcon→PlugZap. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Markets Overview Page] -->|CardAction button| B{Player in selected market?}
    B -->|Yes| C["'Leave Market' link → /community/electricity-markets?market=id"]
    B -->|No| D["'Join Market' link → /community/electricity-markets?market=id"]
    C --> E[Community Electricity Markets Page]
    D --> E
    E -->|URL: ?market=id| F[MarketDetailDialog opens]
    F -->|isCurrentMarket| G["'Leave Market' button (onLeave callback)"]
    F -->|not member| H["'Join Market' button (onJoin callback)"]
    G --> I[LeaveMarketDialog]
    H --> J[JoinMarketDialog]
```

<sub>Reviews (3): Last reviewed commit: ["fix: replace Join/hide logic with Join/L..."](https://github.com/felixvonsamson/energetica/commit/71b2d4da75b0915743902ef10aacc6ae364749f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33612939)</sub>

<!-- /greptile_comment -->