### PR TITLE
fix(#766): stream action log on startup instead of full parse

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,83 @@
+# Energetica — Context Glossary
+
+Project-wide glossary of domain terms. Energetica spans several distinct contexts;
+this file indexes them and defines the vocabulary for each as it gets documented.
+Terms are pinned per-context to keep overloaded words (e.g. three different things
+that all sound like "saving") unambiguous.
+
+## Contexts
+
+- **Persistence & Replay** — how the backend persists game state and reconstructs it
+  on startup. _Documented below._
+- **Electricity-market simulation** — production, markets, climate events, the tick
+  loop. _Not yet documented._
+- **Accounts & users** — players, server-wide accounts, auth. _Not yet documented._
+- **Real-time sync** — socket.io state propagation to the frontend. _Not yet documented._
+- **Frontend** — TSX/Tailwind app and the generated API type bridge. _Not yet documented._
+
+When a new context's terms get pinned, add a `## <Context>` section below (or split
+into a `CONTEXT-MAP.md` + per-context files if this grows unwieldy).
+
+---
+
+## Persistence & Replay
+
+Overloaded in the code — three different operations all sound like "saving" — so the
+terms below are pinned.
+
+### Language
+
+#### Persistence artifacts
+
+**Action log**:
+The append-only, line-delimited JSON record of every game event since `init_engine`,
+written to `instance/actions_history.log`. The authoritative event source; the ground
+truth from which any game state can be reconstructed by replay.
+_Avoid_: history file, log (ambiguous with console log).
+
+**Save**:
+A pickle of in-memory engine state to `instance/engine_data.pck`, taken every 10 min.
+A point-in-time snapshot, not a full backup — it does not include the rest of `instance/`.
+_Avoid_: dump, snapshot (reserve "snapshot" for informal use).
+
+**Checkpoint**:
+A gzipped tarball of the entire `instance/` directory (which includes a fresh **save**),
+taken every 6 h, written to `checkpoints/last_checkpoint.tar.gz`. The unit of disaster
+recovery.
+_Avoid_: backup, save (a checkpoint contains a save but is not one).
+
+#### Replay
+
+**Replay**:
+Re-executing **action log** entries that occur strictly after a known tick to bring
+restored state up to the present. Performed by `simulate.py`.
+
+**Loaded tick**:
+`engine.total_t` immediately after a **save**/**checkpoint** is loaded — the tick the
+restored state is current as of. Replay starts from the action immediately after the
+log entry whose `total_t` equals the loaded tick.
+_Avoid_: checkpoint tick (the loaded tick usually comes from a 10-min **save**, not a
+6-h **checkpoint**).
+
+**Action**:
+A single logged event. One of four discriminated types (`action_type`): `init_engine`
+(always log line 0), `tick`, `create_user`, `request`. The `request` type carries
+arbitrary user-controlled JSON payloads.
+
+### Relationships
+
+- A **checkpoint** contains exactly one **save** plus the rest of `instance/`.
+- Disaster recovery = restore a **checkpoint** (or **save**) + **replay** the **action
+  log** from the **loaded tick** forward. This requires the **action log** to be
+  complete from `init_engine`; truncating it below a tick destroys the ability to
+  replay from any earlier **loaded tick**.
+- Only **actions** after the **loaded tick** are needed at startup; everything before
+  is read solely to locate the **loaded tick**'s log line.
+
+### Flagged ambiguities
+
+- "checkpoint tick" vs "loaded tick": on a normal restart the **loaded tick** comes
+  from the 10-min **save**, not the 6-h **checkpoint** — so replay typically covers
+  ~10 min of actions, not ~6 h. Resolved: use **loaded tick** for the replay boundary.
+- "the log" meant both the **action log** (file) and the console logger in code.
+  Resolved: **action log** is always the persisted event source.

--- a/docs/adr/0001-action-log-stays-complete-fix-oom-on-read.md
+++ b/docs/adr/0001-action-log-stays-complete-fix-oom-on-read.md
@@ -1,0 +1,40 @@
+# Fix startup OOM on the read path; keep the action log complete from init
+
+## Context
+
+`create_app()` deserialised the entire `instance/actions_history.log` into Pydantic
+objects on every startup (~270 MB / 365K lines → ~1.3 GB RSS on a 1.8 GB box → OOM
+crash loop; see issue #766). The full list is barely used: only actions *after* the
+loaded tick are replayed; the rest is read just to locate one boundary line.
+
+## Decision
+
+Fix the spike on the **read path only**: stream the log, skip the pre-boundary prefix
+via top-level `json.loads` (never building objects), and Pydantic-validate only line 0
+(`init_engine`) plus the tail at/after the loaded tick. The **action log remains an
+append-only, complete-from-`init_engine` event source** — we do **not** truncate or
+rotate it.
+
+## Considered Options
+
+- **Truncate the log at each checkpoint** (issue's "simplest"). Rejected: it collapses
+  the recovery surface from "any checkpoint" to "only the newest checkpoint." Full
+  checkpoints run every 6 h but the loaded tick usually comes from the 10-min save; if
+  the newest checkpoint is the corrupt one, recovery falls back to an older checkpoint —
+  but truncation has already deleted the actions needed to replay forward from it. It
+  also introduces a live-writer truncation race on a write path that is currently dead
+  simple.
+- **Rotating log segments.** Rejected for this fix: more moving parts, same recovery
+  concerns, no production urgency.
+- **Move the action log into a database (#766 option 5).** Out of scope: aspirational,
+  unscoped, and orthogonal to a live crash. A localised read-path fix is fully
+  compatible with a later DB migration.
+
+## Consequences
+
+- Disk growth (the log still grows unboundedly) is **not** addressed here; it is a
+  separate, non-urgent track. If addressed later it must be archival (move-aside),
+  never delete-what-you-cannot-replay, to preserve recovery-from-any-checkpoint.
+- The boundary scan uses a top-level JSON parse, **not** a substring search: `request`
+  actions log arbitrary user-controlled payloads that can contain the literal bytes
+  `"action_type":"tick"`, so substring matching is a correctness/security hole.

--- a/docs/backend/incident-recovery.md
+++ b/docs/backend/incident-recovery.md
@@ -34,11 +34,19 @@ cp -r instance/ instance.bak.$(date +%Y%m%d_%H%M%S)/
 
 The `--load_checkpoint` flag handles everything: it preserves the actions log, removes the stale `instance/` folder, extracts `checkpoints/last_checkpoint.tar.gz`, puts the log back, and replays all recorded actions before resuming normal operation.
 
+> ⚠️ **Run the replay as `www-data`, not `root`.** The systemd service runs as `www-data`. If you run the replay as `root`, every file it writes under `instance/` becomes root-owned, and the next live tick fails with `PermissionError` — putting you straight into another crash loop. Use `sudo -u www-data`:
+
 ```bash
-python main.py --env prod --no-reload --load_checkpoint
+sudo -u www-data python main.py --env prod --no-reload --load_checkpoint
 ```
 
 Pass the same SSL and port flags used by the production service. Watch for rapid tick replays (`t = XXXX`). Once the ticks slow to the normal 30-second cadence, recovery is complete. Stop the process with Ctrl+C.
+
+If you did run anything as `root` by mistake, fix ownership before starting the service:
+
+```bash
+chown -R www-data:www-data instance/ checkpoints/
+```
 
 **Step 3 — start the service:**
 
@@ -75,6 +83,9 @@ followed by rapid tick replays (`t = XXXX`). If the engine logs an error instead
 
 ## Checkpoints
 
-Checkpoints are saved to `checkpoints/last_checkpoint.tar.gz` by `save_checkpoint()` in `game_engine.py`. They are a tarball of the entire `instance/` directory including `engine_data.pck` and all data files at a consistent point in time.
+Persistence runs at two cadences (see `utils/tick_execution.py`):
 
-The checkpoint on `energetica-edu` is saved roughly every hour (check `ls -la checkpoints/` to see its age).
+- **`engine.save()` — every 10 minutes.** Writes only `instance/engine_data.pck` (the in-memory engine state). This is what `engine.load()` reads on a normal restart, so the **loaded tick** is usually at most ~10 minutes old.
+- **`save_checkpoint()` — every 6 hours.** Writes `checkpoints/last_checkpoint.tar.gz`, a tarball of the entire `instance/` directory (including a fresh `engine_data.pck` and all data files) at a consistent point in time. This is the unit of disaster recovery.
+
+Check `ls -la checkpoints/` to see the current checkpoint's age. Because the checkpoint is only every 6 h, recovery relies on replaying the actions log forward from the checkpoint tick — which is why the log must never be truncated below a tick you might need to restore from (see `docs/adr/0001-action-log-stays-complete-fix-oom-on-read.md`).

--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -26,7 +26,8 @@ from pydantic import TypeAdapter
 
 from energetica import globals
 from energetica.game_engine import GameEngine
-from energetica.schemas.simulate import Action
+from energetica.schemas.simulate import Action, InitEngineAction
+from energetica.utils.action_log import read_init_action, stream_actions_after_tick
 from energetica.utils.browser_notifications import load_or_create_vapid_keys
 
 _REPO_ROOT = Path(__file__).parent.parent
@@ -92,14 +93,17 @@ def create_app(
     Path("instance").mkdir(exist_ok=True)
     engine.init_loggers()
 
-    actions = []
+    actions: list[Action] = []
+    init_action: InitEngineAction | None = None
     if simulate_file:
-        # Simulate the game run from a file.
+        # Simulate the game run from a file. This dev/CI path replays an arbitrary, dev-chosen
+        # file and still parses it in full — it carries no production crash-loop exposure.
         Path("checkpoints/simulation").mkdir(exist_ok=True)
         TypeAdapterAction = TypeAdapter(Action)
         with open(simulate_file, "r", encoding="utf-8") as file:
             actions = cast(list[Action], [TypeAdapterAction.validate_json(line) for line in file])
         assert actions[0].action_type == "init_engine"
+        init_action = cast(InitEngineAction, actions[0])
 
         checkpoints = {
             int(save.split("checkpoint_")[1].rstrip(".tar.gz")): save
@@ -130,35 +134,39 @@ def create_app(
             if saved_history:
                 os.rename("actions_history.log.bak", "instance/actions_history.log")
             engine.log("Loaded last checkpoint")
+        # The action log is the authoritative event source, but only line 0 (init_engine) and
+        # the actions after the loaded tick are ever needed. Read line 0 now and stream the tail
+        # below, rather than deserialising the whole (multi-hundred-MB) log into Pydantic objects
+        # on every startup, which spiked RSS to ~1.3 GB and OOM-killed the box (issue #766).
         if os.path.isfile("instance/actions_history.log"):
-            with open("instance/actions_history.log", "r") as file:
-                actions = cast(list[Action], [TypeAdapter(Action).validate_json(line) for line in file])
-            if actions:
-                assert actions[0].action_type == "init_engine"
+            init_action = read_init_action("instance/actions_history.log")
     if os.path.isfile("instance/engine_data.pck"):
         engine.load()
-        if actions:
-            assert actions[0].action_type == "init_engine"
-            assert uuid.UUID(actions[0].instance_uuid) == engine.uuid
+        if init_action is not None:
+            assert uuid.UUID(init_action.instance_uuid) == engine.uuid
     else:
-        if actions:
-            assert actions[0].action_type == "init_engine"
-            assert actions[0].game_version == __version__, (
+        if init_action is not None:
+            assert init_action.game_version == __version__, (
                 "Game version mismatch. This actions history is not compatible with this version of the game."
             )
-            kwargs: dict = actions[0].model_dump()
+            kwargs: dict = init_action.model_dump()
             kwargs.pop("action_type")
             engine.init_instance(**kwargs)
         else:
             engine.init_instance(clock_time, in_game_seconds_per_tick, random_seed, env, __version__, disable_signups)
 
-    action_id_by_tick = {
-        action.total_t: action_id for action_id, action in enumerate(actions) if action.action_type == "tick"
-    }
     loaded_tick = engine.total_t
-    start_action_id = action_id_by_tick[loaded_tick] + 1 if loaded_tick else 1
-    last_action_id = action_id_by_tick[simulate_till] if simulate_till else len(actions) - 1
-    actions_to_simulate = actions[start_action_id : last_action_id + 1]
+    if simulate_file:
+        action_id_by_tick = {
+            action.total_t: action_id for action_id, action in enumerate(actions) if action.action_type == "tick"
+        }
+        start_action_id = action_id_by_tick[loaded_tick] + 1 if loaded_tick else 1
+        last_action_id = action_id_by_tick[simulate_till] if simulate_till else len(actions) - 1
+        actions_to_simulate = actions[start_action_id : last_action_id + 1]
+    elif os.path.isfile("instance/actions_history.log"):
+        actions_to_simulate = stream_actions_after_tick("instance/actions_history.log", loaded_tick)
+    else:
+        actions_to_simulate = []
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:

--- a/energetica/utils/action_log.py
+++ b/energetica/utils/action_log.py
@@ -48,6 +48,10 @@ def stream_actions_after_tick(log_path: str | Path, loaded_tick: int) -> list[Ac
     is everything after line 0 (``init_engine``).
     """
     tail: list[Action] = []
+    # A falsy loaded_tick means a fresh engine with no prior saved state: there is no
+    # boundary tick to find, so collect everything after line 0 (init_engine) and skip
+    # the boundary search. The "if not collecting: raise" guard below is intentionally
+    # bypassed in this case — it only fires when a real loaded_tick is never matched.
     collecting = not loaded_tick
     with open(log_path, encoding="utf-8") as file:
         for line_no, line in enumerate(file):

--- a/energetica/utils/action_log.py
+++ b/energetica/utils/action_log.py
@@ -1,0 +1,67 @@
+"""Streaming reader for ``instance/actions_history.log`` (issue #766).
+
+On startup only the actions *after* the loaded tick need replaying, yet the whole
+log used to be deserialised into Pydantic objects — allocating gigabytes of RSS for
+a list that is immediately sliced down to its tail. These helpers read the log
+without materialising the prefix: line 0 (``init_engine``) is validated on its own,
+and the skipped prefix is scanned with a cheap top-level ``json.loads`` rather than
+full validation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import TypeAdapter
+
+from energetica.schemas.simulate import Action, InitEngineAction
+
+_action_adapter: TypeAdapter[Action] = TypeAdapter(Action)
+
+
+def read_init_action(log_path: str | Path) -> InitEngineAction | None:
+    """Validate and return log line 0 (the ``init_engine`` action), or None if the log is empty.
+
+    Reads only the first line, so it is cheap regardless of log size. The caller uses the
+    result for the uuid / game-version invariants and, on a fresh instance, to seed
+    ``engine.init_instance``.
+    """
+    with open(log_path, encoding="utf-8") as file:
+        first_line = file.readline()
+    if not first_line.strip():
+        return None
+    action = _action_adapter.validate_json(first_line)
+    assert isinstance(action, InitEngineAction), (
+        f"First action in {log_path} is {action.action_type!r}, expected 'init_engine'."
+    )
+    return action
+
+
+def stream_actions_after_tick(log_path: str | Path, loaded_tick: int) -> list[Action]:
+    """Return the actions to replay: every action after the loaded tick's log line.
+
+    Forward-scans the log a single time. Lines before the boundary are skipped via a
+    top-level ``json.loads`` (never built into Pydantic objects); the boundary is the
+    ``tick`` action whose ``total_t == loaded_tick``. Every action after it is validated
+    and collected. When ``loaded_tick`` is falsy (fresh instance, no checkpoint) the tail
+    is everything after line 0 (``init_engine``).
+    """
+    tail: list[Action] = []
+    collecting = not loaded_tick
+    with open(log_path, encoding="utf-8") as file:
+        for line_no, line in enumerate(file):
+            if line_no == 0:
+                continue  # init_engine action — restored separately, never replayed
+            if collecting:
+                tail.append(_action_adapter.validate_json(line))
+                continue
+            entry = json.loads(line)
+            if entry.get("action_type") == "tick" and entry.get("total_t") == loaded_tick:
+                collecting = True  # boundary found; collect strictly after this line
+    if not collecting:
+        raise ValueError(
+            f"No 'tick' action with total_t == {loaded_tick} found in {log_path}; "
+            "the action log and the loaded state are out of sync — refusing to replay."
+        )
+    return tail

--- a/tests/unit/test_action_log.py
+++ b/tests/unit/test_action_log.py
@@ -71,8 +71,11 @@ def test_returns_actions_strictly_after_loaded_tick(tmp_path: Path) -> None:
     tail = stream_actions_after_tick(log, loaded_tick=2)
 
     assert [a.action_type for a in tail] == ["request", "tick"]
-    assert tail[0].user_id == 7
-    assert tail[1].total_t == 3
+    request_action, tick_action = tail
+    assert isinstance(request_action, ApiAction)
+    assert isinstance(tick_action, TickAction)
+    assert request_action.user_id == 7
+    assert tick_action.total_t == 3
 
 
 def test_forged_tick_in_request_payload_does_not_fool_boundary(tmp_path: Path) -> None:
@@ -93,8 +96,11 @@ def test_forged_tick_in_request_payload_does_not_fool_boundary(tmp_path: Path) -
     tail = stream_actions_after_tick(log, loaded_tick=5)
 
     assert [a.action_type for a in tail] == ["request", "tick"]
-    assert tail[0].user_id == 9
-    assert tail[1].total_t == 6
+    request_action, tick_action = tail
+    assert isinstance(request_action, ApiAction)
+    assert isinstance(tick_action, TickAction)
+    assert request_action.user_id == 9
+    assert tick_action.total_t == 6
 
 
 def test_non_validating_prefix_line_is_skipped_not_parsed(tmp_path: Path) -> None:
@@ -117,7 +123,9 @@ def test_non_validating_prefix_line_is_skipped_not_parsed(tmp_path: Path) -> Non
     tail = stream_actions_after_tick(log, loaded_tick=2)
 
     assert [a.action_type for a in tail] == ["request"]
-    assert tail[0].user_id == 9
+    (request_action,) = tail
+    assert isinstance(request_action, ApiAction)
+    assert request_action.user_id == 9
 
 
 def test_missing_boundary_tick_raises(tmp_path: Path) -> None:

--- a/tests/unit/test_action_log.py
+++ b/tests/unit/test_action_log.py
@@ -1,0 +1,153 @@
+"""Unit tests for the streaming action-log reader (issue #766).
+
+These exercise the public interface of ``energetica.utils.action_log`` directly,
+without spinning up ``create_app``: given a log file on disk and a loaded tick,
+the reader must return exactly the actions that need replaying — and must do so
+without Pydantic-validating the prefix it skips.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from energetica.schemas.simulate import (
+    ApiAction,
+    ApiActionRequest,
+    ApiActionResponse,
+    InitEngineAction,
+    TickAction,
+)
+from energetica.utils.action_log import read_init_action, stream_actions_after_tick
+
+_TS = datetime(2026, 1, 1)
+
+
+def _init() -> InitEngineAction:
+    return InitEngineAction(
+        instance_uuid="11111111-1111-1111-1111-111111111111",
+        env="dev",
+        game_version="0.0.0",
+        action_type="init_engine",
+        clock_time=3,
+        in_game_seconds_per_tick=1,
+        random_seed=1,
+        start_date=_TS,
+        disable_signups=False,
+    )
+
+
+def _tick(total_t: int) -> TickAction:
+    return TickAction(timestamp=_TS, action_type="tick", total_t=total_t, elapsed=0.1)
+
+
+def _request(user_id: int = 1, payload: dict | None = None) -> ApiAction:
+    return ApiAction(
+        timestamp=_TS,
+        elapsed=0.1,
+        ip="127.0.0.1",
+        action_type="request",
+        user_id=user_id,
+        request=ApiActionRequest(endpoint="/x", method="POST", content_type="application/json", payload=payload),
+        response=ApiActionResponse(status_code=200, content_type="application/json", payload=None),
+    )
+
+
+def _write_log(path: Path, actions: list) -> Path:
+    path.write_text("".join(a.model_dump_json() + "\n" for a in actions), encoding="utf-8")
+    return path
+
+
+def test_returns_actions_strictly_after_loaded_tick(tmp_path: Path) -> None:
+    """The tail is every action after the loaded tick's line — including interleaved non-ticks."""
+    req_after = _request(user_id=7)
+    log = _write_log(
+        tmp_path / "actions_history.log",
+        [_init(), _tick(1), _request(user_id=2), _tick(2), req_after, _tick(3)],
+    )
+
+    tail = stream_actions_after_tick(log, loaded_tick=2)
+
+    assert [a.action_type for a in tail] == ["request", "tick"]
+    assert tail[0].user_id == 7
+    assert tail[1].total_t == 3
+
+
+def test_forged_tick_in_request_payload_does_not_fool_boundary(tmp_path: Path) -> None:
+    """A request payload literally containing a 'tick' action must not be mistaken for the boundary.
+
+    Guards against regressing the prefix scan to a substring match: request payloads are
+    arbitrary user-controlled JSON and can contain the bytes ``"action_type":"tick"``.
+    Only the *top-level* action_type/total_t may decide the boundary.
+    """
+    poison = _request(user_id=2, payload={"action_type": "tick", "total_t": 5})
+    log = _write_log(
+        tmp_path / "actions_history.log",
+        [_init(), _tick(1), poison, _tick(5), _request(user_id=9), _tick(6)],
+    )
+
+    # The real boundary is the top-level tick(5); the forged total_t:5 in the payload
+    # of an earlier *request* line must be ignored.
+    tail = stream_actions_after_tick(log, loaded_tick=5)
+
+    assert [a.action_type for a in tail] == ["request", "tick"]
+    assert tail[0].user_id == 9
+    assert tail[1].total_t == 6
+
+
+def test_non_validating_prefix_line_is_skipped_not_parsed(tmp_path: Path) -> None:
+    """A prefix line that no Action schema accepts must be skipped, proving it is never validated.
+
+    The old code ``validate_json``-ed every line; it would have raised on this line. The
+    streaming reader only ``json.loads`` the prefix to locate the boundary, so a
+    schema-incompatible prefix line (e.g. left over from an older log format) is tolerated.
+    """
+    lines = [
+        _init().model_dump_json(),
+        _tick(1).model_dump_json(),
+        '{"action_type":"request"}',  # valid JSON, invalid Action (missing required fields)
+        _tick(2).model_dump_json(),
+        _request(user_id=9).model_dump_json(),
+    ]
+    log = tmp_path / "actions_history.log"
+    log.write_text("".join(line + "\n" for line in lines), encoding="utf-8")
+
+    tail = stream_actions_after_tick(log, loaded_tick=2)
+
+    assert [a.action_type for a in tail] == ["request"]
+    assert tail[0].user_id == 9
+
+
+def test_missing_boundary_tick_raises(tmp_path: Path) -> None:
+    """If no tick line matches the loaded tick, fail loud rather than silently replay nothing/wrong.
+
+    A silent empty tail would skip real actions and let the game diverge from its history.
+    """
+    log = _write_log(
+        tmp_path / "actions_history.log",
+        [_init(), _tick(1), _request(user_id=2), _tick(2)],
+    )
+
+    with pytest.raises(ValueError, match="42"):
+        stream_actions_after_tick(log, loaded_tick=42)
+
+
+def test_read_init_action_returns_validated_line_zero(tmp_path: Path) -> None:
+    """Line 0 is validated and returned as the init_engine action."""
+    log = _write_log(tmp_path / "actions_history.log", [_init(), _tick(1)])
+
+    init = read_init_action(log)
+
+    assert init is not None
+    assert init.action_type == "init_engine"
+    assert init.instance_uuid == "11111111-1111-1111-1111-111111111111"
+
+
+def test_read_init_action_returns_none_for_empty_log(tmp_path: Path) -> None:
+    """An empty log yields None — the caller treats this as a fresh instance, not an error."""
+    log = tmp_path / "actions_history.log"
+    log.write_text("", encoding="utf-8")
+
+    assert read_init_action(log) is None


### PR DESCRIPTION
## Problem

`create_app()` deserialised the **entire** `instance/actions_history.log` into a list of Pydantic objects on every startup:

```python
actions = [TypeAdapter(Action).validate_json(line) for line in file]
```

On prod the log is ~270 MB / ~365K lines; this allocates ~1.3 GB RSS that pymalloc never returns to the OS. On the 1.8 GB box that means OOM kills → corrupt saves → crash loop (issue #766). The full list is barely used — only actions *after* the loaded tick are replayed; everything before is read solely to locate one boundary line.

## Fix (read path only)

The action log stays append-only and **complete from `init_engine`** — it is the disaster-recovery source of record, so truncating/rotating it was rejected (see `docs/adr/0001`). We only stop materialising the prefix we throw away.

- New `energetica/utils/action_log.py`:
  - `read_init_action()` — validates only log line 0.
  - `stream_actions_after_tick()` — single forward pass; top-level `json.loads` skips the prefix (no objects built), `validate_json` only the tail; **fail-loud** if the loaded-tick boundary is missing.
- `__init__.py` normal-startup path rewired onto these. The full-list parse and `action_id_by_tick` positional slice are dropped from that path. `simulate_file` (dev/CI) keeps full-parse, unchanged.

Peak startup RSS drops from "entire history" to "~10 min of post-save actions" (a normal restart loads `engine_data.pck`, saved every 10 min).

### Why a JSON parse, not a substring scan
The issue suggested skipping prefix lines with "a simple string search for the tick id". That's unsafe: `request` actions log arbitrary user-controlled payloads that can contain the literal bytes `"action_type":"tick","total_t":<forged>`. The boundary is decided by the **top-level** `action_type` via `json.loads` — never a substring match. Parse cost was never the bottleneck; memory retention was.

## Tests
`tests/unit/test_action_log.py`:
1. boundary/tail correctness incl. interleaved non-tick actions
2. forged `"action_type":"tick"` in a pre-boundary request payload does not fool the scan
3. a non-validating prefix line is skipped (proves the prefix is never validated)
4. fail-loud when the loaded-tick boundary is absent
5–6. `read_init_action` happy + empty-log paths

`pytest -m "not external_links"`: green. `test_server_runs` (real fresh startup): green.

## Docs
- `CONTEXT.md` — project glossary; Persistence & Replay vocabulary pinned (save vs checkpoint vs action log).
- `docs/adr/0001-action-log-stays-complete-fix-oom-on-read.md` — durability stance + rejected alternatives.
- `docs/backend/incident-recovery.md` — two live-incident corrections: run the replay as `www-data` (root-run creates root-owned files → `PermissionError` on the next tick), and the real cadence (10-min `save()` / 6-h checkpoint, not "hourly").

Closes #766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes an OOM crash loop on production startup by replacing the full-log Pydantic parse with a streaming read that only deserialises line 0 (`init_engine`) and the tail of actions that actually need replaying.

- **`energetica/utils/action_log.py`** — new module with `read_init_action` (validates only line 0) and `stream_actions_after_tick` (scans prefix via cheap `json.loads`, Pydantic-validates only the tail); the top-level JSON parse guards against forged tick values in user-controlled request payloads.
- **`energetica/__init__.py`** — normal-startup path rewired onto the new helpers; `simulate_file` (dev/CI) path left on the full-parse to avoid touching it.
- **Docs + tests** — `CONTEXT.md` pins persistence vocabulary, ADR 0001 records the decision and rejected alternatives, and six focused unit tests cover boundary detection, injection resistance, corrupt-prefix tolerance, and fail-loud behaviour.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the OOM fix is well-scoped, the boundary logic is sound, and the fail-loud ValueError prevents silent wrong-state replays.

The new streaming read path correctly handles all startup branches (normal restart, load_checkpoint, fresh instance, simulate_file). The boundary scan uses top-level json.loads rather than substring matching, which correctly resists forged tick values in user-controlled request payloads. The fail-loud ValueError when the boundary is missing prevents the engine from silently replaying against stale state. The six unit tests cover the key code paths, and the production OOM scenario is directly addressed without changing the write path or action log retention policy.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/utils/action_log.py | New streaming reader; boundary logic is correct, forged-payload resistance is well-tested, and the fail-loud ValueError on missing boundary prevents silent wrong-state replays. |
| energetica/__init__.py | Normal startup wired onto new helpers; simulate_file path unchanged; action_id_by_tick slice correctly moved inside the simulate_file branch; loaded_tick derivation and UUID/version assertions preserved. |
| tests/unit/test_action_log.py | Six focused unit tests covering boundary correctness, injection resistance, Pydantic-skip-in-prefix, fail-loud on missing boundary, and read_init_action happy/empty paths. |
| CONTEXT.md | New project glossary pinning persistence vocabulary (action log, save, checkpoint, loaded tick) to disambiguate three things that all sound like "saving". |
| docs/adr/0001-action-log-stays-complete-fix-oom-on-read.md | ADR records the decision, considered options (truncate, rotating segments, DB migration), and consequences; clearly explains why substring scan was rejected in favour of a top-level JSON parse. |
| docs/backend/incident-recovery.md | Two live-incident corrections: sudo -u www-data for checkpoint replay (root-owned files cause PermissionError on next tick) and accurate 10-min save / 6-h checkpoint cadence. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[create_app startup] --> B{simulate_file?}
    B -- Yes --> C[Full parse: TypeAdapter for every line\ndev/CI path, unchanged]
    B -- No --> D{actions_history.log\nexists?}
    D -- No --> E[init_action = None]
    D -- Yes --> F[read_init_action\nvalidate line 0 only]
    F --> G[init_action set]
    G --> H{engine_data.pck\nexists?}
    E --> H
    H -- Yes --> I[engine.load\nrestore total_t]
    H -- No --> J[engine.init_instance\ntotal_t = 0]
    I --> K[loaded_tick = engine.total_t]
    J --> K
    K --> L{actions_history.log\nexists?}
    L -- Yes --> M[stream_actions_after_tick\njson.loads prefix only\nPydantic-validate tail]
    L -- No --> N[actions_to_simulate = empty]
    M --> O{loaded_tick == 0?}
    O -- Yes\nfresh instance --> P[collecting=True\nreturn everything after line 0]
    O -- No\nnormal restart --> Q[scan prefix for tick boundary\ncollect strictly after it]
    Q --> R{boundary found?}
    R -- No --> S[raise ValueError\nfail loud]
    R -- Yes --> T[return tail actions]
    C --> U[simulate path\naction_id_by_tick slice]
    P --> V[replay tail]
    T --> V
```

<sub>Reviews (2): Last reviewed commit: ["review: narrow Action union in tests; do..."](https://github.com/felixvonsamson/energetica/commit/3c8bfab44d25588d867573c5e94653119d6bdf33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37434336)</sub>

<!-- /greptile_comment -->