### PR TITLE
fix: send web push notifications off the request critical path (#763)

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -58,6 +59,14 @@ from energetica.technology_effects import (
     package_storage_facilities,
 )
 from energetica.types.facility_statuses import ConsumptionStatus, ProductionStatus, RenewableStatus
+
+# Web push delivery is a blocking network round-trip. It must never sit on a request handler or
+# game-tick critical path, so the actual webpush() calls are dispatched to this background pool
+# (fire-and-forget, best-effort). See issue #763. The per-request timeout below bounds how long a
+# single hung push service can occupy a worker (and bounds interpreter shutdown, since the pool is
+# joined at exit).
+_PUSH_TIMEOUT_SECONDS = 5
+_PUSH_EXECUTOR = ThreadPoolExecutor(max_workers=16, thread_name_prefix="webpush")
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -438,19 +447,29 @@ class Player(DBModel):
         return shipment_speeds
 
     def notify_subscription(self, subscription: Subscription, payload: NotificationPayload) -> None:
-        """Send a push notification to a single subscription without creating a notification object."""
+        """Queue a push notification to a single subscription for background delivery.
+
+        The blocking webpush() round-trip is dispatched to a background thread pool so it never
+        delays the caller (request handler or game tick). Delivery is fire-and-forget and
+        best-effort. See issue #763.
+        """
         notification_data = {
             "type": payload.type,
             "payload": payload.model_dump(exclude={"type"}),
         }
         parsed = urlparse(subscription.endpoint)
         audience = f"{parsed.scheme}://{parsed.netloc}"
+        _PUSH_EXECUTOR.submit(self._deliver_push, subscription, notification_data, audience)
+
+    def _deliver_push(self, subscription: Subscription, notification_data: dict[str, Any], audience: str) -> None:
+        """Perform the blocking webpush delivery. Runs in a background thread; best-effort."""
         try:
             webpush(
                 subscription_info=subscription.model_dump(),
                 data=json.dumps(notification_data),
                 vapid_private_key=engine.VAPID_PRIVATE_KEY,
                 vapid_claims={"aud": audience, "sub": "mailto:energetica.game@gmail.com"},
+                timeout=_PUSH_TIMEOUT_SECONDS,
             )
         except WebPushException as ex:
             if ex.response is not None and ex.response.status_code == 410:
@@ -462,10 +481,10 @@ class Player(DBModel):
             else:
                 engine.warn(f"Failed to send notification: {repr(ex)}")
         except Exception as ex:  # noqa: BLE001
-            # Push delivery is best-effort: any transport/library failure (DNS, TCP, TLS, library
-            # bug, ...) must not abort the caller, since notify() is invoked from inside
-            # complete_project and a raise here leaves the player's state half-finished
-            # (project deleted, ActiveFacility never created). See issue #753.
+            # Push delivery is best-effort: any transport/library failure (DNS, TCP, TLS, timeout,
+            # library bug, ...) must not surface. notify() runs from inside game logic such as
+            # complete_project, where a raise would leave player state half-finished (project
+            # deleted, ActiveFacility never created). See issues #753 and #763.
             engine.warn(f"Failed to send notification: {repr(ex)}")
 
     def notify(self, payload: PersistableNotificationPayload) -> None:

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -473,7 +473,14 @@ class Player(DBModel):
             )
         except WebPushException as ex:
             if ex.response is not None and ex.response.status_code == 410:
-                # Subscription has expired or been revoked — remove it
+                # Subscription has expired or been revoked — remove it.
+                # Thread-safety: this runs on a background worker, while the subscription router
+                # (browser_notifications.py) appends/removes on the same list from request threads.
+                # All mutations are single, individually-atomic list ops (remove guarded by the
+                # except below; the router uses bare append / remove+except), so they are safe
+                # under the GIL with no lock. push_subscriptions is part of the pickled Player
+                # state, so a per-instance Lock is not an option. If a non-atomic check-then-mutate
+                # sequence on this list is ever introduced, it must be synchronised explicitly.
                 try:
                     self.push_subscriptions.remove(subscription)
                 except ValueError:

--- a/tests/integration/test_push_notifications.py
+++ b/tests/integration/test_push_notifications.py
@@ -71,26 +71,27 @@ def test_expired_subscription_is_removed(monkeypatch: pytest.MonkeyPatch) -> Non
     from pywebpush import WebPushException
 
     player = _make_player()
-    player.push_subscriptions.append(_subscription())
 
-    done = threading.Event()
+    # Signal exactly when the background worker calls remove(), so the assertion is deterministic
+    # rather than polling: waiting on the webpush call itself would race the subsequent removal.
+    removed = threading.Event()
+
+    class _SignalingList(list):  # type: ignore[type-arg]
+        def remove(self, value: object) -> None:
+            super().remove(value)
+            removed.set()
+
+    player.push_subscriptions = _SignalingList([_subscription()])
 
     class _Resp:
         status_code = 410
 
     def gone_webpush(**_kwargs: object) -> None:
-        try:
-            raise WebPushException("gone", response=_Resp())
-        finally:
-            done.set()
+        raise WebPushException("gone", response=_Resp())
 
     monkeypatch.setattr(player_module, "webpush", gone_webpush)
 
     player.push_only(ChatMessagePayload(sender_username="alice", message="hi", chat_id=1))
 
-    assert done.wait(timeout=3), "background webpush never ran"
-    # Give the worker thread a moment to perform the removal after raising.
-    deadline = time.perf_counter() + 2
-    while player.push_subscriptions and time.perf_counter() < deadline:
-        time.sleep(0.01)
-    assert player.push_subscriptions == [], "expired (410) subscription was not pruned"
+    assert removed.wait(timeout=3), "expired (410) subscription was not pruned"
+    assert player.push_subscriptions == []

--- a/tests/integration/test_push_notifications.py
+++ b/tests/integration/test_push_notifications.py
@@ -1,0 +1,96 @@
+"""Regression tests for issue #763: web push delivery must not block the caller.
+
+`notify_subscription` used to call the blocking `webpush()` round-trip inline, so sending a chat
+message (or any notification) held the request/tick until every push to every subscriber completed
+serially — multiple seconds in busy chats, unbounded if a push service hung. Delivery is now
+dispatched to a background thread pool with a per-request timeout.
+"""
+
+import threading
+import time
+
+import pytest
+
+from energetica import create_app
+from energetica.database import player as player_module
+from energetica.database.map.hex_tile import HexTile
+from energetica.database.player import Player
+from energetica.database.user import User
+from energetica.schemas.browser_notifications import Subscription, SubscriptionKeys
+from energetica.schemas.notifications import ChatMessagePayload
+from energetica.utils.auth import generate_password_hash
+from energetica.utils.map_helpers import confirm_location
+
+
+def _make_player() -> Player:
+    create_app(rm_instance=True, skip_adding_handlers=True, env="dev")
+    user = User(username="username", pwhash=generate_password_hash("password"), role="player", account_id=1)
+    return confirm_location(user, HexTile.getitem(1))
+
+
+def _subscription() -> Subscription:
+    return Subscription(
+        endpoint="https://push.example.com/sub/abc",
+        keys=SubscriptionKeys(p256dh="p256dh-key", auth="auth-key"),
+    )
+
+
+def test_notify_subscription_does_not_block_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The caller returns immediately even when the underlying webpush round-trip is slow."""
+    player = _make_player()
+    player.push_subscriptions.append(_subscription())
+
+    started = threading.Event()
+    finished = threading.Event()
+    captured: dict[str, object] = {}
+
+    def slow_webpush(**kwargs: object) -> None:
+        started.set()
+        captured.update(kwargs)
+        time.sleep(2)
+        finished.set()
+
+    monkeypatch.setattr(player_module, "webpush", slow_webpush)
+
+    t0 = time.perf_counter()
+    player.push_only(ChatMessagePayload(sender_username="alice", message="hi", chat_id=1))
+    elapsed = time.perf_counter() - t0
+
+    # The call returns essentially immediately, long before the 2s webpush completes.
+    assert elapsed < 0.5, f"push_only blocked the caller for {elapsed:.2f}s"
+    # The delivery really was dispatched (runs in the background pool)...
+    assert started.wait(timeout=1), "webpush was never dispatched to the background pool"
+    assert not finished.is_set(), "webpush finished synchronously — it was not backgrounded"
+    # ...and eventually completes with a bounded timeout applied (issue #763 fix #2).
+    assert finished.wait(timeout=3), "background webpush never completed"
+    assert captured["timeout"] == player_module._PUSH_TIMEOUT_SECONDS
+
+
+def test_expired_subscription_is_removed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 410 Gone from the push service prunes the dead subscription (preserved behaviour)."""
+    from pywebpush import WebPushException
+
+    player = _make_player()
+    player.push_subscriptions.append(_subscription())
+
+    done = threading.Event()
+
+    class _Resp:
+        status_code = 410
+
+    def gone_webpush(**_kwargs: object) -> None:
+        try:
+            raise WebPushException("gone", response=_Resp())
+        finally:
+            done.set()
+
+    monkeypatch.setattr(player_module, "webpush", gone_webpush)
+
+    player.push_only(ChatMessagePayload(sender_username="alice", message="hi", chat_id=1))
+
+    assert done.wait(timeout=3), "background webpush never ran"
+    # Give the worker thread a moment to perform the removal after raising.
+    deadline = time.perf_counter() + 2
+    while player.push_subscriptions and time.perf_counter() < deadline:
+        time.sleep(0.01)
+    assert player.push_subscriptions == [], "expired (410) subscription was not pruned"


### PR DESCRIPTION
Closes #763.

## Problem

Sending a chat message took multiple seconds because `notify_subscription()` ran the blocking `webpush()` round-trip **inline, on the request thread**. Each notification fanned out one serial, synchronous HTTP call per subscriber, so the sender's response was held until every push completed — and with no timeout, a single slow or dead push service could hang it for seconds on its own. The same path also fires from `notify()` during gameplay, which is why the issue was noticeable "on load" too.

### Reproduced

Measured live (server processing time, network excluded):

| Endpoint | Work | Server time |
|---|---|---|
| `GET /chats` | read, no push | ~28 ms |
| `POST /chats/{id}:open` | in-memory mutation, no push | ~28 ms |
| `POST /chats/{id}/messages` | mutation **+ 1 blocking `webpush()`** | ~390 ms |

A 2-person DM already paid ~360 ms for one push. The General Chat has 96 participants — at ~360 ms each, serially, that's the multi-second case, and a hung endpoint makes it unbounded.

## Fix

Both changes land at `notify_subscription` — the single chokepoint shared by `push_only()` (chat), `notify()` (inbox), and the push-subscription router.

1. **Offload delivery off the critical path.** `notify_subscription` now does only cheap prep inline, then dispatches the blocking `webpush()` to a module-level `ThreadPoolExecutor` (fire-and-forget, best-effort) via a new `_deliver_push` helper. Callers return immediately; live clients still get the message in real time over the existing Socket.IO `display_new_message` event (push was always redundant with that for connected clients).
2. **Bound a hung push service** with `timeout=5` on `webpush()`.

410-pruning of expired subscriptions and the best-effort error handling are preserved (just moved into the worker). A thread pool with `submit()` is context-agnostic — works the same whether the caller is a sync request thread or the game-engine thread.

## Tests

New `tests/integration/test_push_notifications.py`:
- caller returns in <0.5s even when `webpush` sleeps 2s; delivery really runs in the background; `timeout=5` is applied.
- a 410 still prunes the dead subscription.

Full suite: 61 passed, ruff + pyright clean. (`test_server_runs` fails pre-existing/environmental — it hardcodes `Popen(["python", ...])`; identical failure with this change stashed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a performance regression where `notify_subscription()` called `webpush()` synchronously on the request thread, causing multi-second latency when sending chat messages (one serial HTTP round-trip per subscriber). The fix dispatches all blocking push deliveries to a module-level `ThreadPoolExecutor` and adds a 5-second per-call timeout, so callers return immediately.

- `notify_subscription` now submits work to `_PUSH_EXECUTOR` (16 workers, fire-and-forget) via a new `_deliver_push` method; 410-pruning and best-effort error handling are preserved inside the worker.
- Two integration tests verify the non-blocking contract and that 410 responses still prune dead subscriptions deterministically using `threading.Event` and a `_SignalingList`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the critical path change is minimal and well-bounded, and the existing error-handling/pruning behaviour is fully preserved in the background worker.

The change is small and targeted: `notify_subscription` no longer blocks the caller, and all pre-existing error paths (410 pruning, broad exception guard, logging) are intact in `_deliver_push`. The thread-safety analysis in the comments is accurate for CPython under the GIL. The two new tests give direct end-to-end coverage of the non-blocking contract and subscription pruning. No correctness issues were found on the production path.

No files require special attention; both changed files are straightforward and well-reasoned.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| energetica/database/player.py | Moves the blocking `webpush()` call off the request critical path by dispatching to a module-level `ThreadPoolExecutor`; adds a 5-second timeout per request; preserves 410-pruning and best-effort error handling in the background worker. |
| tests/integration/test_push_notifications.py | New integration tests verifying non-blocking dispatch and 410 subscription pruning. Uses `threading.Event` and `_SignalingList` for deterministic assertions; both tests are structurally sound with one minor timing caveat noted in the review. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `energetica/database/player.py`, line 478-480 ([link](https://github.com/felixvonsamson/energetica/blob/96126d2581cd19b8dbf2232b06fb92b36a51a07b/energetica/database/player.py#L478-L480)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cross-thread list mutation without a lock**

   `_deliver_push` mutates `self.push_subscriptions` (via `remove()`) from a background worker thread, while the subscription-registration router (`browser_notifications.py`) calls `push_subscriptions.append()` and `push_subscriptions.remove()` from HTTP request threads. In CPython, individual list operations are atomic under the GIL, and the `try/except ValueError` guard handles concurrent removes correctly. However, multi-step sequences such as "check membership, then remove" are not atomic across threads. If these combined sequences are ever added, silent data races would be possible. A `threading.Lock` scoped to this list would make the invariants explicit and safe across Python implementations.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: make 410-pruning test deterministi..."](https://github.com/felixvonsamson/energetica/commit/3854a9ad2492d01e868e4b642be72395e436e32b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37689467)</sub>

<!-- /greptile_comment -->