### PR TITLE
fix: correct climate event recovery durations in wiki

### DIFF
--- a/frontend/src/content/wiki/climate-effects.mdx
+++ b/frontend/src/content/wiki/climate-effects.mdx
@@ -39,7 +39,7 @@ Heatwaves have a higher chance of occurring with higher global temperatures. The
 
 <PropertiesTable
     properties={[
-        { label: "Recovery time", value: "3 days" },
+        { label: "Recovery time", value: "4 days" },
         {
             label: "Recovery cost",
             value: "25% of current industry revenues",
@@ -74,7 +74,7 @@ Coldwaves have a higher chance of occurring with lower global temperatures. They
 
 <PropertiesTable
     properties={[
-        { label: "Recovery time", value: "3 days" },
+        { label: "Recovery time", value: "4 days" },
         {
             label: "Recovery cost",
             value: "25% of current industry revenues",
@@ -98,7 +98,7 @@ Wildfires have a higher chance of occurring with higher global temperatures. The
 
 <PropertiesTable
     properties={[
-        { label: "Recovery time", value: "2 days" },
+        { label: "Recovery time", value: "3 days" },
         {
             label: "Recovery cost",
             value: "60% of current industry revenues",
@@ -147,7 +147,7 @@ Floods can only occur in tiles with a hydro potential higher than 20% and have a
 
 <PropertiesTable
     properties={[
-        { label: "Recovery time", value: "6 days" },
+        { label: "Recovery time", value: "8 days" },
         {
             label: "Recovery cost",
             value: "50% of current industry revenues",
@@ -194,7 +194,7 @@ The hurricane is the most destructive climate event. It can occur anywhere on th
 
 <PropertiesTable
     properties={[
-        { label: "Recovery time", value: "7 days" },
+        { label: "Recovery time", value: "9 days" },
         {
             label: "Recovery cost",
             value: "80% of current industry revenues",


### PR DESCRIPTION
## Summary

- Wiki recovery times for all five climate events were 1–2 days shorter than the actual backend config (`energetica/config/climate_events.py`)
- Updated `frontend/src/content/wiki/climate-effects.mdx` to match: Heatwave 3→4d, Coldwave 3→4d, Wildfire 2→3d, Flood 6→8d, Hurricane 7→9d

Closes #741

## Test plan

- [ ] Visit `/wiki/climate-effects` and verify each event's Recovery time matches the values in `climate_events.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects five wiki recovery-time values that were 1–2 days shorter than the actual backend configuration in `energetica/config/climate_events.py`.

- **Heatwave** and **Coldwave** recovery times updated 3 → 4 days (matching `timedelta(days=4)` in config).
- **Wildfire** updated 2 → 3 days, **Flood** 6 → 8 days, and **Hurricane** 7 → 9 days — each confirmed against the corresponding `ClimateEvent` constructor in `climate_events.py`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with all five updated values verified against the authoritative backend config.

Every updated recovery duration was cross-checked against energetica/config/climate_events.py: Heatwave 4d, Coldwave 4d, Wildfire 3d, Flood 8d, Hurricane 9d all match exactly. No logic, data, or runtime behaviour is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/content/wiki/climate-effects.mdx | Five recovery-time values updated to match backend config; all new values verified correct against climate_events.py. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[climate_events.py] -->|heat_wave: 4d| B[Wiki: Heatwave 4 days ✓]
    A -->|cold_wave: 4d| C[Wiki: Coldwave 4 days ✓]
    A -->|wildfire: 3d| D[Wiki: Wildfire 3 days ✓]
    A -->|flood: 8d| E[Wiki: Flood 8 days ✓]
    A -->|hurricane: 9d| F[Wiki: Hurricane 9 days ✓]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[climate_events.py] -->|heat_wave: 4d| B[Wiki: Heatwave 4 days ✓]
    A -->|cold_wave: 4d| C[Wiki: Coldwave 4 days ✓]
    A -->|wildfire: 3d| D[Wiki: Wildfire 3 days ✓]
    A -->|flood: 8d| E[Wiki: Flood 8 days ✓]
    A -->|hurricane: 9d| F[Wiki: Hurricane 9 days ✓]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/felixvonsamson/energetica/commit/90a6b1b85fdefea012a43644d2f4ab4236a812ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41443056)</sub>

<!-- /greptile_comment -->