### PR TITLE
feat: reduce knowledge spillover to 2% and apply to time and energy

### DIFF
--- a/energetica/config/assets.py
+++ b/energetica/config/assets.py
@@ -483,7 +483,7 @@ const_config: dict = {
         "mathematics": {
             "name": "Mathematics",
             "type": "Technology",
-            "base_price": 36_000,  # [¤]
+            "base_price": 39_600,  # [¤]
             "base_construction_time": timedelta(days=1, hours=1).total_seconds(),  # [in-game seconds]
             "base_construction_energy": 5_000_000,  # [Wh]
             "price_multiplier": 1.3,
@@ -496,7 +496,7 @@ const_config: dict = {
         "mechanical_engineering": {
             "name": "Mechanical Engineering",
             "type": "Technology",
-            "base_price": 36_000,
+            "base_price": 39_600,
             "base_construction_time": timedelta(days=1, hours=1).total_seconds(),
             "base_construction_energy": 5_000_000,
             "price_multiplier": 1.3,
@@ -518,7 +518,7 @@ const_config: dict = {
         "thermodynamics": {
             "name": "Thermodynamics",
             "type": "Technology",
-            "base_price": 36_000,
+            "base_price": 39_600,
             "base_construction_time": timedelta(days=1, hours=1).total_seconds(),
             "base_construction_energy": 5_000_000,
             "price_multiplier": 1.3,
@@ -540,7 +540,7 @@ const_config: dict = {
         "physics": {
             "name": "Physics",
             "type": "Technology",
-            "base_price": 36_000,
+            "base_price": 39_600,
             "base_construction_time": timedelta(days=1, hours=1).total_seconds(),
             "base_construction_energy": 5_000_000,
             "price_multiplier": 1.3,
@@ -561,7 +561,7 @@ const_config: dict = {
         "building_technology": {
             "name": "Building Technology",
             "type": "Technology",
-            "base_price": 56_000,
+            "base_price": 61_600,
             "base_construction_time": timedelta(days=1, hours=16).total_seconds(),
             "base_construction_energy": 16_000_000,
             "price_multiplier": 1.3,
@@ -575,7 +575,7 @@ const_config: dict = {
         "mineral_extraction": {
             "name": "Mineral Extraction",
             "type": "Technology",
-            "base_price": 32_000,
+            "base_price": 35_200,
             "base_construction_time": timedelta(hours=20).total_seconds(),
             "base_construction_energy": 8_000_000,
             "price_multiplier": 1.4,
@@ -596,7 +596,7 @@ const_config: dict = {
         "transport_technology": {
             "name": "Transport Technology",
             "type": "Technology",
-            "base_price": 56_000,
+            "base_price": 61_600,
             "base_construction_time": timedelta(days=1, hours=16).total_seconds(),
             "base_construction_energy": 24_000_000,
             "price_multiplier": 1.4,
@@ -611,7 +611,7 @@ const_config: dict = {
         "materials": {
             "name": "Materials",
             "type": "Technology",
-            "base_price": 84_000,
+            "base_price": 92_400,
             "base_construction_time": timedelta(days=2, hours=12).total_seconds(),
             "base_construction_energy": 48_000_000,
             "price_multiplier": 1.4,
@@ -632,7 +632,7 @@ const_config: dict = {
         "civil_engineering": {
             "name": "Civil Engineering",
             "type": "Technology",
-            "base_price": 28_000,
+            "base_price": 30_800,
             "base_construction_time": timedelta(hours=20).total_seconds(),
             "base_construction_energy": 16_000_000,
             "price_multiplier": 1.25,
@@ -653,7 +653,7 @@ const_config: dict = {
         "aerodynamics": {
             "name": "Aerodynamics",
             "type": "Technology",
-            "base_price": 84_000,
+            "base_price": 92_400,
             "base_construction_time": timedelta(days=2, hours=12).total_seconds(),
             "base_construction_energy": 60_000_000,
             "price_multiplier": 1.5,
@@ -672,7 +672,7 @@ const_config: dict = {
         "chemistry": {
             "name": "Chemistry",
             "type": "Technology",
-            "base_price": 60_000,
+            "base_price": 66_000,
             "base_construction_time": timedelta(days=1, hours=16).total_seconds(),
             "base_construction_energy": 40_000_000,
             "price_multiplier": 1.4,
@@ -691,7 +691,7 @@ const_config: dict = {
         "nuclear_engineering": {
             "name": "Nuclear Engineering",
             "type": "Technology",
-            "base_price": 140_000,
+            "base_price": 154_000,
             "base_construction_time": timedelta(days=3, hours=18).total_seconds(),
             "base_construction_energy": 108_000_000,
             "price_multiplier": 1.5,

--- a/energetica/technology_effects.py
+++ b/energetica/technology_effects.py
@@ -77,7 +77,7 @@ def knowledge_spillover_discount(times_researched: int) -> float:
     :param times_researched: the number of players that have researched the technology
     :return: the discount factor. 1.0 means no discount, 0.8 means a 20% discount
     """
-    return 0.92**times_researched
+    return 0.98**times_researched
 
 
 def price_multiplier(player: Player, project_type: ProjectType) -> float:
@@ -398,6 +398,9 @@ def construction_time(player: Player, project_type: ProjectType) -> float:
                 const_config["laboratory"]["time_factor"]
                 ** player.functional_facility_lvl[FunctionalFacilityType.LABORATORY]
             )
+            duration *= knowledge_spillover_discount(
+                research_prevalence(project_type, next_level(player, project_type))
+            )
     # building technology time reduction
     if isinstance(
         project_type,
@@ -460,6 +463,10 @@ def construction_power(player: Player, project_type: ProjectType) -> float:
     if isinstance(project_type, FunctionalFacilityType | TechnologyType):
         facility_next_level = next_level(player, project_type)
         power *= const_config[project_type]["price_multiplier"] ** (facility_next_level - 1)
+        if isinstance(project_type, TechnologyType):
+            # knowledge spillover reduces total energy: since construction_time already applies the
+            # discount, multiplying power by it again keeps power constant and reduces total energy
+            power *= knowledge_spillover_discount(research_prevalence(project_type, facility_next_level))
     return power
 
 

--- a/frontend/src/components/electricity-markets/join-market-dialog.tsx
+++ b/frontend/src/components/electricity-markets/join-market-dialog.tsx
@@ -53,8 +53,7 @@ export function JoinMarketDialog({
     const willDeleteCurrentNetwork =
         isAlreadyInMarket && currentMarketMemberCount === 1;
     const isMarketFull =
-        market != null &&
-        market.member_ids.length >= market.member_limit;
+        market != null && market.member_ids.length >= market.member_limit;
 
     // Reset state when dialog closes
     const handleClose = () => {

--- a/frontend/src/components/electricity-markets/market-item.tsx
+++ b/frontend/src/components/electricity-markets/market-item.tsx
@@ -18,8 +18,7 @@ export function MarketItem({ market, onClick }: MarketItemProps) {
     const currentMarket = useMyMarket();
     const isCurrentMarket = currentMarket?.id === market.id;
     const isFull =
-        !isCurrentMarket &&
-        market.member_ids.length >= market.member_limit;
+        !isCurrentMarket && market.member_ids.length >= market.member_limit;
 
     return (
         <Card

--- a/tests/unit/test_technology_effects.py
+++ b/tests/unit/test_technology_effects.py
@@ -1,0 +1,48 @@
+"""Unit tests for technology_effects.py — knowledge spillover and energy invariant."""
+
+import pytest
+
+from energetica import create_app
+from energetica.database.map.hex_tile import HexTile
+from energetica.database.user import User
+from energetica.enums import TechnologyType
+from energetica.globals import engine
+from energetica.technology_effects import (
+    construction_power,
+    construction_time,
+    knowledge_spillover_discount,
+)
+from energetica.utils.auth import generate_password_hash
+from energetica.utils.map_helpers import confirm_location
+
+
+def test_knowledge_spillover_discount() -> None:
+    """knowledge_spillover_discount is 0.98^n with no setup required."""
+    assert knowledge_spillover_discount(0) == pytest.approx(1.0)
+    assert knowledge_spillover_discount(1) == pytest.approx(0.98)
+    assert knowledge_spillover_discount(5) == pytest.approx(0.98**5)
+
+
+@pytest.mark.parametrize("n_researchers", [0, 1, 5])
+def test_technology_total_energy_scales_with_spillover(n_researchers: int) -> None:
+    """Total research energy equals base_energy × spillover_discount.
+
+    construction_power already cancels the 1/f boost from the discounted
+    construction_time, so power stays constant while the shorter duration
+    reduces total energy by f = 0.98^n.
+    """
+    create_app(rm_instance=True, skip_adding_handlers=True, env="prod")
+    user = User(username="username", pwhash=generate_password_hash("password"), role="player", account_id=1)
+    player = confirm_location(user, HexTile.getitem(1))
+
+    technology = TechnologyType.MATHEMATICS
+    engine.technology_lvls[technology][0] = n_researchers
+
+    base_energy = engine.const_config["assets"][technology]["base_construction_energy"]  # Wh
+    f = knowledge_spillover_discount(n_researchers)
+
+    ticks = construction_time(player, technology)
+    power = construction_power(player, technology)  # W
+    total_energy = power * ticks * engine.in_game_seconds_per_tick / 3600  # Wh
+
+    assert total_energy == pytest.approx(base_energy * f, rel=1e-6)


### PR DESCRIPTION
## Summary

- Reduces knowledge spillover rate from 8% to 2% per player who has researched a technology (`0.92^n` → `0.98^n`)
- Applies the spillover discount to **research time** (previously only affected monetary cost)
- Applies the spillover discount to **total research energy** (previously only affected monetary cost)
- Increases base price of all 12 technologies by 10%

## How the energy reduction works

`construction_power` for technologies is derived as `base_construction_energy / construction_time`. When `construction_time` is reduced by spillover discount `f`, power increases by `1/f`, keeping total energy constant. To also reduce total energy by `f`, an additional `* f` is applied to `construction_power` for `TechnologyType`.

Closes #704

## Test plan

- [ ] Verify `knowledge_spillover_discount` returns `0.98^n` for n players
- [ ] Check that researching a technology with spillover reduces both the displayed time and energy cost in the UI
- [ ] Confirm technology prices are all 10% higher than before
- [ ] All existing tests pass (excluding pre-existing flaky external URL test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces the knowledge spillover discount rate from `0.92^n` to `0.98^n`, extends the discount to cover research time and total energy (previously only monetary cost), and raises all 12 technology base prices by exactly 10%.

- **`technology_effects.py`**: `construction_time` now multiplies by the spillover discount for `TechnologyType`, and `construction_power` multiplies by it a second time so that the `1/f` power boost from the shorter research window is cancelled — leaving power unchanged while total energy scales by `f`.
- **`assets.py`**: All 12 technology `base_price` values increased by 10% (verified: 36 k → 39.6 k, 56 k → 61.6 k, 84 k → 92.4 k, etc.).
- **`test_technology_effects.py`** (new file): Adds a parametrized test asserting `total_energy ≈ base_energy × 0.98^n` for n = 0, 1, 5, directly validating the core invariant of the PR.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the energy invariant is mathematically sound and verified by the new parametrized test.

The core invariant (total_energy = base_energy × 0.98^n) holds because construction_power divides by the discounted construction_time (gaining a 1/f boost) and then explicitly multiplies by f again, leaving power unchanged while the shorter time window reduces total energy by exactly f. All 12 price increases are the correct 10%. Frontend changes are purely cosmetic reformatting with no logic impact.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/technology_effects.py | Correctly applies knowledge spillover to construction_time and construction_power; math is sound — power ∝ 1/f from shorter time, then ×f to cancel, so total energy ∝ f. |
| energetica/config/assets.py | All 12 technology base prices increased by exactly 10%; all calculations verified correct. |
| tests/unit/test_technology_effects.py | New test file with two tests: one directly validates the 0.98^n formula, and a parametrized test verifies the total-energy invariant for n=0,1,5. |
| frontend/src/components/electricity-markets/join-market-dialog.tsx | Cosmetic reformatting only — boolean expression collapsed to one line; no logic change. |
| frontend/src/components/electricity-markets/market-item.tsx | Cosmetic reformatting only — boolean expression collapsed to one line; no logic change. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[construction_time player, TechnologyType] --> B[base_time / in_game_seconds_per_tick]
    B --> C["× price_multiplier^(0.6 × level_with_constructions)"]
    C --> D["× lab_time_factor^lab_level"]
    D --> E["× knowledge_spillover_discount = 0.98^n"]
    E --> F[construction_time in ticks = T × f]

    G[construction_power player, TechnologyType] --> H[base_energy / construction_time / ticks_per_s × 3600]
    H --> I["÷ f from above → power boosted by 1/f"]
    I --> J["× price_multiplier^(next_level - 1)"]
    J --> K["× knowledge_spillover_discount = 0.98^n = f  ← NEW"]
    K --> L["power = base_energy / T × price_mlt  (f cancels)"]

    F --> M["total_energy = power × ticks × ticks_per_s / 3600"]
    L --> M
    M --> N["= base_energy × price_mlt × f  ✓ scales with spillover"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[construction_time player, TechnologyType] --> B[base_time / in_game_seconds_per_tick]
    B --> C["× price_multiplier^(0.6 × level_with_constructions)"]
    C --> D["× lab_time_factor^lab_level"]
    D --> E["× knowledge_spillover_discount = 0.98^n"]
    E --> F[construction_time in ticks = T × f]

    G[construction_power player, TechnologyType] --> H[base_energy / construction_time / ticks_per_s × 3600]
    H --> I["÷ f from above → power boosted by 1/f"]
    I --> J["× price_multiplier^(next_level - 1)"]
    J --> K["× knowledge_spillover_discount = 0.98^n = f  ← NEW"]
    K --> L["power = base_energy / T × price_mlt  (f cancels)"]

    F --> M["total_energy = power × ticks × ticks_per_s / 3600"]
    L --> M
    M --> N["= base_energy × price_mlt × f  ✓ scales with spillover"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: add unit tests for knowledge spill..."](https://github.com/felixvonsamson/energetica/commit/32c7ead3a1fdaee79acf987c599ca86081fb7f6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41441419)</sub>

<!-- /greptile_comment -->