### PR TITLE
fix zero division error

### DIFF
--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -172,7 +172,8 @@ def set_facilities_usage(new_values: dict, player: Player) -> None:
     """
     for controllable_facility in ControllableFacilityType:
         if controllable_facility in player.capacities:
-            usage = new_values["generation"][controllable_facility] / player.capacities[controllable_facility]["power"]
+            power = player.capacities[controllable_facility]["power"]
+            usage = new_values["generation"][controllable_facility] / power if power > 0 else 0.0
             for af in ActiveFacility.filter_by(player=player, facility_type=controllable_facility):
                 af.usage = usage
 
@@ -186,7 +187,8 @@ def set_facilities_usage(new_values: dict, player: Player) -> None:
 
     for extraction_facility in ExtractionFacilityType:
         if extraction_facility in player.capacities:
-            usage = new_values["demand"][extraction_facility] / player.capacities[extraction_facility]["power_use"]
+            power_use = player.capacities[extraction_facility]["power_use"]
+            usage = new_values["demand"][extraction_facility] / power_use if power_use > 0 else 0.0
             for af in ActiveFacility.filter_by(player=player, facility_type=extraction_facility):
                 af.usage = usage
 

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -861,21 +861,23 @@ def resources_and_pollution(new_values: dict, player: Player) -> None:
     # Calculate resource consumption and pollution of generation facilities
     for facility in ControllableFacilityType:
         if player.capacities.get(facility) is not None:
-            for fuel, amount in player.capacities[facility]["fuel_use"].items():
-                fuel = Fuel(fuel)
-                quantity = amount * generation[facility] / player.capacities[facility]["power"]
-                player.resources[fuel] -= quantity
-            facility_emissions = (
-                player.capacities[facility]["pollution"] * generation[facility] / player.capacities[facility]["power"]
-            )
-            add_emissions(new_values, player, facility, facility_emissions)
+            power = player.capacities[facility]["power"]
+            if power > 0:
+                for fuel, amount in player.capacities[facility]["fuel_use"].items():
+                    fuel = Fuel(fuel)
+                    quantity = amount * generation[facility] / power
+                    player.resources[fuel] -= quantity
+                facility_emissions = (
+                    player.capacities[facility]["pollution"] * generation[facility] / power
+                )
+                add_emissions(new_values, player, facility, facility_emissions)
 
     if player.functional_facility_lvl[FunctionalFacilityType.WAREHOUSE] > 0:
         for extraction_facility in ExtractionFacilityType:
             fuel = extraction_facility.associated_fuel
             if player.capacities.get(extraction_facility) is not None:
                 max_demand = player.capacities[extraction_facility]["power_use"]
-                production_factor = demand[extraction_facility] / max_demand
+                production_factor = demand[extraction_facility] / max_demand if max_demand > 0 else 0.0
                 extracted_quantity = (
                     production_factor
                     * player.capacities[extraction_facility]["extraction_rate_per_day"]


### PR DESCRIPTION
## Root cause

This PR fixes a **ZeroDivisionError** that was crashing the production tick for certain players. To understand why, we need to trace through several earlier changes.

### The invariant that was broken

`player.capacities` is a dict of precalculated max values per facility type (`power`, `power_use`, `capacity`, `fuel_use`, etc.). The original invariant was:

> **If a `player.capacities` entry exists for a given facility type, all its numeric fields are positive.**

Entries were strictly tied to owned facilities: added when the first instance was built (`complete_project`), deleted when the last instance was removed (`CapacityData.update` → `del self._data[facility_type]`).

### Commit `7accd8c6` broke this invariant for storage — incompletely patched

In December 2024, storage decommissioning was introduced. When a storage facility is dismantled, instead of being immediately deleted, it stays in `_player_type_index` with `end_of_life = 0` so it can discharge its stored energy before disappearing. Because `init_facility` skips facilities where `end_of_life == 0`:

```python
if facility.end_of_life > 0:
    effective_values["capacity"] += facility.storage_capacity
```

…a decommissioning storage facility causes its `capacity` field to be 0 while the entry still exists.

A guard was correctly added at that time for the storage usage calculation:

```python
if player.data.capacities[facility]["capacity"] == 0:
    usage = 1.0
else:
    usage = new_values["storage"][facility] / player.data.capacities[facility]["capacity"]
```

**The mistake:** this was treated as a one-off storage-specific patch. The broader lesson — *any capacity field can be 0 while an entry exists; guard all divisions* — was not applied to `power` (controllable facilities) and `power_use` (extraction facilities), leaving them exposed to the same class of bug.

### Commit `ac946331` widened the exposure

In May 2026, `resources_and_pollution()` was added with **new** divisions by `player.capacities[facility]["power"]` and `player.capacities[extraction_facility]["power_use"]` — also without guards.

### What `9ef5ab3a` fixed

Guards in `set_facilities_usage()` for the controllable and extraction cases:

```python
power = player.capacities[controllable_facility]["power"]
usage = new_values["generation"][controllable_facility] / power if power > 0 else 0.0

power_use = player.capacities[extraction_facility]["power_use"]
usage = new_values["demand"][extraction_facility] / power_use if power_use > 0 else 0.0
```

### What `4e206bfd` adds

The same guard was missing in `resources_and_pollution()` at the fuel consumption, emissions, and extraction production-factor calculations:

```python
# controllable: fuel use + emissions
power = player.capacities[facility]["power"]
if power > 0:
    quantity = amount * generation[facility] / power
    facility_emissions = ... * generation[facility] / power

# extraction: production factor
max_demand = player.capacities[extraction_facility]["power_use"]
production_factor = demand[extraction_facility] / max_demand if max_demand > 0 else 0.0
```

## Summary of changes

| File | Change |
|------|--------|
| `energetica/production_update.py` | Guard `power == 0` in `set_facilities_usage` (9ef5ab3a); guard `power == 0` and `power_use == 0` in `resources_and_pollution` (4e206bfd) |

## Test plan

- [ ] Verify server tick completes without ZeroDivisionError for players who have decommissioning storage
- [ ] Verify fuel consumption and emissions are 0 (not erroring) when a facility's capacities entry has `power = 0`
- [ ] Verify extraction production factor is 0 (not erroring) when `power_use = 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR guards against `ZeroDivisionError` in `production_update.py` by checking for zero before dividing by `power` or `power_use` capacities in both the facility-usage setter and the resource/pollution calculator.

- In `set_facilities_usage`, divisions by `power` and `power_use` are replaced with conditional expressions that yield `0.0` when the denominator is zero.
- In `resources_and_pollution`, the fuel-consumption and emission block for controllable facilities is wrapped in `if power > 0`, and the extraction-facility `production_factor` calculation also gets a zero-denominator guard.

<h3>Confidence Score: 5/5</h3>

The change narrows a crash path to a safe default and introduces no new logic branches or state mutations.

All four guarded divisions follow the same pattern already used in the existing StorageFacilityType block in the same function. When power or power_use is zero, usage and production_factor default to 0.0, which correctly represents no activity. The resources_and_pollution block skips fuel deduction and emission accounting entirely when power == 0, which is equally correct since a zero-power facility cannot have produced anything. The fix is minimal, localized, and consistent with surrounding code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/production_update.py | Adds zero-denominator guards in four division sites across set_facilities_usage and resources_and_pollution; logic is correct and consistent with the existing StorageFacilityType guard already present in the file. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[production_update tick] --> B[set_facilities_usage]
    A --> C[resources_and_pollution]

    B --> D{ControllableFacility\npower > 0?}
    D -- yes --> E[usage = generation / power]
    D -- no --> F[usage = 0.0]
    E --> G[af.usage = usage]
    F --> G

    B --> H{ExtractionFacility\npower_use > 0?}
    H -- yes --> I[usage = demand / power_use]
    H -- no --> J[usage = 0.0]
    I --> K[af.usage = usage]
    J --> K

    C --> L{ControllableFacility\npower > 0?}
    L -- yes --> M[Deduct fuel & add emissions]
    L -- no --> N[Skip fuel/emissions block]

    C --> O{ExtractionFacility\nmax_demand > 0?}
    O -- yes --> P[production_factor = demand / max_demand]
    O -- no --> Q[production_factor = 0.0]
    P --> R[Compute extracted_quantity & update resources]
    Q --> R
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[production_update tick] --> B[set_facilities_usage]
    A --> C[resources_and_pollution]

    B --> D{ControllableFacility\npower > 0?}
    D -- yes --> E[usage = generation / power]
    D -- no --> F[usage = 0.0]
    E --> G[af.usage = usage]
    F --> G

    B --> H{ExtractionFacility\npower_use > 0?}
    H -- yes --> I[usage = demand / power_use]
    H -- no --> J[usage = 0.0]
    I --> K[af.usage = usage]
    J --> K

    C --> L{ControllableFacility\npower > 0?}
    L -- yes --> M[Deduct fuel & add emissions]
    L -- no --> N[Skip fuel/emissions block]

    C --> O{ExtractionFacility\nmax_demand > 0?}
    O -- yes --> P[production_factor = demand / max_demand]
    O -- no --> Q[production_factor = 0.0]
    P --> R[Compute extracted_quantity & update resources]
    Q --> R
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: guard remaining zero-division paths..."](https://github.com/felixvonsamson/energetica/commit/4e206bfd478d8f4524bf89fe73a8a83261031735) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35459149)</sub>

<!-- /greptile_comment -->