### PR TITLE
feat(markets): default electricity breakdown view to by-facility

### DIFF
--- a/frontend/src/routes/app/overviews/electricity-markets.tsx
+++ b/frontend/src/routes/app/overviews/electricity-markets.tsx
@@ -176,7 +176,7 @@ function MarketsOverviewContent() {
     );
     const [breakdownMode, setBreakdownMode] = useLocalStorage<BreakdownMode>(
         "energetica:chart:markets:breakdownMode",
-        "player",
+        "type",
     );
     const [hiddenBreakdownItems, toggleBreakdownItem] = useToggleSet<string>(
         undefined,


### PR DESCRIPTION
Addresses #750.

## Change
The Electricity Markets "Market Clearing Volume" breakdown chart now defaults to **By Facility** (`"type"`) instead of **By Player** (`"player"`).

## Notes
- This is a `useLocalStorage` default, so it only changes the initial view for users who haven't already picked a breakdown mode — existing choices are preserved.
- Scoped to this one breakdown default only. The emissions-chart default changes discussed in the issue (Relative/Concentration) were rejected by @felixvonsamson, so they're untouched.
- The UI label for this mode currently reads "By Type" rather than "By Facility"; left as-is to keep the change minimal. Happy to rename it if preferred.

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the default breakdown view for the Electricity Markets \"Market Clearing Volume\" chart from **By Player** (`\"player\"`) to **By Facility/Type** (`\"type\"`). Because the value is stored via `useLocalStorage`, the change only affects users who have not yet made a manual selection — existing preferences are untouched.

- The new default `\"type\"` is a valid member of `BreakdownMode = \"player\" | \"type\"`, so no type error is introduced.
- No other defaults, labels, or chart logic are changed; the PR is tightly scoped to the single one-line diff.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line default value change with no side effects on existing user data or chart logic.

The only change is swapping a useLocalStorage default from 'player' to 'type'. Both values are explicitly valid members of the BreakdownMode union type, the new default is only applied to users who have never set the preference, and no chart rendering logic or data flow is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/routes/app/overviews/electricity-markets.tsx | Changes the useLocalStorage default for breakdownMode from 'player' to 'type' — a valid BreakdownMode value that only affects first-time/unset users. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant LS as LocalStorage
    participant Chart as MarketClearingVolumeChart

    User->>LS: First visit (no stored key)
    LS-->>Chart: "default = "type" (was "player")"
    Chart->>User: Renders breakdown by Facility/Type

    User->>LS: Subsequent visits (key already set)
    LS-->>Chart: persisted user preference (unchanged)
    Chart->>User: Renders breakdown per user choice
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant LS as LocalStorage
    participant Chart as MarketClearingVolumeChart

    User->>LS: First visit (no stored key)
    LS-->>Chart: "default = "type" (was "player")"
    Chart->>User: Renders breakdown by Facility/Type

    User->>LS: Subsequent visits (key already set)
    LS-->>Chart: persisted user preference (unchanged)
    Chart->>User: Renders breakdown per user choice
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(markets): default electricity break..."](https://github.com/felixvonsamson/energetica/commit/7c9a3d249d511c096b8e599b44a1c70a8cf46713) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41222527)</sub>

<!-- /greptile_comment -->