### PR TITLE
fix: skip push notifications during replay/re-simulation

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -452,7 +452,13 @@ class Player(DBModel):
         The blocking webpush() round-trip is dispatched to a background thread pool so it never
         delays the caller (request handler or game tick). Delivery is fire-and-forget and
         best-effort. See issue #763.
+
+        During replay/re-simulation (engine.serve_local) there is no live client to receive the
+        push, and the stored subscriptions belong to a different VAPID keypair, so every send would
+        fail with a credentials mismatch and flood the console. Skip delivery entirely. See #701.
         """
+        if engine.serve_local:
+            return
         notification_data = {
             "type": payload.type,
             "payload": payload.model_dump(exclude={"type"}),


### PR DESCRIPTION
## What

Skip web push delivery while the engine is replaying/re-simulating.

Closes #701.

## Why

During replay — both dedicated `simulate_file` runs and the startup re-simulation of `actions_history.log` — game logic still calls `player.notify()` / `player.push_only()`, which fire real `webpush()` calls to the push endpoints baked into the pickled player state. Nobody is connected during a simulation, and those stored subscriptions belong to a different VAPID keypair, so every send fails with a credentials mismatch and floods the console:

```
Failed to send notification: WebPushException('Push failed: 403 Forbidden ... the VAPID credentials ... do not correspond ...')
```

## How

A single guard at the top of `notify_subscription()` — the one chokepoint both `notify()` and `push_only()` funnel through — returns early when `engine.serve_local` is set. `serve_local` is `True` for the entire replay/resim window and flips to `False` only once real users are being served (it's already the "resimulating" signal in `health.py`), so it's exactly the "nobody's connected" condition.

The socketio `invalidate` emits in `notify()` are intentionally left alone: they iterate `self.socketio_clients`, which is empty during replay, so they're harmless no-ops.

Per the issue discussion, this is the deliberately naive one-line guard rather than a general "live-only side effects" framework, since push is currently the only side effect that actually misbehaves during replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a single early-return guard at the top of `notify_subscription()` — the shared chokepoint for both `notify()` and `push_only()` — to skip web push delivery while `engine.serve_local` is `True` (i.e., during startup replay or `simulate_file` re-simulation).

- **Guard placement**: The check `if engine.serve_local: return` is inserted before any subscription processing, preventing `_PUSH_EXECUTOR.submit()` from ever being called during replay. Both callers (`notify()` and `push_only()`) funnel through this single method, so all push paths are covered.
- **Scope**: SocketIO `invalidate` emits in `notify()` are left untouched; they iterate `self.socketio_clients`, which is empty during replay, so they are already harmless no-ops.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line guard at a well-understood chokepoint with no risk of suppressing notifications outside the replay window.

The fix targets a single boolean flag (serve_local) that is already used throughout the codebase as the authoritative replay signal. It is inserted at notify_subscription(), which is the only path through which push work is enqueued, so nothing else needs to change. The flag starts True on engine init and is set to False immediately before the scheduler hands off to live ticking — there is no scenario where real users would silently lose a push notification. SocketIO invalidation paths are unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/player.py | Adds a two-line early-return guard in notify_subscription() keyed on engine.serve_local; correct placement at the sole push chokepoint, well-documented, no logic regressions. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GL as Game Logic
    participant P as Player
    participant NS as notify_subscription()
    participant EX as _PUSH_EXECUTOR
    participant WP as webpush (external)

    Note over GL,WP: During replay (engine.serve_local = True)
    GL->>P: notify() / push_only()
    P->>NS: notify_subscription(subscription, payload)
    NS-->>P: return early (serve_local is True)
    Note over EX,WP: No push sent

    Note over GL,WP: During normal operation (engine.serve_local = False)
    GL->>P: notify() / push_only()
    P->>NS: notify_subscription(subscription, payload)
    NS->>EX: submit(_deliver_push)
    EX->>WP: webpush(subscription, data, vapid_key)
    WP-->>EX: 200 OK / 410 Gone / 403 Forbidden
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GL as Game Logic
    participant P as Player
    participant NS as notify_subscription()
    participant EX as _PUSH_EXECUTOR
    participant WP as webpush (external)

    Note over GL,WP: During replay (engine.serve_local = True)
    GL->>P: notify() / push_only()
    P->>NS: notify_subscription(subscription, payload)
    NS-->>P: return early (serve_local is True)
    Note over EX,WP: No push sent

    Note over GL,WP: During normal operation (engine.serve_local = False)
    GL->>P: notify() / push_only()
    P->>NS: notify_subscription(subscription, payload)
    NS->>EX: submit(_deliver_push)
    EX->>WP: webpush(subscription, data, vapid_key)
    WP-->>EX: 200 OK / 410 Gone / 403 Forbidden
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: skip push notifications during repl..."](https://github.com/felixvonsamson/energetica/commit/0a9d40240565cc771e52c19a67f218e74f2ebdd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41177883)</sub>

<!-- /greptile_comment -->