### PR TITLE
feat: enforce 15-player limit on electricity market networks

### DIFF
--- a/energetica/config/constants.py
+++ b/energetica/config/constants.py
@@ -1,0 +1,3 @@
+"""Game-wide configuration constants."""
+
+NETWORK_MEMBER_LIMIT = 15

--- a/energetica/game_error.py
+++ b/energetica/game_error.py
@@ -73,6 +73,7 @@ class GameExceptionType(StrEnum):
     PLAYER_ALREADY_IN_NETWORK = "playerAlreadyInNetwork"
     NAME_ALREADY_USED = "nameAlreadyUsed"
     NOT_IN_NETWORK = "notInNetwork"
+    NETWORK_FULL = "networkFull"
     # Resource market
     NOT_ENOUGH_RESOURCE = "notEnoughResource"
     INVALID_QUANTITY = "invalidQuantity"

--- a/energetica/schemas/electricity_markets.py
+++ b/energetica/schemas/electricity_markets.py
@@ -17,6 +17,8 @@ from energetica.enums import (
 if TYPE_CHECKING:
     from energetica.database.network import Network
 
+from energetica.config.constants import NETWORK_MEMBER_LIMIT
+
 
 class ElectricityMarketBase(BaseModel):
     name: str = Field(min_length=3, max_length=40, description="Name of the electricity market")
@@ -25,6 +27,7 @@ class ElectricityMarketBase(BaseModel):
 class ElectricityMarketOut(ElectricityMarketBase):
     id: int = Field(description="ID of the electricity market")
     member_ids: list[int] = Field(description="List of player IDs in the electricity market")
+    member_limit: int = Field(description="Maximum number of members allowed in this market")
     created_tick: int = Field(description="Tick when the electricity market was created")
 
     @classmethod
@@ -33,6 +36,7 @@ class ElectricityMarketOut(ElectricityMarketBase):
             id=network.id,
             name=network.name,
             member_ids=[member.id for member in network.members],
+            member_limit=NETWORK_MEMBER_LIMIT,
             created_tick=network.created_tick,
         )
 

--- a/energetica/utils/network_helpers.py
+++ b/energetica/utils/network_helpers.py
@@ -5,6 +5,8 @@ from energetica.database.player import Player
 from energetica.game_error import GameError, GameExceptionType
 from energetica.globals import engine
 
+NETWORK_MEMBER_LIMIT = 15
+
 
 # TODO (Felix): Move this to a method in Player
 def join_network(player: Player, network: Network | None) -> Network:
@@ -17,6 +19,8 @@ def join_network(player: Player, network: Network | None) -> Network:
         raise GameError(GameExceptionType.NO_SUCH_NETWORK)
     if player.money <= 0:
         raise GameError(GameExceptionType.NOT_ENOUGH_MONEY)
+    if len(network.members) >= NETWORK_MEMBER_LIMIT:
+        raise GameError(GameExceptionType.NETWORK_FULL)
     if player.network is not None:
         leave_network(player)
     player.network = network

--- a/energetica/utils/network_helpers.py
+++ b/energetica/utils/network_helpers.py
@@ -1,11 +1,10 @@
 """Utility functions relating to electricity market networks."""
 
+from energetica.config.constants import NETWORK_MEMBER_LIMIT
 from energetica.database.network import Network
 from energetica.database.player import Player
 from energetica.game_error import GameError, GameExceptionType
 from energetica.globals import engine
-
-NETWORK_MEMBER_LIMIT = 15
 
 
 # TODO (Felix): Move this to a method in Player

--- a/frontend/src/components/electricity-markets/join-market-dialog.tsx
+++ b/frontend/src/components/electricity-markets/join-market-dialog.tsx
@@ -19,7 +19,6 @@ import {
 } from "@/hooks/use-electricity-markets";
 import { usePlayerMoney } from "@/hooks/use-player-money";
 import { useMyId } from "@/hooks/use-players";
-import { NETWORK_MEMBER_LIMIT } from "@/lib/network-constants";
 
 interface JoinMarketDialogProps {
     isOpen: boolean;
@@ -54,7 +53,8 @@ export function JoinMarketDialog({
     const willDeleteCurrentNetwork =
         isAlreadyInMarket && currentMarketMemberCount === 1;
     const isMarketFull =
-        market != null && market.member_ids.length >= NETWORK_MEMBER_LIMIT;
+        market != null &&
+        market.member_ids.length >= market.member_limit;
 
     // Reset state when dialog closes
     const handleClose = () => {
@@ -134,7 +134,7 @@ export function JoinMarketDialog({
                                     </p>
                                     <p className="text-sm">
                                         This market has reached its limit of{" "}
-                                        {NETWORK_MEMBER_LIMIT} members and is
+                                        {market!.member_limit} members and is
                                         not accepting new players.
                                     </p>
                                 </div>

--- a/frontend/src/components/electricity-markets/join-market-dialog.tsx
+++ b/frontend/src/components/electricity-markets/join-market-dialog.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/hooks/use-electricity-markets";
 import { usePlayerMoney } from "@/hooks/use-player-money";
 import { useMyId } from "@/hooks/use-players";
+import { NETWORK_MEMBER_LIMIT } from "@/lib/network-constants";
 
 interface JoinMarketDialogProps {
     isOpen: boolean;
@@ -52,6 +53,8 @@ export function JoinMarketDialog({
     const isAlreadyInMarket = currentMarketId !== null;
     const willDeleteCurrentNetwork =
         isAlreadyInMarket && currentMarketMemberCount === 1;
+    const isMarketFull =
+        market != null && market.member_ids.length >= NETWORK_MEMBER_LIMIT;
 
     // Reset state when dialog closes
     const handleClose = () => {
@@ -119,6 +122,22 @@ export function JoinMarketDialog({
                         {error && (
                             <InfoBanner variant="error" className="text-sm">
                                 {error}
+                            </InfoBanner>
+                        )}
+
+                        {/* Market full warning */}
+                        {isMarketFull && (
+                            <InfoBanner variant="error">
+                                <div>
+                                    <p className="font-semibold mb-1">
+                                        Market is full
+                                    </p>
+                                    <p className="text-sm">
+                                        This market has reached its limit of{" "}
+                                        {NETWORK_MEMBER_LIMIT} members and is
+                                        not accepting new players.
+                                    </p>
+                                </div>
                             </InfoBanner>
                         )}
 
@@ -216,7 +235,11 @@ export function JoinMarketDialog({
                             type="submit"
                             form="join-market-form"
                             variant={isPending ? "outline" : "default"}
-                            disabled={isPending || hasInsufficientFunds}
+                            disabled={
+                                isPending ||
+                                hasInsufficientFunds ||
+                                isMarketFull
+                            }
                             className="flex items-center gap-2"
                         >
                             {isPending && <Spinner />}

--- a/frontend/src/components/electricity-markets/market-item.tsx
+++ b/frontend/src/components/electricity-markets/market-item.tsx
@@ -2,7 +2,6 @@ import { PlugZap, Check, Lock } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { useMyMarket } from "@/hooks/use-electricity-markets";
-import { NETWORK_MEMBER_LIMIT } from "@/lib/network-constants";
 import { cn } from "@/lib/utils";
 import { ElectricityMarket } from "@/types/electricity-markets";
 
@@ -19,7 +18,8 @@ export function MarketItem({ market, onClick }: MarketItemProps) {
     const currentMarket = useMyMarket();
     const isCurrentMarket = currentMarket?.id === market.id;
     const isFull =
-        !isCurrentMarket && market.member_ids.length >= NETWORK_MEMBER_LIMIT;
+        !isCurrentMarket &&
+        market.member_ids.length >= market.member_limit;
 
     return (
         <Card
@@ -72,7 +72,7 @@ export function MarketItem({ market, onClick }: MarketItemProps) {
                 <div className="flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
                     <PlugZap className="w-4 h-4" />
                     <span>
-                        {market.member_ids.length}/{NETWORK_MEMBER_LIMIT}{" "}
+                        {market.member_ids.length}/{market.member_limit}{" "}
                         {market.member_ids.length === 1 ? "member" : "members"}
                     </span>
                 </div>

--- a/frontend/src/components/electricity-markets/market-item.tsx
+++ b/frontend/src/components/electricity-markets/market-item.tsx
@@ -1,7 +1,8 @@
-import { PlugZap, Check } from "lucide-react";
+import { PlugZap, Check, Lock } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui";
 import { useMyMarket } from "@/hooks/use-electricity-markets";
+import { NETWORK_MEMBER_LIMIT } from "@/lib/network-constants";
 import { cn } from "@/lib/utils";
 import { ElectricityMarket } from "@/types/electricity-markets";
 
@@ -17,13 +18,17 @@ interface MarketItemProps {
 export function MarketItem({ market, onClick }: MarketItemProps) {
     const currentMarket = useMyMarket();
     const isCurrentMarket = currentMarket?.id === market.id;
+    const isFull =
+        !isCurrentMarket && market.member_ids.length >= NETWORK_MEMBER_LIMIT;
 
     return (
         <Card
             className={cn(
                 "cursor-pointer transition-all duration-200",
-                "hover:border-brand-green hover:scale-105",
                 "flex flex-col h-full relative",
+                isFull
+                    ? "opacity-60"
+                    : "hover:border-brand-green hover:scale-105",
                 isCurrentMarket && "border-brand-green bg-muted",
             )}
             onClick={onClick}
@@ -32,6 +37,13 @@ export function MarketItem({ market, onClick }: MarketItemProps) {
             {isCurrentMarket && (
                 <div className="absolute top-2 right-2 bg-brand text-white rounded-full p-1">
                     <Check className="w-4 h-4" />
+                </div>
+            )}
+
+            {/* Full badge */}
+            {isFull && (
+                <div className="absolute top-2 right-2 bg-muted-foreground text-background rounded-full p-1">
+                    <Lock className="w-4 h-4" />
                 </div>
             )}
 
@@ -60,7 +72,7 @@ export function MarketItem({ market, onClick }: MarketItemProps) {
                 <div className="flex items-center justify-center gap-1.5 text-sm text-muted-foreground">
                     <PlugZap className="w-4 h-4" />
                     <span>
-                        {market.member_ids.length}{" "}
+                        {market.member_ids.length}/{NETWORK_MEMBER_LIMIT}{" "}
                         {market.member_ids.length === 1 ? "member" : "members"}
                     </span>
                 </div>

--- a/frontend/src/lib/game-messages.ts
+++ b/frontend/src/lib/game-messages.ts
@@ -83,6 +83,7 @@ export const GAME_ERROR_MESSAGES: Record<GameExceptionType, string> = {
     nameAlreadyUsed: "This market name is already in use.",
     notInNetwork: "You are not a member of this market.",
     noSuchNetwork: "This electricity market does not exist.",
+    networkFull: "This market has reached its maximum number of members.",
     malformedRequest: "Invalid request. Please check your input.",
     storagePriceInversion:
         "Invalid order: a storage facility's discharge price must be higher than its charge price.",

--- a/frontend/src/lib/network-constants.ts
+++ b/frontend/src/lib/network-constants.ts
@@ -1,0 +1,1 @@
+export const NETWORK_MEMBER_LIMIT = 15;

--- a/frontend/src/lib/network-constants.ts
+++ b/frontend/src/lib/network-constants.ts
@@ -1,1 +1,0 @@
-export const NETWORK_MEMBER_LIMIT = 15;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2487,6 +2487,12 @@ export interface components {
              */
             member_ids: number[];
             /**
+             * Member Limit
+             *
+             * Maximum number of members allowed in this market
+             */
+            member_limit: number;
+            /**
              * Created Tick
              *
              * Tick when the electricity market was created
@@ -4820,6 +4826,7 @@ export interface components {
             | "playerAlreadyInNetwork"
             | "nameAlreadyUsed"
             | "notInNetwork"
+            | "networkFull"
             | "notEnoughResource"
             | "invalidQuantity";
     };


### PR DESCRIPTION
Closes #702

## Summary

- **Backend:** Added `NETWORK_FULL` game error type and a `NETWORK_MEMBER_LIMIT = 15` constant in `network_helpers.py`; `join_network()` now raises `NETWORK_FULL` before adding a player when the network is at capacity
- **Frontend:** Market cards show `x/15 members` and display a lock badge + reduced opacity when full; the join dialog shows a "Market is full" error banner and disables the join button

## Test plan

- [ ] Verify joining a network with 15 members returns a 400 with `game_exception_type: "networkFull"`
- [ ] Verify a full market card shows the lock icon and `x/15 members` count
- [ ] Verify the join dialog disables the join button and shows the error banner for a full market
- [ ] Verify joining a non-full market still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces a 15-player cap on electricity market networks, adding a backend guard in `join_network()` and surfacing the limit in the frontend market cards and join dialog.

- **Backend**: `NETWORK_MEMBER_LIMIT = 15` is defined in `network_helpers.py` and checked in `join_network()` before any state mutations (leaving the current network, appending to the target), so a full-network rejection is clean with no side effects. A new `NETWORK_FULL` game error type is wired up correctly.
- **Frontend**: `MarketItem` shows `x/15 members`, dims full cards with `opacity-60`, and adds a lock badge (correctly skipping the player's own market). `JoinMarketDialog` derives `isMarketFull` from live member count, shows an error banner, and disables the join button.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the backend enforces the limit before any mutations and the frontend accurately reflects it.

The capacity check in `join_network()` is placed before `leave_network()` and before `network.members.append()`, so a rejected join leaves both the player and the network in their original state. The frontend derives `isMarketFull` directly from the live `member_ids` array, so the UI stays in sync with real data. No existing paths are broken and no new state can be corrupted.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/utils/network_helpers.py | Adds NETWORK_MEMBER_LIMIT = 15 constant and enforces it in join_network() before any state mutations (leave_network / append), which is the correct ordering. |
| energetica/game_error.py | Adds NETWORK_FULL = "networkFull" to GameExceptionType; straightforward, no issues. |
| frontend/src/components/electricity-markets/market-item.tsx | Adds isFull guard (excluding the player's own market), lock badge, opacity-60, and x/15 member count display; logic is correct. |
| frontend/src/components/electricity-markets/join-market-dialog.tsx | Adds isMarketFull derived state, shows error banner, and disables join button; correctly handles the full-market UX path. |
| frontend/src/lib/network-constants.ts | New file exporting NETWORK_MEMBER_LIMIT = 15; duplicated constant is an acknowledged trade-off per prior thread. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Player clicks Join Market] --> B{isMarketFull?}
    B -- Yes --> C[Show 'Market is full' banner\nDisable join button]
    B -- No --> D{hasInsufficientFunds?}
    D -- Yes --> E[Show 'Insufficient funds' banner\nDisable join button]
    D -- No --> F[User submits join form]
    F --> G[POST /join-network]
    G --> H{Backend checks}
    H -->|NETWORK_NOT_UNLOCKED| I[GameError]
    H -->|NO_SUCH_NETWORK| I
    H -->|NOT_ENOUGH_MONEY| I
    H -->|len members >= 15| J[GameError: NETWORK_FULL]
    H -->|OK| K[leave_network if in one]
    K --> L[append player to network]
    L --> M[invalidate electricity-markets cache]
    M --> N[Return network]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Player clicks Join Market] --> B{isMarketFull?}
    B -- Yes --> C[Show 'Market is full' banner\nDisable join button]
    B -- No --> D{hasInsufficientFunds?}
    D -- Yes --> E[Show 'Insufficient funds' banner\nDisable join button]
    D -- No --> F[User submits join form]
    F --> G[POST /join-network]
    G --> H{Backend checks}
    H -->|NETWORK_NOT_UNLOCKED| I[GameError]
    H -->|NO_SUCH_NETWORK| I
    H -->|NOT_ENOUGH_MONEY| I
    H -->|len members >= 15| J[GameError: NETWORK_FULL]
    H -->|OK| K[leave_network if in one]
    K --> L[append player to network]
    L --> M[invalidate electricity-markets cache]
    M --> N[Return network]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["refactor: expose network member limit vi..."](https://github.com/felixvonsamson/energetica/commit/64b2479952cc898de9900cccacdf01d2a55b67fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41437454)</sub>

<!-- /greptile_comment -->