### PR TITLE
feat: highlight current player's name in community lists

### DIFF
--- a/frontend/src/components/electricity-markets/market-detail-dialog.tsx
+++ b/frontend/src/components/electricity-markets/market-detail-dialog.tsx
@@ -192,7 +192,12 @@ function MarketContent({
                         {market.member_ids.map((memberId) => (
                             <div
                                 key={memberId}
-                                className="px-3 py-2 bg-card rounded text-sm"
+                                className={cn(
+                                    "px-3 py-2 rounded text-sm",
+                                    memberId === currentPlayerId
+                                        ? "player-self-card"
+                                        : "bg-card",
+                                )}
                             >
                                 {playerMap[memberId] ? (
                                     <PlayerName

--- a/frontend/src/components/electricity-markets/market-detail-dialog.tsx
+++ b/frontend/src/components/electricity-markets/market-detail-dialog.tsx
@@ -13,6 +13,7 @@ import { Duration } from "@/components/ui/duration";
 import { PlayerName } from "@/components/ui/player-name";
 import { TypographyH2, TypographyH3 } from "@/components/ui/typography";
 import { useLatestChartDataSlice } from "@/hooks/use-charts";
+import { useCurrentPlayer } from "@/hooks/use-current-player";
 import { useMyMarket } from "@/hooks/use-electricity-markets";
 import { useGameTick } from "@/hooks/use-game-tick";
 import { useLastDefined } from "@/hooks/use-last-defined";
@@ -62,6 +63,7 @@ function MarketContent({
     onJoin: (market: ElectricityMarket) => void;
 }) {
     const currentMarket = useMyMarket();
+    const { playerId: currentPlayerId } = useCurrentPlayer();
     const { currentTick } = useGameTick();
     const { data: marketData } = useLatestChartDataSlice({
         chartType: "market-clearing",
@@ -193,7 +195,10 @@ function MarketContent({
                                 className="px-3 py-2 bg-card rounded text-sm"
                             >
                                 {playerMap[memberId] ? (
-                                    <PlayerName player={playerMap[memberId]} />
+                                    <PlayerName
+                                        player={playerMap[memberId]}
+                                        isSelf={memberId === currentPlayerId}
+                                    />
                                 ) : (
                                     `Player ${memberId}`
                                 )}

--- a/frontend/src/components/ui/player-name.tsx
+++ b/frontend/src/components/ui/player-name.tsx
@@ -41,14 +41,38 @@ interface PlayerNameProps {
     dotClassName?: string;
 }
 
-export function PlayerName({ player, isSelf, className, dotClassName }: PlayerNameProps) {
+export function PlayerName({
+    player,
+    isSelf,
+    className,
+    dotClassName,
+}: PlayerNameProps) {
+    return (
+        <span className={cn("inline-flex items-center gap-1.5", className)}>
+            <ActivityDot
+                status={player.activity_status}
+                className={dotClassName}
+            />
+            {player.username}
+            {isSelf && <SelfBadge />}
+        </span>
+    );
+}
+
+/**
+ * "You" tag shown after the current player's name. The red outline matches the
+ * map tile / row-rail hue so identity reads the same across the app.
+ */
+function SelfBadge() {
     return (
         <span
-            className={cn("inline-flex items-center gap-1.5", isSelf && "font-semibold", className)}
-            style={isSelf ? { color: "var(--player-self-color)" } : undefined}
+            className="rounded-full border px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none tracking-wide"
+            style={{
+                color: "var(--player-self-color)",
+                borderColor: "var(--player-self-color)",
+            }}
         >
-            <ActivityDot status={player.activity_status} className={dotClassName} />
-            {player.username}
+            You
         </span>
     );
 }
@@ -60,10 +84,22 @@ interface PlayerNameByIdProps {
     dotClassName?: string;
 }
 
-export function PlayerNameById({ playerId, isSelf, className, dotClassName }: PlayerNameByIdProps) {
+export function PlayerNameById({
+    playerId,
+    isSelf,
+    className,
+    dotClassName,
+}: PlayerNameByIdProps) {
     const player = usePlayer(playerId);
 
     if (!player) return null;
 
-    return <PlayerName player={player} isSelf={isSelf} className={className} dotClassName={dotClassName} />;
+    return (
+        <PlayerName
+            player={player}
+            isSelf={isSelf}
+            className={className}
+            dotClassName={dotClassName}
+        />
+    );
 }

--- a/frontend/src/components/ui/player-name.tsx
+++ b/frontend/src/components/ui/player-name.tsx
@@ -36,13 +36,17 @@ export function ActivityDot({ status, className }: ActivityDotProps) {
 
 interface PlayerNameProps {
     player: Player;
+    isSelf?: boolean;
     className?: string;
     dotClassName?: string;
 }
 
-export function PlayerName({ player, className, dotClassName }: PlayerNameProps) {
+export function PlayerName({ player, isSelf, className, dotClassName }: PlayerNameProps) {
     return (
-        <span className={cn("inline-flex items-center gap-1.5", className)}>
+        <span
+            className={cn("inline-flex items-center gap-1.5", isSelf && "font-semibold", className)}
+            style={isSelf ? { color: "var(--player-self-color)" } : undefined}
+        >
             <ActivityDot status={player.activity_status} className={dotClassName} />
             {player.username}
         </span>
@@ -51,14 +55,15 @@ export function PlayerName({ player, className, dotClassName }: PlayerNameProps)
 
 interface PlayerNameByIdProps {
     playerId: number;
+    isSelf?: boolean;
     className?: string;
     dotClassName?: string;
 }
 
-export function PlayerNameById({ playerId, className, dotClassName }: PlayerNameByIdProps) {
+export function PlayerNameById({ playerId, isSelf, className, dotClassName }: PlayerNameByIdProps) {
     const player = usePlayer(playerId);
 
     if (!player) return null;
 
-    return <PlayerName player={player} className={className} dotClassName={dotClassName} />;
+    return <PlayerName player={player} isSelf={isSelf} className={className} dotClassName={dotClassName} />;
 }

--- a/frontend/src/routes/app/community/leaderboards.tsx
+++ b/frontend/src/routes/app/community/leaderboards.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { GameLayout } from "@/components/layout/game-layout";
 import { PageCard, CardContent, Money } from "@/components/ui";
 import { PlayerName } from "@/components/ui/player-name";
+import { useCurrentPlayer } from "@/hooks/use-current-player";
 import { useLeaderboards } from "@/hooks/use-leaderboards";
 import { usePlayerMap } from "@/hooks/use-players";
 import { formatPower, formatEnergy, formatMass } from "@/lib/format-utils";
@@ -67,6 +68,7 @@ function LeaderboardsContent() {
 
     const { data: leaderboards, isLoading, error } = useLeaderboards();
     const playerMap = usePlayerMap();
+    const { playerId: currentPlayerId } = useCurrentPlayer();
     if (isLoading) {
         return (
             <div className="p-4 md:p-8 text-center">
@@ -598,10 +600,11 @@ function LeaderboardsContent() {
 
     const renderTableRow = (row: PlayerDetailStats) => {
         const player = playerMap?.[row.player_id];
+        const isSelf = row.player_id === currentPlayerId;
         const commonCells = (
             <>
                 <td className="py-3 px-4">
-                    {player ? <PlayerName player={player} /> : row.username}
+                    {player ? <PlayerName player={player} isSelf={isSelf} /> : row.username}
                 </td>
                 <td className="py-3 px-4">{row.general.network_name || "-"}</td>
             </>
@@ -670,7 +673,7 @@ function LeaderboardsContent() {
                 return (
                     <>
                         <td className="py-3 px-4">
-                            {player ? <PlayerName player={player} /> : row.username}
+                            {player ? <PlayerName player={player} isSelf={isSelf} /> : row.username}
                         </td>
                         <td className="py-3 px-4 text-right">
                             {row.technologies.total_technologies}

--- a/frontend/src/routes/app/community/leaderboards.tsx
+++ b/frontend/src/routes/app/community/leaderboards.tsx
@@ -10,6 +10,7 @@ import { useCurrentPlayer } from "@/hooks/use-current-player";
 import { useLeaderboards } from "@/hooks/use-leaderboards";
 import { usePlayerMap } from "@/hooks/use-players";
 import { formatPower, formatEnergy, formatMass } from "@/lib/format-utils";
+import { cn } from "@/lib/utils";
 import type { PlayerDetailStats } from "@/types/leaderboards";
 
 function LeaderboardsHelp() {
@@ -205,9 +206,7 @@ function LeaderboardsContent() {
                         </th>
                         <th
                             className="py-3 px-4 text-right font-semibold cursor-pointer hover:bg-tan-green/80 dark:hover:bg-card transition-colors"
-                            onClick={() =>
-                                handleSort("general.total_projects")
-                            }
+                            onClick={() => handleSort("general.total_projects")}
                         >
                             Projects
                             {getSortIndicator("general.total_projects")}
@@ -604,7 +603,11 @@ function LeaderboardsContent() {
         const commonCells = (
             <>
                 <td className="py-3 px-4">
-                    {player ? <PlayerName player={player} isSelf={isSelf} /> : row.username}
+                    {player ? (
+                        <PlayerName player={player} isSelf={isSelf} />
+                    ) : (
+                        row.username
+                    )}
                 </td>
                 <td className="py-3 px-4">{row.general.network_name || "-"}</td>
             </>
@@ -673,7 +676,11 @@ function LeaderboardsContent() {
                 return (
                     <>
                         <td className="py-3 px-4">
-                            {player ? <PlayerName player={player} isSelf={isSelf} /> : row.username}
+                            {player ? (
+                                <PlayerName player={player} isSelf={isSelf} />
+                            ) : (
+                                row.username
+                            )}
                         </td>
                         <td className="py-3 px-4 text-right">
                             {row.technologies.total_technologies}
@@ -795,7 +802,12 @@ function LeaderboardsContent() {
                             {sortedRows.map((row) => (
                                 <tr
                                     key={row.player_id}
-                                    className="border-b border-gray-200 dark:border-gray-700 hover:bg-tan-green/20 dark:hover:bg-muted/30 transition-colors"
+                                    className={cn(
+                                        "border-b border-gray-200 dark:border-gray-700 transition-colors",
+                                        row.player_id === currentPlayerId
+                                            ? "player-self-row"
+                                            : "hover:bg-tan-green/20 dark:hover:bg-muted/30",
+                                    )}
                                 >
                                     {renderTableRow(row)}
                                 </tr>

--- a/frontend/src/routes/app/community/resource-market.tsx
+++ b/frontend/src/routes/app/community/resource-market.tsx
@@ -15,6 +15,7 @@ import { CreateAskDialog } from "@/components/resource-market/create-ask-dialog"
 import { PurchaseDialog } from "@/components/resource-market/purchase-dialog";
 import { Button, CardContent, Money, PageCard } from "@/components/ui";
 import { DualDuration } from "@/components/ui/duration";
+import { PlayerName } from "@/components/ui/player-name";
 import { useCurrentPlayer } from "@/hooks/use-current-player";
 import { usePlayerResources } from "@/hooks/use-player-resources";
 import { usePlayerMap } from "@/hooks/use-players";
@@ -434,7 +435,9 @@ function AskRow({
                     ask.resource_type}
             </td>
             <td className="py-3 px-4 text-left">
-                {playerMap?.[ask.seller_id]?.username ?? "—"}
+                {playerMap?.[ask.seller_id] ? (
+                    <PlayerName player={playerMap[ask.seller_id]!} isSelf={isOwnAsk} />
+                ) : "—"}
             </td>
             <td className="py-3 px-4 text-right font-mono">
                 {formatMass(ask.quantity)}

--- a/frontend/src/routes/app/community/resource-market.tsx
+++ b/frontend/src/routes/app/community/resource-market.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/hooks/use-resource-market";
 import { useShipments } from "@/hooks/use-shipments";
 import { formatMass } from "@/lib/format-utils";
+import { cn } from "@/lib/utils";
 import { Player } from "@/types/players";
 import {
     ResourceType,
@@ -428,7 +429,12 @@ function AskRow({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="border-b border-border/30 hover:bg-tan-green/20 dark:hover:bg-muted/30 transition-colors"
+            className={cn(
+                "border-b border-border/30 transition-colors",
+                isOwnAsk
+                    ? "player-self-row"
+                    : "hover:bg-tan-green/20 dark:hover:bg-muted/30",
+            )}
         >
             <td className="py-3 px-4 font-medium capitalize">
                 {RESOURCE_LABELS[ask.resource_type as ResourceType] ||
@@ -436,8 +442,13 @@ function AskRow({
             </td>
             <td className="py-3 px-4 text-left">
                 {playerMap?.[ask.seller_id] ? (
-                    <PlayerName player={playerMap[ask.seller_id]!} isSelf={isOwnAsk} />
-                ) : "—"}
+                    <PlayerName
+                        player={playerMap[ask.seller_id]!}
+                        isSelf={isOwnAsk}
+                    />
+                ) : (
+                    "—"
+                )}
             </td>
             <td className="py-3 px-4 text-right font-mono">
                 {formatMass(ask.quantity)}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -326,6 +326,8 @@
         --map-tile-current-player: hsl(0, 64%, 47%);
         --map-tile-other-player: var(--color-pine-500);
         --map-tile-vacant: var(--color-bone-100);
+
+        --player-self-color: hsl(0, 64%, 38%);
     }
 
     /* ============================================
@@ -519,6 +521,8 @@
         --map-tile-current-player: hsl(0, 97%, 23%);
         --map-tile-other-player: var(--color-pine-800);
         --map-tile-vacant: var(--color-bone-300);
+
+        --player-self-color: hsl(0, 70%, 62%);
     }
 
     html,

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -327,7 +327,10 @@
         --map-tile-other-player: var(--color-pine-500);
         --map-tile-vacant: var(--color-bone-100);
 
+        /* Current-player identity (matches the map tile hue) */
         --player-self-color: hsl(0, 64%, 38%);
+        --player-self-row-bg: hsl(0, 72%, 50%, 0.07);
+        --player-self-row-hover-bg: hsl(0, 72%, 50%, 0.12);
     }
 
     /* ============================================
@@ -522,7 +525,10 @@
         --map-tile-other-player: var(--color-pine-800);
         --map-tile-vacant: var(--color-bone-300);
 
+        /* Current-player identity (matches the map tile hue) */
         --player-self-color: hsl(0, 70%, 62%);
+        --player-self-row-bg: hsl(0, 80%, 62%, 0.13);
+        --player-self-row-hover-bg: hsl(0, 80%, 62%, 0.2);
     }
 
     html,
@@ -687,4 +693,21 @@
 body.has-topbar [data-slot="sidebar-container"] {
     top: var(--topbar-height);
     height: calc(100svh - var(--topbar-height));
+}
+
+/* Current-player highlight. Outside any @layer so the tint wins over the
+   table's hover:bg-* utilities. The accent rail rides the first cell of the
+   row (a tinted band + a left rail reads as "this is you", not "bad value"). */
+.player-self-row {
+    background-color: var(--player-self-row-bg);
+}
+.player-self-row:hover {
+    background-color: var(--player-self-row-hover-bg);
+}
+.player-self-row > td:first-child {
+    box-shadow: inset 3px 0 0 0 var(--player-self-color);
+}
+.player-self-card {
+    background-color: var(--player-self-row-bg);
+    box-shadow: inset 3px 0 0 0 var(--player-self-color);
 }


### PR DESCRIPTION
I was not able to test this locally as the local frontend is currently not working.

Closes #767

## Summary

- Adds `--player-self-color` CSS variable (a red matching the map tile hue: `hsl(0, 64%, 38%)` light / `hsl(0, 70%, 62%)` dark) to `global.css`
- Adds `isSelf?: boolean` prop to `PlayerName` / `PlayerNameById` — applies the color and `font-semibold` when true
- Wires up `isSelf` in:
  - **Leaderboards** — all category tabs (common cells + technologies-only cell)
  - **Resource Market** — seller column (also migrated from raw `username` string to `<PlayerName>`)
  - **Electricity Market dialog** — Market Members list

## Test plan

- [ ] Open leaderboards and confirm your row's username is highlighted in red/bold across all category tabs
- [ ] Open resource market and confirm your listings show your name highlighted
- [ ] Open an electricity market you belong to and confirm your name is highlighted in the members list
- [ ] Verify other players' names are unaffected
- [ ] Check both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR highlights the current player's name across community-facing views (leaderboards, resource market, electricity market members) using a "You" badge and a red left-rail row/card tint that matches the existing map tile hue.

- Adds `--player-self-color`, `--player-self-row-bg`, and `--player-self-row-hover-bg` CSS variables in both light and dark theme blocks, then wires `.player-self-row` / `.player-self-card` utility classes outside any `@layer` so they outrank Tailwind hover utilities.
- Extends `PlayerName` and `PlayerNameById` with an optional `isSelf` prop that, when true, appends a small red-outlined "You" badge after the username.
- Applies `isSelf` and the corresponding row/card CSS classes in all three callsites (`leaderboards.tsx`, `resource-market.tsx`, `market-detail-dialog.tsx`); also migrates the resource-market seller column from a bare `username` string to a full `<PlayerName>` component.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive UI decoration with no logic mutations or data-path alterations.

All three callsites correctly derive isSelf from useCurrentPlayer and propagate it consistently. CSS specificity is handled deliberately by placing .player-self-row and .player-self-card outside any @layer. No existing behavior is removed; the hover styles are replaced only for the current player's own rows. The migration from a bare username string to PlayerName in the resource-market seller column is a net improvement.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/styles/global.css | Adds three CSS custom properties for both light and dark themes, and two plain-class rules (.player-self-row, .player-self-card) outside any @layer to guarantee precedence over Tailwind utilities. |
| frontend/src/components/ui/player-name.tsx | Adds optional isSelf prop to PlayerName and PlayerNameById; when true, appends a SelfBadge ("You") with the red CSS-variable color. PlayerNameById correctly threads the prop through to PlayerName. |
| frontend/src/routes/app/community/leaderboards.tsx | Wires isSelf into all category cells (via commonCells and the technologies-only cell) and applies the player-self-row CSS class to the tr. |
| frontend/src/routes/app/community/resource-market.tsx | Migrates seller column from bare username string to PlayerName with isSelf, and applies player-self-row on the motion.tr. |
| frontend/src/components/electricity-markets/market-detail-dialog.tsx | Adds useCurrentPlayer hook to obtain currentPlayerId, swaps bg-card for player-self-card on the member's div, and passes isSelf to PlayerName. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useCurrentPlayer\nplayerId] --> B{row.player_id\n=== currentPlayerId?}
    B -- Yes --> C[isSelf = true]
    B -- No --> D[isSelf = false]
    C --> E[Apply player-self-row\nor player-self-card CSS]
    C --> F[PlayerName isSelf=true]
    D --> G[Apply hover:bg-tan-green\ndark:hover:bg-muted CSS]
    D --> H[PlayerName isSelf=false]
    F --> I[Render username + SelfBadge]
    H --> J[Render username only]
    I --> K[SelfBadge: border + text\nin --player-self-color red]
    E --> L[Row background tint\n+ inset left red rail]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useCurrentPlayer\nplayerId] --> B{row.player_id\n=== currentPlayerId?}
    B -- Yes --> C[isSelf = true]
    B -- No --> D[isSelf = false]
    C --> E[Apply player-self-row\nor player-self-card CSS]
    C --> F[PlayerName isSelf=true]
    D --> G[Apply hover:bg-tan-green\ndark:hover:bg-muted CSS]
    D --> H[PlayerName isSelf=false]
    F --> I[Render username + SelfBadge]
    H --> J[Render username only]
    I --> K[SelfBadge: border + text\nin --player-self-color red]
    E --> L[Row background tint\n+ inset left red rail]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["feat: promote current-player highlight f..."](https://github.com/felixvonsamson/energetica/commit/524fd1455e4e3373202d1d329ed3f5c6e621648d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40579965)</sub>

<!-- /greptile_comment -->