### PR TITLE
fix: reclaim local & against-prod dev workflows broken by the multi-instance refactor

### DIFF
--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -55,7 +55,7 @@ To authenticate via API:
 
 **Middleware:** `energetica/routers/__init__.py`
 
--   Unauthenticated GET requests that return 401 are redirected to `/app/login`
+-   The API only ever speaks JSON — it never issues browser redirects. An unauthenticated request returns a `401` (JSON) from the endpoint; the SPA owns the redirect to `/app/login` client-side (`frontend/src/routes/__root.tsx`, driven by `/auth/me`). After the Phase 5 cutover FastAPI serves no HTML, so a server-side redirect could only land a `fetch` client on Apache's (or, in dev, Vite's) `index.html` — the `Unexpected token '<', "<!DOCTYPE"...` break.
 -   POST/PUT/PATCH/DELETE requests require authentication (enforced per-endpoint)
 
 **Authentication enforcement:** Endpoints use FastAPI `Depends()` to require authentication:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -24,16 +24,22 @@ source .venv/bin/activate && python main.py --env dev
 
 ### Run the Frontend
 
-Use existing backend:
+Against the live production game backend (auto-discovers the current instance — see below):
 
 ```bash
-VITE_BACKEND_URL=https://energetica-game.org bun dev
+bun run dev:game
 ```
 
-Use http://localhost:8000 as backend:
+Against a local backend (`http://localhost:8000`):
 
 ```bash
 bun dev
+```
+
+Against one specific backend, overriding everything:
+
+```bash
+VITE_BACKEND_URL=https://mar-27-2026.energetica-game.org bun dev
 ```
 
 Or configure `/frontend/.env.example`.
@@ -152,9 +158,26 @@ cd frontend
 # Connect to local backend (default)
 bun dev
 
-# OR connect to production backend
-VITE_BACKEND_URL=https://energetica-game.org bun dev
+# OR connect to the live production game (dev:edu / dev:ethz for those deployments)
+bun run dev:game
 ```
+
+#### How `dev:game` finds the backend
+
+`dev:game` / `dev:edu` / `dev:ethz` run `vite --mode {game,edu,ethz}`, which loads
+`frontend/.env.{mode}`. After the multi-instance cutover the **apex** (`energetica-game.org`)
+serves only the static landing — the game backend lives on a per-season instance **subdomain**
+(`{slug}.energetica-game.org`) that is created and deleted over time. Pointing a dev mode at the
+apex would proxy `/api` into the landing's `index.html` and break with
+`Unexpected token '<', "<!DOCTYPE"...`.
+
+So each `.env.{mode}` sets only the **stable apex** (`VITE_APEX_DOMAIN=energetica-game.org`), and
+`vite.config.ts` discovers the current instance at startup by fetching the apex's public
+`instances.json` manifest and taking the newest advertised slug — the same ordering the landing's
+picker uses. No slug is ever hardcoded; it self-updates when the season's instance turns over. To
+target a specific instance (or a local backend) instead, set `VITE_BACKEND_URL` explicitly — it
+overrides the apex discovery. If the manifest is empty or unreachable, the dev server fails with an
+actionable message rather than silently falling back.
 
 ## Quick Reference
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -196,6 +196,20 @@ python main.py --env dev --run_init_test_players
 python main.py --env dev --rm_instance
 ```
 
+#### Local State & Resetting
+
+A dev instance keeps all of its state under `instance/` (gitignored): the engine pickle
+(`engine_data.pck`), the session signing key (`secret_key.txt`), and the server-wide accounts
+store (`accounts.db`). In production these paths are set explicitly via the systemd unit (e.g.
+`ENERGETICA_ACCOUNTS_DB_PATH=/var/lib/energetica/accounts.db`); locally the code defaults to
+`instance/` so `python main.py --env dev` runs with **zero host configuration**.
+
+`--rm_instance` wipes the whole `instance/` folder, so the pickle and `accounts.db` are reset
+together (the freshly-printed `instance/admin_accounts.txt` password stays in sync). **If your
+local instance predates server-wide accounts** (a pickle whose `User`s have no `account_id`,
+which raises a `RuntimeError` on startup), reset it with `--rm_instance` — the production
+`scripts/migrate-to-server-accounts.py` is not needed for disposable local data.
+
 ## Next Steps
 
 Places to get started with in the documentation:

--- a/energetica/accounts/db.py
+++ b/energetica/accounts/db.py
@@ -12,7 +12,13 @@ from typing import Iterator
 
 from energetica.utils.auth import check_password_hash
 
-_DEFAULT_DB_PATH = "/var/lib/energetica/accounts.db"
+# The default targets local dev: a repo-relative path under instance/ (the per-instance
+# working dir, alongside engine_data.pck and secret_key.txt), so `python main.py --env dev`
+# runs with zero host configuration and `--rm_instance` wipes credentials and pickle in
+# lockstep. Production never hits this default — the systemd unit sets
+# ENERGETICA_ACCOUNTS_DB_PATH=/var/lib/energetica/accounts.db explicitly
+# (scripts/infra/energetica.service). Keep the default dev-friendly; let prod be explicit.
+_DEFAULT_DB_PATH = "instance/accounts.db"
 _ENV_VAR = "ENERGETICA_ACCOUNTS_DB_PATH"
 
 _initialised_paths: set[Path] = set()

--- a/energetica/routers/__init__.py
+++ b/energetica/routers/__init__.py
@@ -7,7 +7,7 @@ from typing import Awaitable, Callable, cast
 from fastapi import FastAPI, Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import JSONResponse
 
 from energetica.game_error import GameError
 from energetica.globals import engine
@@ -112,8 +112,6 @@ def setup_routes(app: FastAPI):
                 print(f"{request.method} {request.url.path}")
                 print(f"content-type: {request.headers.get('content-type')}")
                 raise e
-            if get_request and response.status_code == status.HTTP_401_UNAUTHORIZED and "/auth/me" not in path:
-                return RedirectResponse(url="/app/login", status_code=status.HTTP_303_SEE_OTHER)
             return response
 
         start = datetime.now()

--- a/frontend/.env.edu
+++ b/frontend/.env.edu
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=https://energetica-edu.org
+VITE_APEX_DOMAIN=energetica-edu.org

--- a/frontend/.env.ethz
+++ b/frontend/.env.ethz
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=https://energetica.ethz.ch
+VITE_APEX_DOMAIN=energetica.ethz.ch

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,8 +1,18 @@
 # Backend Configuration
-# Set this to connect to a different backend (e.g., energetica-game.org)
-# Leave empty or unset to use the default local backend (localhost:8000)
+#
+# The dev server picks its backend in this order (see frontend/vite.config.ts):
+#
+# 1. VITE_BACKEND_URL — an explicit override, always wins. Point it at a specific
+#    instance subdomain, or a local backend. Leave empty to fall through.
+# 2. VITE_APEX_DOMAIN — a deployment's stable apex. The game backend lives on a
+#    rotating instance subdomain ({slug}.{apex}), never the apex (which is the
+#    static landing), so the dev server discovers the current slug at startup from
+#    https://{apex}/instances.json. This is what `bun run dev:game` / `dev:edu` /
+#    `dev:ethz` use (see frontend/.env.game etc.) — no slug is ever hardcoded.
+# 3. Neither set — the local backend on http://localhost:8000 (plain `bun dev`).
 VITE_BACKEND_URL=
 
 # Examples:
-# VITE_BACKEND_URL=https://energetica-game.org
-# VITE_BACKEND_URL=http://localhost:8000
+# VITE_BACKEND_URL=https://mar-27-2026.energetica-game.org   # a specific live instance
+# VITE_BACKEND_URL=http://localhost:8000                     # local backend
+# VITE_APEX_DOMAIN=energetica-game.org                       # discover the live instance

--- a/frontend/.env.game
+++ b/frontend/.env.game
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=https://energetica-game.org
+VITE_APEX_DOMAIN=energetica-game.org

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,10 +10,74 @@ import rehypeSlug from "rehype-slug";
 import svgr from "vite-plugin-svgr";
 import path from "path";
 
-export default defineConfig(({ mode, command }) => {
+interface InstanceManifest {
+    instances?: { slug?: string }[];
+}
+
+/**
+ * Resolve which backend the dev server proxies /api, /socket.io and /static to.
+ *
+ * Precedence:
+ *
+ * 1. An explicit VITE_BACKEND_URL always wins (a specific instance, a local
+ *    backend, CI).
+ * 2. A per-deployment mode (dev:game / dev:edu / dev:ethz) sets the stable
+ *    VITE_APEX_DOMAIN. The game backend lives on a rotating instance
+ *    _subdomain_ ({slug}.{apex}), never the apex — which post-cutover is the
+ *    pure-static landing, whose FallbackResource answers every path (so
+ *    proxying /api there returns index.html → "Unexpected token '<'"). We
+ *    discover the current slug at dev-server startup from the apex's public
+ *    instances.json manifest (newest advertised first — the ordering the
+ *    landing's picker uses), so no slug is ever baked into the repo and it
+ *    self-updates when the season's instance turns over.
+ * 3. Otherwise the local backend on :8000.
+ *
+ * Only runs for `serve`: a production `build` also sets VITE_APEX_DOMAIN but
+ * must never reach out to the live manifest, and its proxy/backend config is
+ * unused anyway.
+ */
+async function resolveBackendUrl(
+    command: "serve" | "build",
+    env: Record<string, string>,
+): Promise<string> {
+    if (env.VITE_BACKEND_URL) return env.VITE_BACKEND_URL;
+
+    const apex = env.VITE_APEX_DOMAIN;
+    if (command === "serve" && apex) {
+        const manifestUrl = `https://${apex}/instances.json`;
+        let manifest: InstanceManifest;
+        try {
+            const res = await fetch(manifestUrl, {
+                signal: AbortSignal.timeout(5000),
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            manifest = (await res.json()) as InstanceManifest;
+        } catch (cause) {
+            throw new Error(
+                `[vite] could not fetch ${manifestUrl} to discover the live instance — ` +
+                    `set VITE_BACKEND_URL explicitly to target a backend. (${String(cause)})`,
+            );
+        }
+        const slug = manifest.instances?.[0]?.slug;
+        if (!slug) {
+            throw new Error(
+                `[vite] no advertised instance at ${apex} (empty instances.json) — ` +
+                    `set VITE_BACKEND_URL explicitly to target a backend.`,
+            );
+        }
+        const url = `https://${slug}.${apex}`;
+        console.info(`[vite] apex ${apex} → live instance "${slug}" (${url})`);
+        return url;
+    }
+
+    return "http://localhost:8000";
+}
+
+export default defineConfig(async ({ mode, command }) => {
     const env = loadEnv(mode, process.cwd(), "");
-    // Backend URL from environment variable, fallback to local development server
-    const backendUrl = env.VITE_BACKEND_URL || "http://localhost:8000";
+    // Backend the dev server proxies to: explicit override, else slug discovered from the
+    // mode's apex manifest, else local :8000. See resolveBackendUrl above.
+    const backendUrl = await resolveBackendUrl(command, env);
     const wsUrl = backendUrl.replace(/^http/, "ws");
 
     return {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig, loadEnv, type Plugin, type ProxyOptions } from "vite";
 import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
@@ -73,6 +73,45 @@ async function resolveBackendUrl(
     return "http://localhost:8000";
 }
 
+/**
+ * Dev-only: mirror production's Apache `RedirectMatch ^/$ → /app/`. The app bundle only routes
+ * `/app/*` (there is no `/` route), so without this the bare root 404s in dev — in prod Apache
+ * handles it. `apply: "serve"` keeps it out of builds.
+ */
+const devRootRedirect: Plugin = {
+    name: "dev-root-redirect",
+    apply: "serve",
+    configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+            if (req.url === "/") {
+                res.writeHead(302, { Location: "/app/" });
+                res.end();
+                return;
+            }
+            next();
+        });
+    },
+};
+
+/**
+ * Strip `Secure` and `Domain` from `Set-Cookie` on proxied responses so a session cookie minted
+ * by an HTTPS backend round-trips through the `http://localhost` dev origin. Without this, the
+ * browser won't persist the fresh `Secure` cookie over plain-HTTP localhost (so a stale,
+ * foreign-signed cookie lingers and every authed request 401s), and a future parent-domain
+ * (`Domain=.{apex}`) cookie wouldn't match `localhost` at all. No-op for the local backend, which
+ * sets neither attribute.
+ */
+const rewriteSetCookieForLocalhost: NonNullable<ProxyOptions["configure"]> = (proxy) => {
+    proxy.on("proxyRes", (proxyRes) => {
+        const setCookie = proxyRes.headers["set-cookie"];
+        if (setCookie) {
+            proxyRes.headers["set-cookie"] = setCookie.map((cookie) =>
+                cookie.replace(/;\s*Secure/gi, "").replace(/;\s*Domain=[^;]*/gi, ""),
+            );
+        }
+    });
+};
+
 export default defineConfig(async ({ mode, command }) => {
     const env = loadEnv(mode, process.cwd(), "");
     // Backend the dev server proxies to: explicit override, else slug discovered from the
@@ -82,6 +121,7 @@ export default defineConfig(async ({ mode, command }) => {
 
     return {
         plugins: [
+            devRootRedirect,
             // Please make sure that '@tanstack/router-plugin' is passed before '@vitejs/plugin-react'
             tanstackRouter({
                 target: "react",
@@ -121,6 +161,7 @@ export default defineConfig(async ({ mode, command }) => {
                 "^/api": {
                     target: backendUrl,
                     changeOrigin: true,
+                    configure: rewriteSetCookieForLocalhost,
                 },
                 // Static assets
                 "^/static": {
@@ -146,6 +187,7 @@ export default defineConfig(async ({ mode, command }) => {
                 "^/logout$": {
                     target: backendUrl,
                     changeOrigin: true,
+                    configure: rewriteSetCookieForLocalhost,
                 },
             },
         },

--- a/scripts/migrate-to-server-accounts.py
+++ b/scripts/migrate-to-server-accounts.py
@@ -20,8 +20,9 @@ The combination of INSERT OR IGNORE + SELECT guarantees recovery from both parti
 Usage:
     python scripts/migrate-to-server-accounts.py --pickle <path> [--accounts-db <path>]
 
-If --accounts-db is omitted, defaults to /var/lib/energetica/accounts.db (matching the production
-path read by the running backend via ENERGETICA_ACCOUNTS_DB_PATH).
+If --accounts-db is omitted, defaults to the production path /var/lib/energetica/accounts.db.
+This is a production-only tool, so it pins the prod path explicitly rather than inheriting the
+library default in energetica/accounts/db.py (which targets local dev, instance/accounts.db).
 """
 
 from __future__ import annotations
@@ -39,14 +40,15 @@ def main() -> int:
     parser.add_argument(
         "--accounts-db",
         type=Path,
-        default=None,
-        help="Path to accounts.db (default: /var/lib/energetica/accounts.db or $ENERGETICA_ACCOUNTS_DB_PATH)",
+        default=Path("/var/lib/energetica/accounts.db"),
+        help="Path to accounts.db (default: the production path /var/lib/energetica/accounts.db).",
     )
     parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing.")
     args = parser.parse_args()
 
-    if args.accounts_db is not None:
-        os.environ["ENERGETICA_ACCOUNTS_DB_PATH"] = str(args.accounts_db)
+    # Pin the resolved path into the env the accounts library reads, so this prod tool never
+    # inherits db.py's dev-oriented default.
+    os.environ["ENERGETICA_ACCOUNTS_DB_PATH"] = str(args.accounts_db)
 
     # This is the one tool that must read a pre-migration pickle, whose User objects have no
     # account_id yet. User.__setstate__ hard-fails on that by default (to stop the backend ever

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@
 
 The autouse `_isolated_accounts_db` fixture redirects the server-wide accounts SQLite store to a
 per-test temp file. Without it, any test that calls ``create_app`` (or otherwise touches
-``energetica.accounts``) would try to write to the production path ``/var/lib/energetica/accounts.db``.
+``energetica.accounts``) would write to the dev default ``instance/accounts.db`` in the repo,
+leaking state across tests and into the developer's working tree.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_templates_routes.py
+++ b/tests/integration/test_templates_routes.py
@@ -47,3 +47,17 @@ def test_static_and_page_routes_are_gone(client: TestClient, path: str) -> None:
     """All static/SPA serving moved to Apache — FastAPI returns 404 for them."""
     response = client.get(path, follow_redirects=False)
     assert response.status_code == 404
+
+
+def test_unauthenticated_protected_get_returns_json_401_not_spa_redirect(client: TestClient) -> None:
+    """An unauthenticated GET to a protected API endpoint returns a JSON 401 — never a 303
+    redirect to /app/login.
+
+    FastAPI serves no SPA shell after Phase 5, so a redirect can only dump a fetch client onto
+    Apache's (or, in dev, Vite's) index.html, which `response.json()` then chokes on with
+    "Unexpected token '<', "<!DOCTYPE"...". The SPA owns the redirect to /app/login client-side
+    (routes/__root.tsx), driven by /auth/me; the API only ever speaks JSON.
+    """
+    response = client.get("/api/v1/achievements", follow_redirects=False)
+    assert response.status_code == 401
+    assert "application/json" in response.headers["content-type"]


### PR DESCRIPTION
Two dev workflows broke when the static-serving / server-wide-accounts refactor (RFC Phases 2–5) cut production over to the landing-apex + instance-subdomain topology. Both surfaced as `Unexpected token '<', "<!DOCTYPE"... is not valid JSON`. This PR reclaims both. Scope is strictly **dev/local workflows** — no production behaviour changes.

## Part 1 — local full-stack loop (`python main.py --env dev` + `bun dev`)

**Accounts store had no dev fallback.** `accounts/db.py` defaulted to `/var/lib/energetica/accounts.db`; `_connect()` `mkdir`s the parent, which `PermissionError`s under root-owned `/private/var` on macOS, so the admin bootstrap, signup, and login all failed locally.
→ Default to `instance/accounts.db` (repo-local, co-located with the pickle/secret key, wiped together by `--rm_instance`). Production sets `ENERGETICA_ACCOUNTS_DB_PATH` explicitly via systemd, so the default is dev-only. `migrate-to-server-accounts.py` pins the prod path explicitly so it never inherits the dev default.

**Vestigial redirect produced the `<!DOCTYPE` error.** The `log_action` middleware turned any unauthenticated GET into `303 → /app/login`; Vite doesn't proxy `/app`, so a `fetch` follows it onto the SPA `index.html`. Post-Phase-5 FastAPI serves no HTML, so the redirect is dead weight in prod too.
→ Delete the redirect; the API returns `401` JSON and the SPA (`routes/__root.tsx`, via `/auth/me`) owns the client-side redirect. Regression test added (red-first: `303 == 401`).

## Part 2 — against-prod frontend modes (`bun run dev:game` / `dev:edu` / `dev:ethz`)

These run local Vite proxied at a live backend. Each `.env.{mode}` hard-coded `VITE_BACKEND_URL` at an **apex** — but the cutover made every apex a pure-static landing whose `FallbackResource → index.html` answers all paths, so proxied `/api` came back as HTML. The game backend now lives on a **rotating instance subdomain** (`{slug}.{apex}`), so baking a slug would rot each season.
→ `.env.{mode}` now sets only the **stable** `VITE_APEX_DOMAIN`; `vite.config.ts` discovers the current slug at dev-server startup from the apex's public `instances.json` (newest advertised — the ordering the landing picker uses). No slug is hardcoded; it self-updates across seasons. Explicit `VITE_BACKEND_URL` still wins; default stays `localhost:8000`; runs only for `serve` (never at build); fails loud on an empty/unreachable manifest.

## Scope & non-goals

- Restores the **single-instance localhost loop** and the **against-prod modes** only. A local harness that *mimics* the apex+instance topology (subdomains-on-localhost behind a reverse proxy) was considered and **deferred** — its unique value (cross-origin landing↔instance↔lobby flows, the parent-domain SSO cookie) is mostly not built yet; it should land with the lobby work.
- No ADR — the operative principle (*code defaults target dev; prod is explicit via systemd*) lives as a code comment in `db.py`.

## Out of scope (flagged, not fixed here)

`package.json`'s `deploy:game` / `deploy:edu` / etc. still call `bash scripts/deploy.sh`, which was **deleted** in Phase 5 (replaced by `deploy-instance.sh` / `deploy-landing.sh`). Those *deployment* aliases are broken too, but that's a separate concern from dev workflows.

## Verification

- Backend: 30 affected tests pass (accounts, login, signup, change-password, templates); `ruff` clean. Smoke-tested the real dev default with `ENERGETICA_ACCOUNTS_DB_PATH` unset → resolves to `instance/accounts.db`, no `PermissionError`.
- Frontend: `bun run dev:game` resolves `energetica-game.org → mar-27-2026` from the live manifest; plain `bun dev` stays on localhost with no fetch; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores two broken dev workflows after the multi-instance refactor: the local full-stack loop (`python main.py --env dev` + `bun dev`) and the against-prod frontend modes (`bun run dev:game` / `dev:edu` / `dev:ethz`). Both failures manifested as `Unexpected token '<', "<!DOCTYPE"...` JSON parse errors.

- **Accounts DB default** changed from `/var/lib/energetica/accounts.db` to the CWD-relative `instance/accounts.db`, eliminating the `PermissionError` on macOS; production always overrides via `ENERGETICA_ACCOUNTS_DB_PATH` in systemd. The migration script and test fixtures are updated to stay pinned to the prod path and a per-test tmp file, respectively.
- **Vestigial 303 redirect** removed from the `log_action` middleware — the API now only speaks JSON on 401; the SPA owns the client-side redirect. A regression test (red-first) locks in the JSON 401 contract.
- **`.env.{mode}` files** replaced hardcoded apex URLs with `VITE_APEX_DOMAIN`; `vite.config.ts` now discovers the current season's instance slug at dev-server startup by fetching `instances.json` from the apex, with `VITE_BACKEND_URL` as an explicit override and `localhost:8000` as the plain-dev fallback.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are scoped to dev workflows; production behaviour is unchanged.

The accounts DB default only affects local dev (production always supplies the path via systemd); the 303 redirect removal is verified by a new regression test; the Vite config apex-discovery logic is guarded behind command === serve so it never runs during builds; and the migration script is correctly hardened to never inherit the new dev-friendly default. No production code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/vite.config.ts | Major additions: async resolveBackendUrl (fetches instances.json to discover live slug), devRootRedirect plugin mirroring Apache root redirect, rewriteSetCookieForLocalhost cookie scrubber for /api and /logout. Config function made async. |
| energetica/accounts/db.py | Default DB path changed from /var/lib/energetica/accounts.db to instance/accounts.db (CWD-relative). Safe for dev; prod always overrides via ENERGETICA_ACCOUNTS_DB_PATH. |
| energetica/routers/__init__.py | Removed 303 redirect for unauthenticated GET requests; also removes the now-unused RedirectResponse import. Clean removal of dead code. |
| scripts/migrate-to-server-accounts.py | Hardcodes the prod accounts-db default in argparse and unconditionally sets the env var, preventing accidental inheritance of the new dev-oriented library default. |
| tests/conftest.py | Docstring updated to reflect new dev default (instance/accounts.db); autouse fixture correctly redirects all tests to a per-test tmp path. |
| tests/integration/test_templates_routes.py | Added regression test verifying unauthenticated protected GETs return JSON 401, not a 303 redirect. |

<sub>Reviews (3): Last reviewed commit: ["fix(dev): dev-only / → /app/ redirect; s..."](https://github.com/felixvonsamson/energetica/commit/0c6962cc2480759bbc632b9445f737477920e4fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40627712)</sub>

<!-- /greptile_comment -->