### PR TITLE
fix: replace destructive badge with inline count on projects panel toggle

### DIFF
--- a/frontend/src/components/dashboard/projects-panel.tsx
+++ b/frontend/src/components/dashboard/projects-panel.tsx
@@ -13,7 +13,6 @@ import { type LucideIcon } from "lucide-react";
 import { DashboardSection } from "@/components/dashboard/dashboard-section";
 import { ProjectList } from "@/components/dashboard/progress-lists";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import { ProjectCategory } from "@/types/projects";
 
 interface ProjectsPanelProps {
@@ -56,7 +55,7 @@ interface ProjectsPanelToggleProps {
     onToggle: () => void;
 }
 
-/** Toggle button with count badge. Renders nothing when count is 0. */
+/** Toggle button with inline count. Renders nothing when count is 0. */
 export function ProjectsPanelToggle({
     count,
     icon: Icon,
@@ -67,26 +66,13 @@ export function ProjectsPanelToggle({
     if (count === 0) return null;
 
     return (
-        <div className="relative inline-flex">
-            <Button
-                variant="outline"
-                onClick={onToggle}
-                className="flex items-center gap-2"
-            >
-                <Icon className="w-5 h-5" />
-                {isOpen ? "Hide" : "Show"} {buttonLabel}
-            </Button>
-            <span
-                className={cn(
-                    "absolute -top-2 -right-2",
-                    "min-w-5 h-5 px-1 rounded-full",
-                    "bg-destructive text-destructive-foreground",
-                    "text-xs font-bold leading-none",
-                    "flex items-center justify-center",
-                )}
-            >
-                {count}
-            </span>
-        </div>
+        <Button
+            variant="outline"
+            onClick={onToggle}
+            className="flex items-center gap-2"
+        >
+            <Icon className="w-5 h-5" />
+            {isOpen ? `Hide ${buttonLabel}` : `Show ${buttonLabel} (${count})`}
+        </Button>
     );
 }


### PR DESCRIPTION
Closes #646

## Summary
- Removes the red (`destructive`) badge overlaid on the construction/research projects toggle button on the facility and technology catalog pages
- The count is now embedded in the button text: **"Show Construction Projects (3)"** when closed, **"Hide Construction Projects"** when open (count omitted — it's visible in the expanded panel)

## Test plan
- [ ] Open the power facility catalog with ≥1 ongoing construction project — button should read "Show Construction Projects (N)"
- [ ] Click to expand — button should read "Hide Construction Projects" with no badge
- [ ] Same for the technology catalog with ongoing research projects
- [ ] Verify button renders nothing when count is 0 (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces a red destructive badge overlaid on the construction/research projects toggle button with an inline count in the button label, reducing DOM complexity and removing an arguably alarming visual affordance.

- The wrapper `<div>` with absolute-positioned badge span is removed; the `cn` import is cleaned up accordingly.
- Button text is now `\"Show {label} (N)\"` when closed and `\"Hide {label}\"` when open, consistent across all five facility/technology callers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward UI simplification with no logic regressions.

The only changed file removes a DOM wrapper and an absolute-positioned badge in favour of inline text in the button label. The count === 0 early-return guard and the isOpen branching are both preserved correctly. The now-unused cn import is cleanly removed. All five caller sites pass the same props unchanged and will automatically get the new label format.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/dashboard/projects-panel.tsx | Badge replaced with inline count in button label; unused cn import removed; logic and early-return guard unchanged. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Parent as Parent Page
    participant Toggle as ProjectsPanelToggle
    participant Panel as ProjectsPanel

    Parent->>Toggle: "render(count, isOpen=false)"
    Toggle-->>Parent: Button "Show Construction Projects (N)"
    Parent->>Toggle: onToggle()
    Parent->>Panel: "render(isOpen=true)"
    Panel-->>Parent: Expanded DashboardSection with ProjectList
    Parent->>Toggle: "render(count, isOpen=true)"
    Toggle-->>Parent: Button "Hide Construction Projects"
```

<sub>Reviews (1): Last reviewed commit: ["fix: replace destructive badge with inli..."](https://github.com/felixvonsamson/energetica/commit/5c1762790acf3cbd86e1a4fcc283768b158d6669) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33642611)</sub>

<!-- /greptile_comment -->