### PR TITLE
fix(technology): remove broken "learn more" links; fix industry wiki link

### DIFF
--- a/energetica/config/assets.py
+++ b/energetica/config/assets.py
@@ -410,7 +410,7 @@ const_config: dict = {
             "power_factor": 1.4,
             "income_factor": 1.33,
             "description": "The industry generates revenue from energy. The Power consumption of the Industry varies "
-            "daily and seasonally. (<a href='/wiki/functional_facilities#The_Industry'>See wiki</a>)",
+            "daily and seasonally. (<a href='/app/wiki/functional-facilities#the-industry'>See wiki</a>)",
             "wikipedia_link": "",
             "requirements": {},
         },

--- a/frontend/src/components/technologies/technology-detail-dialog.tsx
+++ b/frontend/src/components/technologies/technology-detail-dialog.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@tanstack/react-router";
-import { ExternalLink } from "lucide-react";
 import { ReactNode } from "react";
 
 import { RequirementsDisplay, ConstructionInfo } from "@/components/facilities";
@@ -31,7 +30,6 @@ interface TechnologyDetailModalProps<T> {
               name: ProjectType;
               price: number;
               description: string;
-              wikipedia_link: string;
               requirements_status: string;
               requirements: Requirement[];
               construction_time: number;
@@ -114,7 +112,7 @@ export function TechnologyDetailDialog<T>({
                                 </p>
                             </div>
 
-                            {/* Description & Learn More */}
+                            {/* Description */}
                             <CardContent className="space-y-2">
                                 <div className="[&_p:last-of-type]:inline">
                                     <div
@@ -124,16 +122,6 @@ export function TechnologyDetailDialog<T>({
                                         }}
                                     />
                                 </div>
-                                <a
-                                    href={displayedTechnology.wikipedia_link}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className="flex items-center gap-1 text-sm text-muted-foreground underline hover:text-foreground w-fit"
-                                    onClick={(e) => e.stopPropagation()}
-                                >
-                                    <ExternalLink className="w-3 h-3" />
-                                    Learn more
-                                </a>
                                 {/* Affected Facilities */}
                                 {displayedTechnology.affected_facilities.length > 0 && (
                                     <div>


### PR DESCRIPTION
Addresses #714.

## Changes

**1. Removed broken "Learn more" links on the technology page** (`technology-detail-dialog.tsx`)
- Removed the external Wikipedia "Learn more" `<a>` link (it pointed at `wikipedia_link`, which was broken).
- Cleaned up the now-unused `ExternalLink` import and `wikipedia_link` prop type field.
- Kept the equivalent Wikipedia links on the power/storage/extraction **facility** dialogs, per @felixvonsamson's clarification in the issue ("only remove the links from technology page").
- Left the *Knowledge Spillover* tooltip "Learn more" link intact — it's a working internal wiki link, not one of the broken ones.

**2. Fixed the broken wiki link in the industry dialog** (`config/assets.py`)
- The industry description's `See wiki` link was `/wiki/functional_facilities#The_Industry`, broken two ways: the old Jinja `/wiki/` path and an underscore slug/anchor that don't match the SPA routing.
- Corrected to `/app/wiki/functional-facilities#the-industry` — the slug matches the `functional-facilities.mdx` filename and the anchor matches the `rehypeSlug`-generated id for the `## The Industry` heading.

## Notes
The same broken-link pattern (`/wiki/...` with underscore slugs) exists in other `assets.py` descriptions and `functional.tsx`'s help dialog, but this is scoped to the industry dialog only per the issue discussion.

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes broken external Wikipedia "Learn more" links from the technology detail dialog and fixes the wiki link in the Industry facility description. The changes are narrow and well-scoped, touching only the two files identified in issue #714.

- `technology-detail-dialog.tsx`: Drops the `wikipedia_link` prop field, the `ExternalLink` import, and the external `<a>` link that pointed at often-empty or broken Wikipedia URLs; the working internal Knowledge Spillover "Learn more" link is intentionally preserved.
- `assets.py`: Corrects the Industry description's `See wiki` href from the defunct Jinja `/wiki/functional_facilities#The_Industry` path to the correct SPA route `/app/wiki/functional-facilities#the-industry`, which maps to the `functional-facilities.mdx` file and its `rehypeSlug`-generated `the-industry` anchor.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are targeted removals or link corrections with no logic at risk.

The technology dialog change simply removes dead UI (a broken external link and its unused prop), while the assets.py change swaps one string for a corrected one. The corrected path matches the actual MDX filename and the rehypeSlug-generated heading anchor, and the internal Knowledge Spillover link is untouched.

No files require special attention. Other broken wiki links noted in the PR description remain but are explicitly out of scope for this fix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/technologies/technology-detail-dialog.tsx | Removed the broken 'Learn more' external Wikipedia link and its associated `wikipedia_link` prop field and `ExternalLink` import; the Knowledge Spillover internal wiki link is preserved; no logic changes. |
| energetica/config/assets.py | Fixed the Industry description's wiki link from the old Jinja-style `/wiki/functional_facilities#The_Industry` to the correct SPA route `/app/wiki/functional-facilities#the-industry`; slug and anchor match the MDX file and rehypeSlug output. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Technology Page] --> B[TechnologyDetailDialog]
    B --> C[Description HTML]
    B --> D[Affected Facilities Links]
    B --> E{Has discount?}
    E -->|yes| F[Knowledge Spillover Badge]
    F --> G[Internal wiki link kept]
    B --> X[External Wikipedia link removed]

    H[Industry Facility Dialog] --> I[Description with See wiki]
    I --> J[Fixed SPA wiki path]
    I --> Y[Old Jinja path removed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Technology Page] --> B[TechnologyDetailDialog]
    B --> C[Description HTML]
    B --> D[Affected Facilities Links]
    B --> E{Has discount?}
    E -->|yes| F[Knowledge Spillover Badge]
    F --> G[Internal wiki link kept]
    B --> X[External Wikipedia link removed]

    H[Industry Facility Dialog] --> I[Description with See wiki]
    I --> J[Fixed SPA wiki path]
    I --> Y[Old Jinja path removed]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(technology): remove broken &quot;learn mo..."](https://github.com/felixvonsamson/energetica/commit/88a9d2eb0c2f78f9adcd7f59ff8ea369e4aebde8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41219272)</sub>

<!-- /greptile_comment -->