### PR TITLE
fix(infra): cache SPA shell as no-cache, hashed assets as immutable

### DIFF
--- a/scripts/infra/apache-instance.conf
+++ b/scripts/infra/apache-instance.conf
@@ -60,22 +60,25 @@
     # --- Caching ------------------------------------------------------------------
     # Content-hashed bundles (the filename IS a content hash, e.g. index-Dt2SAy2m.js) never
     # change in place, so cache them forever — a content change ships a new filename.
+    # "Header set" (not "always") is deliberate: it writes onsuccess only, so a 404 for a
+    # pruned/missing hashed asset is NOT given the year-long immutable directive (an "always"
+    # rule here would cache transient errors for a year). The /app/* SPA fallback is scoped
+    # below, so a missing /static/app/assets/* path returns a real 404, not the shell.
     <LocationMatch "^/static/app/assets/">
         Header set Cache-Control "public, max-age=31536000, immutable"
     </LocationMatch>
-    # The SPA shell must ALWAYS be revalidated. deploy-instance.sh rsyncs with --delete, so a
-    # deploy renames the hashed bundles and prunes the old ones; without this, index.html ships
-    # with no Cache-Control and browsers cache it heuristically — a returning visitor would keep
-    # loading a stale shell referencing now-404 bundles until that window lapsed. ETag makes the
-    # revalidation a cheap 304. Matches both /static/app/index.html and the FallbackResource
-    # /app/* routes (the resolved file is index.html in both cases). service-worker.js must also
-    # never be served stale, or a client can be pinned to an outdated worker.
-    <FilesMatch "\.html$">
+    # These stable-named entry points change between deploys and must ALWAYS be revalidated.
+    # deploy-instance.sh rsyncs with --delete, so a deploy renames the hashed bundles and prunes
+    # the old ones; without this they ship with no Cache-Control and browsers cache them
+    # heuristically — a returning visitor would keep loading a stale index.html referencing
+    # now-404 bundles until that window lapsed. ETag makes revalidation a cheap 304.
+    #   - *.html: the SPA shell — also the FallbackResource /app/* target (resolved file is
+    #     index.html in both cases).
+    #   - service-worker.js: never pin a client to an outdated worker.
+    #   - manifest.json: stable-named PWA manifest, may change between deploys.
+    <FilesMatch "^(.*\.html|service-worker\.js|manifest\.json)$">
         Header set Cache-Control "no-cache"
     </FilesMatch>
-    <Files "service-worker.js">
-        Header set Cache-Control "no-cache"
-    </Files>
 
     # --- Dynamic traffic proxied to uvicorn ---------------------------------------
     ProxyPreserveHost On

--- a/scripts/infra/apache-instance.conf
+++ b/scripts/infra/apache-instance.conf
@@ -57,6 +57,26 @@
         Options -Indexes
     </Directory>
 
+    # --- Caching ------------------------------------------------------------------
+    # Content-hashed bundles (the filename IS a content hash, e.g. index-Dt2SAy2m.js) never
+    # change in place, so cache them forever — a content change ships a new filename.
+    <LocationMatch "^/static/app/assets/">
+        Header set Cache-Control "public, max-age=31536000, immutable"
+    </LocationMatch>
+    # The SPA shell must ALWAYS be revalidated. deploy-instance.sh rsyncs with --delete, so a
+    # deploy renames the hashed bundles and prunes the old ones; without this, index.html ships
+    # with no Cache-Control and browsers cache it heuristically — a returning visitor would keep
+    # loading a stale shell referencing now-404 bundles until that window lapsed. ETag makes the
+    # revalidation a cheap 304. Matches both /static/app/index.html and the FallbackResource
+    # /app/* routes (the resolved file is index.html in both cases). service-worker.js must also
+    # never be served stale, or a client can be pinned to an outdated worker.
+    <FilesMatch "\.html$">
+        Header set Cache-Control "no-cache"
+    </FilesMatch>
+    <Files "service-worker.js">
+        Header set Cache-Control "no-cache"
+    </Files>
+
     # --- Dynamic traffic proxied to uvicorn ---------------------------------------
     ProxyPreserveHost On
     ProxyTimeout 300

--- a/scripts/infra/apache-main.conf
+++ b/scripts/infra/apache-main.conf
@@ -47,6 +47,9 @@
     # --- Caching ------------------------------------------------------------------
     # Content-hashed bundles (the filename IS a content hash, e.g. index.landing-LpslSca-.js)
     # never change in place, so cache them forever — a content change ships a new filename.
+    # "Header set" (not "always") is deliberate: it writes onsuccess only, so a 404 for a
+    # pruned/missing hashed asset is NOT given the year-long immutable directive (an "always"
+    # rule here would cache transient errors for a year).
     <LocationMatch "^/assets/">
         Header set Cache-Control "public, max-age=31536000, immutable"
     </LocationMatch>
@@ -55,8 +58,9 @@
     # with no Cache-Control and browsers cache it heuristically — a returning visitor would keep
     # loading a stale shell referencing now-404 bundles until that window lapsed. ETag makes the
     # revalidation a cheap 304. Matches both / and the FallbackResource SPA routes (the resolved
-    # file is index.html in both cases).
-    <FilesMatch "\.html$">
+    # file is index.html in both cases). The PWA manifest is likewise stable-named but changes
+    # between deploys, so it must revalidate too.
+    <FilesMatch "^(.*\.html|manifest\.json)$">
         Header set Cache-Control "no-cache"
     </FilesMatch>
 

--- a/scripts/infra/apache-main.conf
+++ b/scripts/infra/apache-main.conf
@@ -44,6 +44,22 @@
         Options -Indexes
     </Directory>
 
+    # --- Caching ------------------------------------------------------------------
+    # Content-hashed bundles (the filename IS a content hash, e.g. index.landing-LpslSca-.js)
+    # never change in place, so cache them forever — a content change ships a new filename.
+    <LocationMatch "^/assets/">
+        Header set Cache-Control "public, max-age=31536000, immutable"
+    </LocationMatch>
+    # The SPA shell must ALWAYS be revalidated. deploy-landing.sh rsyncs with --delete, so a
+    # deploy renames the hashed bundles and prunes the old ones; without this, index.html ships
+    # with no Cache-Control and browsers cache it heuristically — a returning visitor would keep
+    # loading a stale shell referencing now-404 bundles until that window lapsed. ETag makes the
+    # revalidation a cheap 304. Matches both / and the FallbackResource SPA routes (the resolved
+    # file is index.html in both cases).
+    <FilesMatch "\.html$">
+        Header set Cache-Control "no-cache"
+    </FilesMatch>
+
     # The instance manifest changes whenever an admin edits an instance.json (picked up on
     # the instance's next login/restart). A short TTL lets edits propagate within a minute
     # without explicit cache-busting. The per-instance fragments under instances/ are


### PR DESCRIPTION
## Problem

The apex landing and per-instance app Apache vhosts served `index.html` with **no `Cache-Control`**, so browsers cache the SPA shell *heuristically* (~10% of the time since `Last-Modified`). Because `deploy-{landing,instance}.sh` rsync with `--delete`, every deploy renames the content-hashed bundles and prunes the old ones — a returning visitor on a heuristically-cached shell keeps loading an `index.html` that references **now-404 bundles** until that window lapses.

During the `energetica-game` cutover this surfaced as a stale *pre-cutover app shell* booting on the apex (the `useAuth`/`isLoading` flash, then a redirect to the landing) instead of the new static landing bundle. The server was serving the correct landing bundle the whole time — the stale shell was replayed from the visitor's own browser cache.

## Fix

Both vhost templates now set explicit cache policy:

| Path | Policy | Why |
|---|---|---|
| `/assets/*` (landing), `/static/app/assets/*` (instance) | `public, max-age=31536000, immutable` | filename is a content hash → safe forever |
| `*.html` SPA shell (`<FilesMatch>`) | `no-cache` | always revalidate; ETag/`Last-Modified` keep it a cheap `304`. Covers FallbackResource SPA routes (resolved file is `index.html`) |
| instance `service-worker.js` | `no-cache` | never pin a client to a stale worker |

`instances.json` keeps its existing `max-age=60`. `setup-{landing,instance}.sh` need no change — they render these templates verbatim.

## Verified live (`-game` server)

Applied to the apex + `mar-27-2026` instance vhosts (backed up, `configtest` OK, graceful reload):

- apex `/`, `/landing-page` (fallback) → `no-cache` ✓
- apex `/assets/*.js` → `immutable` ✓; `/instances.json` → `max-age=60` (unchanged) ✓
- instance `/app/`, `/app/login` (fallback), `/static/app/index.html` → `no-cache` ✓
- instance `/static/app/assets/*.js` → `immutable` ✓; `/service-worker.js` → `no-cache` ✓
- conditional re-request of the shell returns **`304 Not Modified`**

The `-edu` server is not yet migrated to Apache static-serving and was left untouched.

## Notes

- **Self-healing, not retroactive:** stops *new* stale-shell incidents; anyone whose browser already cached the old shell clears on their existing heuristic window lapse (or a hard refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale-shell caching for the SPA landing and per-instance Apache vhosts by adding explicit `Cache-Control` headers, preventing browsers from heuristically caching `index.html` past a deploy that renames content-hashed bundles.

- **Content-hashed assets** (`/assets/*` on landing, `/static/app/assets/*` on instance) get `public, max-age=31536000, immutable` via `LocationMatch`; the intentional use of `Header set` (not `always`) is well-commented and prevents a transient 404 or 503 from being cached as immutable for a year.
- **Stable-named entry points** (`*.html`, `service-worker.js`, `manifest.json`) get `no-cache` via `FilesMatch`, ensuring revalidation on every visit while still allowing the server to respond with a cheap `304 Not Modified` via ETag.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two config templates only add Cache-Control headers and leave all routing, proxy, and SSL directives untouched.

The change is narrowly scoped to cache policy: correct LocationMatch patterns for hashed assets, correct FilesMatch patterns for stable-named files, and the deliberate Header set (not always) is clearly explained in comments. FilesMatch correctly applies to the physical file resolved by FallbackResource, so SPA shell routes also get no-cache. No routing, auth, or proxy logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/infra/apache-instance.conf | Adds explicit cache headers for content-hashed assets (immutable) and stable-named files (no-cache); manifest.json is now correctly covered alongside html and service-worker.js. |
| scripts/infra/apache-main.conf | Adds explicit cache headers for landing assets (immutable) and the SPA shell/manifest (no-cache); existing instances.json max-age=60 rule is unaffected. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    REQ([Incoming Request]) --> MATCH{URL matches?}

    MATCH -->|"/static/app/assets/*" instance vhost| IM1["LocationMatch\nCache-Control: public, max-age=31536000, immutable\n(Header set – 2xx only)"]
    MATCH -->|"/assets/*" landing vhost| IM2["LocationMatch\nCache-Control: public, max-age=31536000, immutable\n(Header set – 2xx only)"]

    MATCH -->|"*.html / service-worker.js / manifest.json"| NC["FilesMatch\nCache-Control: no-cache\n(ETag → cheap 304)"]

    MATCH -->|"/instances.json /instances/*.json"| TTL["LocationMatch\nCache-Control: max-age=60\n(unchanged)"]

    MATCH -->|"/app/* (no file)" instance vhost| FB1["FallbackResource → index.html\n(FilesMatch no-cache applies)"]
    MATCH -->|"/landing-page etc (no file)" landing vhost| FB2["FallbackResource → index.html\n(FilesMatch no-cache applies)"]

    FB1 --> NC
    FB2 --> NC

    IM1 --> RESP([Response])
    IM2 --> RESP
    NC --> RESP
    TTL --> RESP
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    REQ([Incoming Request]) --> MATCH{URL matches?}

    MATCH -->|"/static/app/assets/*" instance vhost| IM1["LocationMatch\nCache-Control: public, max-age=31536000, immutable\n(Header set – 2xx only)"]
    MATCH -->|"/assets/*" landing vhost| IM2["LocationMatch\nCache-Control: public, max-age=31536000, immutable\n(Header set – 2xx only)"]

    MATCH -->|"*.html / service-worker.js / manifest.json"| NC["FilesMatch\nCache-Control: no-cache\n(ETag → cheap 304)"]

    MATCH -->|"/instances.json /instances/*.json"| TTL["LocationMatch\nCache-Control: max-age=60\n(unchanged)"]

    MATCH -->|"/app/* (no file)" instance vhost| FB1["FallbackResource → index.html\n(FilesMatch no-cache applies)"]
    MATCH -->|"/landing-page etc (no file)" landing vhost| FB2["FallbackResource → index.html\n(FilesMatch no-cache applies)"]

    FB1 --> NC
    FB2 --> NC

    IM1 --> RESP([Response])
    IM2 --> RESP
    NC --> RESP
    TTL --> RESP
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/infra/apache-instance.conf`, line 50-53 ([link](https://github.com/felixvonsamson/energetica/blob/0286b04d82682b518f4cd278a6a392585f8c9089/scripts/infra/apache-instance.conf#L50-L53)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`manifest.json` left without explicit caching**

   `/manifest.json` is aliased to a non-hashed file (`static/app/manifest.json`) that won't match the `LocationMatch "^/static/app/assets/"` (wrong URL prefix) or `FilesMatch "\.html$"` blocks added in this PR. Browsers will therefore cache it heuristically — the same root cause being fixed here for `index.html`. If the PWA manifest is updated (new icon path, changed `start_url`, etc.) a returning visitor could see stale PWA metadata until the heuristic window lapses. Adding a `<Files "manifest.json">` block with `Cache-Control: no-cache` alongside the `service-worker.js` rule would close this gap.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["review: revalidate manifest.json; docume..."](https://github.com/felixvonsamson/energetica/commit/e4379b0d39509a84db05c92a4c4be33fa777fd77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40284615)</sub>

<!-- /greptile_comment -->