### PR TITLE
feat(overviews): color-coded magnitude bars in overview tables

### DIFF
--- a/frontend/src/components/charts/cash-flow-chart.tsx
+++ b/frontend/src/components/charts/cash-flow-chart.tsx
@@ -7,14 +7,36 @@ import {
 import { FacilityIcon } from "@/components/ui/asset-icon";
 import { FacilityName } from "@/components/ui/asset-name";
 import { CashFlow } from "@/components/ui/cash-flow";
-import { Money } from "@/components/ui/money";
+import { MagnitudeBar } from "@/components/ui/magnitude-bar";
 import { useAssetColorGetter } from "@/hooks/use-asset-color-getter";
 import { useChartFilters } from "@/hooks/use-chart-filters";
 import { useGameEngine } from "@/hooks/use-game";
-import { formatCashFlow } from "@/lib/format-utils";
+import { formatCashFlow, formatMoney } from "@/lib/format-utils";
 
 export type CashFlowType = "revenues" | "expenses" | "net-profit";
 export type NetProfitViewMode = "net" | "breakdown";
+
+/**
+ * Color for a cash-flow series by key.
+ *
+ * Net-profit mode uses synthetic keys (`profit`/`loss`/`baseline`) that have no
+ * entry in the asset color system, so they resolve here instead. Returns `null`
+ * for real facility keys — callers fall back to the asset color getter. Shared
+ * by the chart and the overview table so both stay in sync.
+ */
+export function cashFlowSeriesColor(key: string): string | null {
+    switch (key) {
+        case "baseline":
+            return "var(--muted)";
+        case "profit":
+        case "net-profit":
+            return "var(--success)";
+        case "loss":
+            return "var(--destructive)";
+        default:
+            return null;
+    }
+}
 
 interface CashFlowChartProps {
     chartData: Array<Record<string, unknown>>;
@@ -38,13 +60,12 @@ export function CashFlowChart({
     const { data: gameEngineConfig } = useGameEngine();
     const getColor = useAssetColorGetter();
 
-    // Custom color getter for breakdown mode
-    const getBreakdownColor = useCallback((key: string) => {
-        if (key === "baseline") return "hsl(var(--muted-foreground) / 0.5)";
-        if (key === "profit") return "var(--success)";
-        if (key === "loss") return "var(--destructive)";
-        return "var(--foreground)";
-    }, []);
+    // Breakdown mode uses synthetic series keys (profit/loss/baseline) that the
+    // asset color system doesn't know about; cashFlowSeriesColor resolves them.
+    const getBreakdownColor = useCallback(
+        (key: string) => cashFlowSeriesColor(key) ?? "var(--foreground)",
+        [],
+    );
 
     // Create filters - don't filter non-zero for net-profit view
     const filterDataKeys = useChartFilters(
@@ -134,7 +155,10 @@ export function CashFlowChart({
             formatYAxis: (value: number) =>
                 isShowingPercent
                     ? `${value}%`
-                    : formatCashFlow(value, "h", gameEngineConfig).replace("$", ""),
+                    : formatCashFlow(value, "h", gameEngineConfig).replace(
+                          "$",
+                          "",
+                      ),
             // Use gradient fill for the "net-profit" series only in net mode
             gradientKeys: isNetMode ? ["net-profit"] : [],
         };
@@ -190,6 +214,7 @@ export function CashFlowOverviewTable({
 }: CashFlowOverviewTableProps) {
     const [sortKey, setSortKey] = useState<SortKey>("revenues");
     const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+    const getColor = useAssetColorGetter();
 
     // Check if all facilities are hidden
     const allHidden = useMemo(() => {
@@ -300,6 +325,13 @@ export function CashFlowOverviewTable({
         return sorted;
     }, [facilityRows, sortKey, sortDirection]);
 
+    // Largest total normalises the magnitude bars into a ranked micro-chart.
+    const maxRevenues = useMemo(
+        () =>
+            facilityRows.reduce((m, row) => Math.max(m, row.totalRevenues), 0),
+        [facilityRows],
+    );
+
     const handleSort = (key: SortKey) => {
         if (sortKey === key) {
             // Toggle direction
@@ -379,8 +411,18 @@ export function CashFlowOverviewTable({
                                         />
                                     </div>
                                 </td>
-                                <td className="py-3 px-4 text-right font-mono">
-                                    <Money amount={row.totalRevenues} />
+                                <td className="py-3 px-4">
+                                    <MagnitudeBar
+                                        value={row.totalRevenues}
+                                        max={maxRevenues}
+                                        color={
+                                            cashFlowSeriesColor(
+                                                row.facilityType,
+                                            ) ?? getColor(row.facilityType)
+                                        }
+                                        label={formatMoney(row.totalRevenues)}
+                                        dimmed={!isVisible}
+                                    />
                                 </td>
                                 <td className="py-3 px-4 text-center">
                                     <button

--- a/frontend/src/components/charts/emissions-chart.tsx
+++ b/frontend/src/components/charts/emissions-chart.tsx
@@ -7,6 +7,7 @@ import {
 import { AssetIcon } from "@/components/ui/asset-icon";
 import { AssetName } from "@/components/ui/asset-name";
 import { Label } from "@/components/ui/label";
+import { MagnitudeBar } from "@/components/ui/magnitude-bar";
 import { useAssetColorGetter } from "@/hooks/use-asset-color-getter";
 import { useChartFilters } from "@/hooks/use-chart-filters";
 import { useGameEngine } from "@/hooks/use-game";
@@ -213,6 +214,7 @@ export function EmissionsOverviewTable({
 }: EmissionsOverviewTableProps) {
     const [sortKey, setSortKey] = useState<SortKey>("emissions");
     const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+    const getColor = useAssetColorGetter();
 
     // Check if all sources are hidden
     const allHidden = useMemo(() => {
@@ -311,6 +313,17 @@ export function EmissionsOverviewTable({
         return sorted;
     }, [rows, sortKey, sortDirection]);
 
+    // Largest source normalises the magnitude bars (uses absolute emissions,
+    // so carbon-capture removals are ranked by size like any other source).
+    const maxEmissions = useMemo(
+        () =>
+            rows.reduce(
+                (m, row) => Math.max(m, Math.abs(row.totalEmissions)),
+                0,
+            ),
+        [rows],
+    );
+
     const getSortIcon = (key: SortKey) => {
         if (sortKey !== key) return null;
         return sortDirection === "asc" ? "↑" : "↓";
@@ -366,8 +379,14 @@ export function EmissionsOverviewTable({
                                     <AssetName assetId={row.sourceType} />
                                 </div>
                             </td>
-                            <td className="py-2 px-4 text-right font-mono">
-                                {formatMass(row.totalEmissions)}
+                            <td className="py-2 px-4">
+                                <MagnitudeBar
+                                    value={row.totalEmissions}
+                                    max={maxEmissions}
+                                    color={getColor(row.sourceType)}
+                                    label={formatMass(row.totalEmissions)}
+                                    dimmed={hiddenSources.has(row.sourceType)}
+                                />
                             </td>
                             <td className="py-2 px-4 text-center">
                                 <Label className="inline-flex items-center cursor-pointer">

--- a/frontend/src/components/charts/market-clearing-volume-chart.tsx
+++ b/frontend/src/components/charts/market-clearing-volume-chart.tsx
@@ -6,13 +6,14 @@ import {
 } from "@/components/charts/echarts-time-series";
 import { FacilityName } from "@/components/ui/asset-name";
 import { Button } from "@/components/ui/button";
+import { MagnitudeBar } from "@/components/ui/magnitude-bar";
 import { useAssetColorGetter } from "@/hooks/use-asset-color-getter";
 import { useChartFilters } from "@/hooks/use-chart-filters";
 import { useChartData } from "@/hooks/use-charts";
 import { useElectricityMarket } from "@/hooks/use-electricity-markets";
 import { useGameEngine } from "@/hooks/use-game";
 import { usePlayerMap } from "@/hooks/use-players";
-import { getHashBasedChartColor } from "@/lib/charts/color-utils";
+import { getHashBasedChartColor, resolveColor } from "@/lib/charts/color-utils";
 import { createIncludeKeysFilter } from "@/lib/charts/filter-utils";
 import { KEY_ORDER_BY_CHART_TYPE } from "@/lib/charts/key-order";
 import { formatEnergy, formatPower } from "@/lib/format-utils";
@@ -187,6 +188,7 @@ export function MarketClearingTable({
     const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
     const { data: gameEngine } = useGameEngine();
     const playerMap = usePlayerMap();
+    const getColor = useAssetColorGetter();
 
     // Calculate aggregated data for each item
     const rows = useMemo(() => {
@@ -232,6 +234,12 @@ export function MarketClearingTable({
         });
         return sorted;
     }, [rows, sortKey, sortDirection]);
+
+    // Largest total normalises the magnitude bars into a ranked micro-chart.
+    const maxEnergy = useMemo(
+        () => rows.reduce((m, row) => Math.max(m, row.totalEnergy), 0),
+        [rows],
+    );
 
     const handleSort = (key: "name" | "energy") => {
         if (sortKey === key) {
@@ -330,8 +338,30 @@ export function MarketClearingTable({
                                             ?.username ?? row.name)
                                     )}
                                 </td>
-                                <td className="py-3 px-4 text-right font-mono">
-                                    {formatEnergy(row.totalEnergy)}
+                                <td className="py-3 px-4">
+                                    {breakdownEnabled ? (
+                                        <MagnitudeBar
+                                            value={row.totalEnergy}
+                                            max={maxEnergy}
+                                            color={
+                                                breakdownMode === "type"
+                                                    ? getColor(row.name)
+                                                    : resolveColor(
+                                                          getHashBasedChartColor(
+                                                              row.name,
+                                                          ),
+                                                      )
+                                            }
+                                            label={formatEnergy(
+                                                row.totalEnergy,
+                                            )}
+                                            dimmed={!isVisible}
+                                        />
+                                    ) : (
+                                        <span className="block text-right font-mono">
+                                            {formatEnergy(row.totalEnergy)}
+                                        </span>
+                                    )}
                                 </td>
                                 <td className="py-3 px-4 text-center">
                                     <Button

--- a/frontend/src/components/charts/power-chart.tsx
+++ b/frontend/src/components/charts/power-chart.tsx
@@ -3,9 +3,11 @@
  *
  * This is a thin wrapper around EChartsTimeSeries that handles the
  * power-chart-specific concerns:
- *  - Deriving visible keys from the canonical facility order (hidden + zero filtering)
- *  - Percent-mode normalization of the data
- *  - Facility icon + name labels in the tooltip
+ *
+ * - Deriving visible keys from the canonical facility order (hidden + zero
+ *   filtering)
+ * - Percent-mode normalization of the data
+ * - Facility icon + name labels in the tooltip
  */
 
 import { Link } from "@tanstack/react-router";
@@ -18,6 +20,7 @@ import {
 import { FacilityIcon } from "@/components/ui/asset-icon";
 import { FacilityName } from "@/components/ui/asset-name";
 import { FacilityGauge } from "@/components/ui/facility-gauge";
+import { MagnitudeBar } from "@/components/ui/magnitude-bar";
 import {
     Tooltip,
     TooltipContent,
@@ -66,7 +69,9 @@ export function PowerChart({
     // and series that are all-zero across the entire data set.
     const visibleKeys = useMemo(() => {
         if (!chartData.length) return [];
-        const keyOrder = KEY_ORDER_BY_CHART_TYPE[chartType] as readonly string[];
+        const keyOrder = KEY_ORDER_BY_CHART_TYPE[
+            chartType
+        ] as readonly string[];
         return keyOrder.filter(
             (key) =>
                 !hiddenFacilities.has(key) &&
@@ -90,9 +95,7 @@ export function PowerChart({
             for (const k of visibleKeys) {
                 const v = Number(dataPoint[k] ?? 0);
                 row[k] =
-                    viewMode === "percent" && total > 0
-                        ? (v / total) * 100
-                        : v;
+                    viewMode === "percent" && total > 0 ? (v / total) * 100 : v;
             }
             return row;
         });
@@ -106,9 +109,7 @@ export function PowerChart({
             getColor,
             formatLabel,
             formatValue: (v) =>
-                viewMode === "percent"
-                    ? `${v.toFixed(1)}%`
-                    : formatPower(v),
+                viewMode === "percent" ? `${v.toFixed(1)}%` : formatPower(v),
             formatYAxis:
                 viewMode === "percent"
                     ? (v: number) => `${v.toFixed(0)}%`
@@ -162,6 +163,7 @@ export function PowerOverviewTable({
 
     const { data: facilitiesData } = useFacilities();
     const { data: gameEngine } = useGameEngine();
+    const getColor = useAssetColorGetter();
     const isGeneration = chartType === "power-sources";
 
     const allHidden = useMemo(() => {
@@ -273,6 +275,14 @@ export function PowerOverviewTable({
         });
     }, [facilityRows, sortKey, sortDirection]);
 
+    // Largest total normalises the consumption magnitude bars. Generation
+    // rows keep the plain number — their capacity-factor gauge already carries
+    // the color, and two bars per row would be noise.
+    const maxEnergy = useMemo(
+        () => facilityRows.reduce((m, row) => Math.max(m, row.totalEnergy), 0),
+        [facilityRows],
+    );
+
     const handleSort = (key: SortKey) => {
         if (sortKey === key) {
             setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
@@ -381,8 +391,22 @@ export function PowerOverviewTable({
                                         />
                                     </div>
                                 </td>
-                                <td className="py-3 px-4 text-right font-mono">
-                                    {formatEnergy(row.totalEnergy)}
+                                <td className="py-3 px-4">
+                                    {isGeneration ? (
+                                        <span className="block text-right font-mono">
+                                            {formatEnergy(row.totalEnergy)}
+                                        </span>
+                                    ) : (
+                                        <MagnitudeBar
+                                            value={row.totalEnergy}
+                                            max={maxEnergy}
+                                            color={getColor(row.facilityType)}
+                                            label={formatEnergy(
+                                                row.totalEnergy,
+                                            )}
+                                            dimmed={!isVisible}
+                                        />
+                                    )}
                                 </td>
                                 {isGeneration && (
                                     <>

--- a/frontend/src/components/ui/magnitude-bar.tsx
+++ b/frontend/src/components/ui/magnitude-bar.tsx
@@ -1,0 +1,77 @@
+/**
+ * Inline data bar for a table's magnitude column.
+ *
+ * Sibling to {@link FacilityGauge}. Where the gauge shows how full a _bounded_
+ * quantity is (state of charge, capacity factor — always a pill with a `%`
+ * label), the magnitude bar shows how large a row is _relative to the largest
+ * row in the same table_. Width = `|value| / max`, filled with the row's
+ * asset/series color, so a table sorted by size reads as a horizontal ranked
+ * micro-chart that mirrors the stacked chart above it.
+ *
+ * The softer `rounded-md` (vs the gauge's `rounded-full`) is the quiet cue that
+ * these two bars mean different things while staying the same family.
+ */
+import { readableTextColor } from "@/lib/charts/color-utils";
+
+interface MagnitudeBarProps {
+    /** This row's magnitude. Only its absolute value drives the bar width. */
+    value: number;
+    /** Largest `|value|` among sibling rows; normalises the fill (0 → empty). */
+    max: number;
+    /** Resolved fill color: `rgb()`/`#hex`, or a `var(--…)` reference. */
+    color: string;
+    /** Preformatted value label, e.g. `"12.4 GWh"` or `"$1.2M"`. */
+    label: string;
+    /** Dim the bar (e.g. when the series is hidden from the chart). */
+    dimmed?: boolean;
+    className?: string;
+}
+
+/**
+ * @example
+ *     <MagnitudeBar
+ *         value={840}
+ *         max={2100}
+ *         color="rgb(0,119,182)"
+ *         label="840 MWh"
+ *     />;
+ */
+export function MagnitudeBar({
+    value,
+    max,
+    color,
+    label,
+    dimmed = false,
+    className = "",
+}: MagnitudeBarProps) {
+    const fraction = max > 0 ? Math.min(Math.abs(value) / max, 1) : 0;
+    const pct = fraction * 100;
+    const fg = readableTextColor(color);
+
+    return (
+        <div
+            className={`relative w-full min-w-30 h-8 bg-gray-200 dark:bg-gray-700 rounded-md overflow-hidden transition-opacity ${dimmed ? "opacity-40" : ""} ${className}`}
+        >
+            <div
+                className="absolute inset-y-0 left-0 transition-all"
+                style={{ width: `${pct}%`, backgroundColor: color }}
+            />
+            {/* Label over the unfilled (track) portion — uses default fg. */}
+            <span
+                className="absolute inset-0 flex items-center justify-end pr-3 text-xs font-semibold font-mono text-gray-800 dark:text-white transition-all"
+                style={{ clipPath: `inset(0 0 0 ${pct}%)` }}
+            >
+                {label}
+            </span>
+            {/* Label over the filled portion — uses a luminance-picked color.
+               Both spans share the transition so the split tracks the fill. */}
+            <span
+                className="absolute inset-0 flex items-center justify-end pr-3 text-xs font-semibold font-mono transition-all"
+                style={{ color: fg, clipPath: `inset(0 ${100 - pct}% 0 0)` }}
+                aria-hidden="true"
+            >
+                {label}
+            </span>
+        </div>
+    );
+}

--- a/frontend/src/lib/assets/asset-icons.ts
+++ b/frontend/src/lib/assets/asset-icons.ts
@@ -146,6 +146,9 @@ export const specialIcons: Record<string, LucideIcon> = {
     temperature: Thermometer,
     baseline: SquareDashedBottom,
     profit: DollarSignSquare,
+    // Same icon as profit: color (success/destructive) carries the direction,
+    // and a tick is only ever profit or loss, never both at once.
+    loss: DollarSignSquare,
 };
 
 /** Combined registry of all asset icons. */

--- a/frontend/src/lib/assets/asset-names.ts
+++ b/frontend/src/lib/assets/asset-names.ts
@@ -281,6 +281,10 @@ export const specialNames: Record<string, AssetDisplayName> = {
         long: "Profit",
         short: "Profit",
     },
+    loss: {
+        long: "Loss",
+        short: "Loss",
+    },
 };
 
 /** Combined registry of all asset names. */

--- a/frontend/src/lib/charts/color-utils.ts
+++ b/frontend/src/lib/charts/color-utils.ts
@@ -16,6 +16,50 @@ export function resolveColor(color: string): string {
     return resolveCSSVar(varName);
 }
 
+/**
+ * Pick black or white text for legibility over an arbitrary fill `color`.
+ *
+ * Accepts a resolved `rgb()/rgba()/#hex` value or a `var(--…)` reference
+ * (resolved first). Falls back to the theme foreground for anything it can't
+ * parse. Used by {@link MagnitudeBar} so labels stay readable over both facility
+ * colors and hash-assigned player colors, without relying on a per-asset `-fg`
+ * CSS variable.
+ */
+export function readableTextColor(color: string): string {
+    const c = resolveColor(color);
+    let r = NaN;
+    let g = NaN;
+    let b = NaN;
+
+    const rgb = c.match(/rgba?\(([^)]+)\)/);
+    if (rgb?.[1]) {
+        const parts = rgb[1].split(",");
+        r = parseFloat(parts[0] ?? "");
+        g = parseFloat(parts[1] ?? "");
+        b = parseFloat(parts[2] ?? "");
+    } else if (c.startsWith("#")) {
+        const hex = c.slice(1);
+        const full =
+            hex.length === 3
+                ? hex
+                      .split("")
+                      .map((h) => h + h)
+                      .join("")
+                : hex;
+        r = parseInt(full.slice(0, 2), 16);
+        g = parseInt(full.slice(2, 4), 16);
+        b = parseInt(full.slice(4, 6), 16);
+    } else {
+        return "var(--foreground)";
+    }
+
+    if ([r, g, b].some((v) => Number.isNaN(v))) return "var(--foreground)";
+
+    // Perceived luminance (sRGB weights). Bias slightly toward black text.
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance > 0.6 ? "#000" : "#fff";
+}
+
 /** Chart color palette using semantic CSS variables. */
 
 export const CHART_COLORS = [

--- a/frontend/src/lib/charts/color-utils.ts
+++ b/frontend/src/lib/charts/color-utils.ts
@@ -16,48 +16,68 @@ export function resolveColor(color: string): string {
     return resolveCSSVar(varName);
 }
 
+const contrastCache = new Map<string, string>();
+let probeCanvas: HTMLCanvasElement | null = null;
+
+/**
+ * Rasterize any CSS color to sRGB bytes via a 1×1 canvas, or `null` if the
+ * color is invalid or no canvas is available (SSR).
+ *
+ * Going through the canvas means we don't hand-parse each color space: the
+ * browser converts `oklch()`, `hsl()`, named colors and every hex length to
+ * sRGB for us — which matters here because the design tokens resolve to
+ * `oklch()`.
+ */
+function colorToRgb(color: string): [number, number, number] | null {
+    if (typeof document === "undefined") return null;
+    if (!probeCanvas) {
+        probeCanvas = document.createElement("canvas");
+        probeCanvas.width = probeCanvas.height = 1;
+    }
+    const ctx = probeCanvas.getContext("2d", { willReadFrequently: true });
+    if (!ctx) return null;
+
+    // Validity probe: the fillStyle setter ignores an unparseable color, so it
+    // reads back differently depending on the two known-different priors.
+    ctx.fillStyle = "#000";
+    ctx.fillStyle = color;
+    const fromBlack = ctx.fillStyle;
+    ctx.fillStyle = "#fff";
+    ctx.fillStyle = color;
+    if (ctx.fillStyle !== fromBlack) return null;
+
+    ctx.fillRect(0, 0, 1, 1);
+    const d = ctx.getImageData(0, 0, 1, 1).data;
+    return [d[0] ?? 0, d[1] ?? 0, d[2] ?? 0];
+}
+
 /**
  * Pick black or white text for legibility over an arbitrary fill `color`.
  *
- * Accepts a resolved `rgb()/rgba()/#hex` value or a `var(--…)` reference
- * (resolved first). Falls back to the theme foreground for anything it can't
- * parse. Used by {@link MagnitudeBar} so labels stay readable over both facility
- * colors and hash-assigned player colors, without relying on a per-asset `-fg`
- * CSS variable.
+ * Accepts any CSS color or a `var(--…)` reference (resolved first). Falls back
+ * to the theme foreground only when the color can't be rasterized at all.
+ * Results are cached by resolved value, so a theme switch (which changes what a
+ * `var()` resolves to) naturally recomputes under a new key. Used by
+ * {@link MagnitudeBar} so labels stay readable over facility colors and
+ * hash-assigned player colors alike, without a per-asset `-fg` CSS variable.
  */
 export function readableTextColor(color: string): string {
-    const c = resolveColor(color);
-    let r = NaN;
-    let g = NaN;
-    let b = NaN;
+    const resolved = resolveColor(color);
+    const cached = contrastCache.get(resolved);
+    if (cached) return cached;
 
-    const rgb = c.match(/rgba?\(([^)]+)\)/);
-    if (rgb?.[1]) {
-        const parts = rgb[1].split(",");
-        r = parseFloat(parts[0] ?? "");
-        g = parseFloat(parts[1] ?? "");
-        b = parseFloat(parts[2] ?? "");
-    } else if (c.startsWith("#")) {
-        const hex = c.slice(1);
-        const full =
-            hex.length === 3
-                ? hex
-                      .split("")
-                      .map((h) => h + h)
-                      .join("")
-                : hex;
-        r = parseInt(full.slice(0, 2), 16);
-        g = parseInt(full.slice(2, 4), 16);
-        b = parseInt(full.slice(4, 6), 16);
+    const rgb = colorToRgb(resolved);
+    let result: string;
+    if (rgb === null) {
+        result = "var(--foreground)";
     } else {
-        return "var(--foreground)";
+        // Perceived luminance (sRGB weights). Bias slightly toward black text.
+        const luminance = (0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]) / 255;
+        result = luminance > 0.6 ? "#000" : "#fff";
     }
 
-    if ([r, g, b].some((v) => Number.isNaN(v))) return "var(--foreground)";
-
-    // Perceived luminance (sRGB weights). Bias slightly toward black text.
-    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-    return luminance > 0.6 ? "#000" : "#fff";
+    contrastCache.set(resolved, result);
+    return result;
 }
 
 /** Chart color palette using semantic CSS variables. */


### PR DESCRIPTION
## What

Closes #670. Adds color to the data tables under the overview charts, as requested: a facility-colored bar in each row's total column whose width is proportional to that row's magnitude.

The device is a new shared component, **`MagnitudeBar`** — a sibling to the existing `FacilityGauge`:

- **Gauge** (`rounded-full`, `%` label) = how full a *bounded* thing is (state of charge, capacity factor). Unchanged.
- **MagnitudeBar** (`rounded-md`, quantity label) = this row's size vs the *largest row in the table*. Width = `|value| / max`, filled with the row's asset/series color.

Sorted descending, each total column now reads as a horizontal ranked micro-chart in the same colors as the stacked chart above it. Hidden rows dim to 40%. Labels stay legible on any fill via the gauge's dual-clip trick, with the text color picked by luminance (`readableTextColor`) so it works for facility colors *and* hash-assigned player colors.

## Where (holistic pass across the overviews)

| Page | Change |
|------|--------|
| electricity-markets | Magnitude bars (by type → asset color; by player → hash color) |
| cash-flow | Magnitude bars, all modes |
| power — consumption/sinks | Magnitude bars |
| emissions | Magnitude bars |
| power — generation, storage, resources | **Unchanged** — capacity/level gauges already carry the color; a second bar per row would be noise |

## Also: net-profit color plumbing fix

While wiring cash-flow, found the chart and the overview table resolved net-profit series colors through **two divergent code paths** — the chart used a local `getBreakdownColor`, the table used the asset getter, which has no entry for the synthetic `profit`/`loss`/`baseline` keys and silently returned gray. Consolidated both onto a shared `cashFlowSeriesColor()`. Along the way:

- Added the missing **`loss`** icon (same `DollarSignSquare` as profit — color carries the direction) and display name.
- Swapped `baseline`'s unresolvable `hsl(var(--muted-foreground) / 0.5)` for `var(--muted)`, so it resolves for both the ECharts fill and the tooltip swatch. **Note:** baseline was previously drawn with an invalid (invisible) color; it now renders as a muted band under the floating profit/loss segment.

## Testing

`bun run typecheck`, `bun run lint`, `bun run format` all clean. Verified in a live dev server against a real backend across all four pages and net-profit breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds color-coded magnitude bars (`MagnitudeBar`) to the overview tables across the electricity-markets, cash-flow, power-consumption, and emissions pages, turning each total column into a horizontal ranked micro-chart that mirrors the stacked chart above it. It also consolidates net-profit series color resolution into a single exported `cashFlowSeriesColor()` function (fixing a silent gray fallback in the table) and adds the missing `loss` icon and display-name registry entries.

- `MagnitudeBar` uses a dual-clip, dual-span technique so the preformatted label stays legible over both the filled and unfilled portions; `readableTextColor` picks black or white via canvas-rasterized luminance, handling any CSS color space (oklch, hsl, hex) without manual parsing.
- `colorToRgb` in `color-utils.ts` routes all color parsing through a persistent 1×1 probe canvas with a two-prior validity check; results are cached by resolved value so a theme switch naturally busts stale entries.
- Generation rows in the power table deliberately keep plain text to avoid doubling up with the existing capacity-factor gauge.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive UI enhancements with no data-path or API changes.

The change adds a new display-only component and wires it into four overview tables. The color consolidation in cash-flow is a straightforward correctness fix. The canvas-based color rasterizer handles all CSS color spaces correctly for opaque colors, which is all that is passed today. No state management, routing, or backend interactions are touched.

color-utils.ts — the probe canvas is never cleared before rasterizing, which would affect any future caller passing semi-transparent colors.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/ui/magnitude-bar.tsx | New component: inline data bar showing a row's magnitude relative to the table maximum, using a dual-clip dual-span trick for legible labels over both the fill and the track. |
| frontend/src/lib/charts/color-utils.ts | Adds colorToRgb (canvas-based rasterizer) and readableTextColor (luminance-picker with module-level cache). Canvas is never cleared between calls, making semi-transparent color results dependent on call order. |
| frontend/src/components/charts/cash-flow-chart.tsx | Adds cashFlowSeriesColor() consolidation fixing divergent chart/table color paths, replaces Money with MagnitudeBar in the overview table, and adds maxRevenues normaliser. |
| frontend/src/components/charts/emissions-chart.tsx | Replaces plain text totalEmissions cell with MagnitudeBar; maxEmissions uses Math.abs() so carbon-capture removals are ranked by size, which is correct. |
| frontend/src/components/charts/market-clearing-volume-chart.tsx | MagnitudeBar shown only when breakdownEnabled; player mode pre-resolves the var() color before passing it to MagnitudeBar, while type mode passes the raw color — both work correctly via readableTextColor's resolveColor step. |
| frontend/src/components/charts/power-chart.tsx | Consumption rows get MagnitudeBar; generation rows keep plain text to avoid duplication with the existing capacity-factor gauge. Minor formatting refactors only. |
| frontend/src/lib/assets/asset-icons.ts | Adds missing loss icon (same DollarSignSquare as profit — direction is communicated through color). |
| frontend/src/lib/assets/asset-names.ts | Adds missing loss display name entry to specialNames registry. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Overview table row] --> B{Color source?}
    B -->|facility asset| C[useAssetColorGetter]
    B -->|synthetic key\nprofit/loss/baseline/net-profit| D[cashFlowSeriesColor]
    B -->|player hash| E[getHashBasedChartColor → resolveColor]
    C --> F[color string\nvar or hex]
    D --> F
    E --> F
    F --> G[MagnitudeBar]
    G --> H[readableTextColor]
    H --> I[resolveColor\nvar → computed value]
    I --> J[colorToRgb\n1×1 canvas rasterize]
    J -->|rgb tuple| K{luminance > 0.6?}
    K -->|yes| L[#000 black text]
    K -->|no| M[#fff white text]
    J -->|null SSR / invalid| N[var--foreground fallback]
    L & M & N --> O[clip-path dual-span\nlegible label over fill + track]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Overview table row] --> B{Color source?}
    B -->|facility asset| C[useAssetColorGetter]
    B -->|synthetic key\nprofit/loss/baseline/net-profit| D[cashFlowSeriesColor]
    B -->|player hash| E[getHashBasedChartColor → resolveColor]
    C --> F[color string\nvar or hex]
    D --> F
    E --> F
    F --> G[MagnitudeBar]
    G --> H[readableTextColor]
    H --> I[resolveColor\nvar → computed value]
    I --> J[colorToRgb\n1×1 canvas rasterize]
    J -->|rgb tuple| K{luminance > 0.6?}
    K -->|yes| L[#000 black text]
    K -->|no| M[#fff white text]
    J -->|null SSR / invalid| N[var--foreground fallback]
    L & M & N --> O[clip-path dual-span\nlegible label over fill + track]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(charts): rasterize colors for contra..."](https://github.com/felixvonsamson/energetica/commit/171350bf111797933fcf152405457d5e37ce866a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41188730)</sub>

<!-- /greptile_comment -->