### PR TITLE
feat: show affecting technologies in facility detail dialog

### DIFF
--- a/frontend/src/components/facilities/facility-detail-dialog.tsx
+++ b/frontend/src/components/facilities/facility-detail-dialog.tsx
@@ -1,5 +1,6 @@
+import { Link } from "@tanstack/react-router";
 import { ExternalLink, GitCompareArrows } from "lucide-react";
-import { ReactNode } from "react";
+import { ReactNode, useMemo } from "react";
 
 import { RequirementsDisplay, ConstructionInfo } from "@/components/facilities";
 import {
@@ -7,6 +8,7 @@ import {
     FacilityIcon,
     Money,
     CardContent,
+    AssetName,
 } from "@/components/ui";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,7 +20,8 @@ import {
 } from "@/components/ui/dialog";
 import { TypographyH2 } from "@/components/ui/typography";
 import { useLastDefined } from "@/hooks/use-last-defined";
-import { useQueueProject } from "@/hooks/use-projects";
+import { useQueueProject, useTechnologiesCatalog } from "@/hooks/use-projects";
+import { getTechnologyRoute } from "@/lib/facility-routes";
 import { ProjectType, Requirement } from "@/types/projects";
 
 interface FacilityDetailDialogProps<T> {
@@ -56,6 +59,21 @@ export function FacilityDetailDialog<T>({
 }: FacilityDetailDialogProps<T>) {
     const displayedFacility = useLastDefined(facility);
     const queueProjectMutation = useQueueProject();
+    const { data: technologiesData } = useTechnologiesCatalog();
+
+    // Reverse of each technology's `affected_facilities`: the technologies that
+    // affect the displayed facility. Derived from the same catalog that drives
+    // the forward "Affects:" list in the technology dialog, so the two
+    // directions stay consistent by construction.
+    const affectingTechnologies = useMemo(() => {
+        const name = displayedFacility?.name;
+        if (!name) return [];
+        return (technologiesData?.technologies ?? [])
+            .filter((technology) =>
+                technology.affected_facilities.includes(name),
+            )
+            .map((technology) => technology.name);
+    }, [technologiesData?.technologies, displayedFacility?.name]);
 
     const handleConstruction = () => {
         if (!facility) return;
@@ -75,6 +93,7 @@ export function FacilityDetailDialog<T>({
                         renderStatsTable,
                         onCompare,
                         handleConstruction,
+                        affectingTechnologies,
                     )}
             </DialogContent>
         </Dialog>
@@ -102,6 +121,7 @@ function FacilityContent<T>(
     renderStatsTable: (facility: T) => ReactNode,
     onCompare: ((facility: T) => void) | undefined,
     handleConstruction: () => void,
+    affectingTechnologies: string[],
 ) {
     const imageUrl = `/static/images/${facilityType}_facilities/${facility.name}.png`;
     const isLocked = facility.requirements_status === "unsatisfied";
@@ -185,6 +205,36 @@ function FacilityContent<T>(
                         </div>
                     )}
                 </CardContent>
+
+                {/* Affecting Technologies */}
+                {affectingTechnologies.length > 0 && (
+                    <CardContent>
+                        <strong>Affected by:</strong>{" "}
+                        <span className="text-hyperlink">
+                            {affectingTechnologies.map(
+                                (technologyName, idx) => (
+                                    <span key={technologyName}>
+                                        <Link
+                                            to={getTechnologyRoute(
+                                                technologyName,
+                                            )}
+                                            className="underline hover:opacity-80"
+                                        >
+                                            <AssetName
+                                                assetId={technologyName}
+                                                mode="long"
+                                                className="underline"
+                                            />
+                                        </Link>
+                                        {idx <
+                                            affectingTechnologies.length - 1 &&
+                                            ", "}
+                                    </span>
+                                ),
+                            )}
+                        </span>
+                    </CardContent>
+                )}
 
                 {/* Stats Table + Compare */}
                 <CardContent>


### PR DESCRIPTION
Closes #761.

Technologies already list the facilities they affect; this adds the reverse direction, so a facility's detail dialog lists the technologies that affect it.

## What changed

- Added an **"Affected by:"** section to the shared `FacilityDetailDialog`, between the description and the stats table. Each technology links to its catalog page (`getTechnologyRoute`) and renders via `AssetName`, mirroring the styling of the technology dialog's existing "Affects:" block. The section is hidden when the list is empty.
- The facility→technologies mapping is inverted **client-side** from `useTechnologiesCatalog()` — the same catalog that drives the forward "Affects:" list — so the two directions stay consistent by construction. No backend/schema/API changes.
- Because the logic lives in the single shared `FacilityDetailDialog`, all four facility catalogs (power, storage, extraction, functional) get the feature with no route changes.

## Known limitation

`building_technology` and `transport_technology` have empty `affected_facilities` in the backend `config/assets.py` despite affecting facilities in-game, so they don't appear in the reverse list — exactly as they're already absent from the forward view. Surfacing them is a separate source-data fix, out of scope here.

## Testing

- `bun run typecheck`, `bun run lint`, `bun run format` all pass.
- Verified on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an "Affected by:" section to the shared `FacilityDetailDialog`, showing which technologies affect each facility. The mapping is derived client-side by inverting each technology's `affected_facilities` list from the existing `useTechnologiesCatalog()` hook, so the two directions stay consistent without any backend changes.

- A `useMemo` in `FacilityDetailDialog` filters the technologies catalog for entries whose `affected_facilities` includes the current facility's name, then passes the result to `FacilityContent` as a new `affectingTechnologies: string[]` parameter.
- The new section renders technology links via `getTechnologyRoute` + `AssetName`, mirroring the forward "Affects:" block in `technology-detail-dialog.tsx`. The section is conditionally hidden when the list is empty.
- All four facility catalog types (power, storage, extraction, functional) gain the feature through the single shared component; no route or API changes are required.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is additive, client-side only, and uses already-cached catalog data.

The inversion logic is correct and mirrors the existing technology dialog pattern faithfully. The useTechnologiesCatalog() hook is now called unconditionally from every FacilityDetailDialog instance, but React Query's 10-minute stale time means the catalog is fetched once and shared; there is no double-fetch concern. Clicking a technology link navigates without explicitly closing the dialog, which is consistent with how requirements-display.tsx already handles getTechnologyRoute links. No data correctness or rendering issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/facilities/facility-detail-dialog.tsx | Adds useTechnologiesCatalog hook and a useMemo to compute affecting technologies, then renders an 'Affected by:' section. Logic is correct and mirrors the existing technology dialog pattern; minor note that the tech catalog is now fetched unconditionally by all facility dialogs, and clicking a tech link does not close the dialog. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FacilityDetailDialog mounts] --> B[useTechnologiesCatalog]
    B --> C{technologiesData loaded?}
    C -- No --> D[affectingTechnologies = empty list]
    C -- Yes --> E[filter technologies where\naffected_facilities.includes\ndisplayedFacility.name]
    E --> F[map to technology names]
    F --> G{list empty?}
    D --> G
    G -- Yes --> H[Affected by section hidden]
    G -- No --> I[Render Affected by: section\nwith Link + AssetName per tech]
    I --> J[Link uses getTechnologyRoute\nnavigates to /app/facilities/technology?technology=name]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[FacilityDetailDialog mounts] --> B[useTechnologiesCatalog]
    B --> C{technologiesData loaded?}
    C -- No --> D[affectingTechnologies = empty list]
    C -- Yes --> E[filter technologies where\naffected_facilities.includes\ndisplayedFacility.name]
    E --> F[map to technology names]
    F --> G{list empty?}
    D --> G
    G -- Yes --> H[Affected by section hidden]
    G -- No --> I[Render Affected by: section\nwith Link + AssetName per tech]
    I --> J[Link uses getTechnologyRoute\nnavigates to /app/facilities/technology?technology=name]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat: show affecting technologies in fac..."](https://github.com/felixvonsamson/energetica/commit/f77a5e272ceb89d1d28639dfc5466cd080374221) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41448288)</sub>

<!-- /greptile_comment -->