### PR TITLE
feat: lobby Phase A — membership, my-runs, shared-secret support (#815)

### DIFF
--- a/energetica/accounts/__init__.py
+++ b/energetica/accounts/__init__.py
@@ -9,24 +9,30 @@ from __future__ import annotations
 
 from energetica.accounts.db import (
     Account,
+    Membership,
     UsernameTakenError,
     create_account,
     delete_account,
     get_account_by_username,
+    get_memberships,
     get_or_create_account_id,
     init_db,
+    record_membership,
     update_password,
     verify_password,
 )
 
 __all__ = [
     "Account",
+    "Membership",
     "UsernameTakenError",
     "create_account",
     "delete_account",
     "get_account_by_username",
+    "get_memberships",
     "get_or_create_account_id",
     "init_db",
+    "record_membership",
     "update_password",
     "verify_password",
 ]

--- a/energetica/accounts/db.py
+++ b/energetica/accounts/db.py
@@ -191,7 +191,16 @@ def record_membership(*, account_id: int, slug: str, settled_at: str) -> None:
     Written by the instance when a Player is created (settle). Re-settling is impossible, but
     the write is on the settle path so it must never raise on a duplicate; INSERT OR IGNORE also
     means a re-run of the backfill migration leaves the original ``settled_at`` untouched.
+
+    ``settled_at`` is normalised to a canonical UTC ISO-8601 string at this single write site so
+    that ``get_memberships``' ``ORDER BY settled_at`` (a lexicographic sort on a TEXT column) is
+    always chronological — regardless of the offset or ``Z``/``+00:00`` spelling a caller passes.
+    A naive (tz-less) timestamp is a bug and fails loud rather than sorting unpredictably.
     """
+    parsed = datetime.fromisoformat(settled_at)
+    if parsed.tzinfo is None:
+        raise ValueError(f"settled_at must be timezone-aware, got naive {settled_at!r}")
+    settled_at = parsed.astimezone(timezone.utc).isoformat()
     with _connect() as conn:
         conn.execute(
             "INSERT OR IGNORE INTO instance_membership (account_id, slug, settled_at) VALUES (?, ?, ?)",

--- a/energetica/accounts/db.py
+++ b/energetica/accounts/db.py
@@ -33,6 +33,15 @@ class Account:
     created_at: str
 
 
+@dataclass(frozen=True)
+class Membership:
+    """An account that has settled (has a Player) in a run — one row of the 'your runs' set."""
+
+    account_id: int
+    slug: str
+    settled_at: str
+
+
 class UsernameTakenError(Exception):
     """Raised when a signup or rename collides with an existing username."""
 
@@ -67,6 +76,16 @@ def _create_schema(conn: sqlite3.Connection) -> None:
             email      TEXT             UNIQUE,
             pwhash     TEXT    NOT NULL,
             created_at TEXT    NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS instance_membership (
+            account_id INTEGER NOT NULL,
+            slug       TEXT    NOT NULL,
+            settled_at TEXT    NOT NULL,            -- ISO-8601 UTC
+            PRIMARY KEY (account_id, slug)
         )
         """
     )
@@ -164,3 +183,33 @@ def get_account_by_username(username: str) -> Account | None:
         email=row["email"],
         created_at=row["created_at"],
     )
+
+
+def record_membership(*, account_id: int, slug: str, settled_at: str) -> None:
+    """Record that ``account_id`` has settled in run ``slug``. Idempotent (INSERT OR IGNORE).
+
+    Written by the instance when a Player is created (settle). Re-settling is impossible, but
+    the write is on the settle path so it must never raise on a duplicate; INSERT OR IGNORE also
+    means a re-run of the backfill migration leaves the original ``settled_at`` untouched.
+    """
+    with _connect() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO instance_membership (account_id, slug, settled_at) VALUES (?, ?, ?)",
+            (account_id, slug, settled_at),
+        )
+        conn.commit()
+
+
+def get_memberships(*, account_id: int) -> list[Membership]:
+    """Return the runs ``account_id`` has settled in, most recently settled first.
+
+    Rows for runs later deleted are tolerated here (stale rows) — the caller filters them against
+    the on-disk fragments, matching the RFC's stale-fragment stance.
+    """
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT account_id, slug, settled_at FROM instance_membership "
+            "WHERE account_id = ? ORDER BY settled_at DESC",
+            (account_id,),
+        ).fetchall()
+    return [Membership(account_id=row["account_id"], slug=row["slug"], settled_at=row["settled_at"]) for row in rows]

--- a/energetica/instance_config.py
+++ b/energetica/instance_config.py
@@ -137,6 +137,25 @@ def load_instance_config() -> InstanceConfig | None:
         raise InstanceConfigError(f"invalid instance.json at {path}: {exc}") from exc
 
 
+def load_fragment(slug: str) -> InstanceFragment | None:
+    """Read a single on-disk instance fragment by slug, or ``None`` if it is absent or unreadable.
+
+    Fragments are the public projection published to the landing dir (``name`` / ``advertised`` /
+    ``starts_at``), and exist for **unadvertised** runs too — so this is how an account discovers
+    its own hidden runs when joining ``instance_membership`` against on-disk metadata. A stale
+    membership (run since deleted → fragment gone) or a malformed fragment reads as ``None``, and
+    the caller filters it out.
+    """
+    fragment_path = _landing_dir() / "instances" / f"{slug}.json"
+    if not fragment_path.exists():
+        return None
+    try:
+        return InstanceFragment.model_validate_json(fragment_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.warning("skipping unreadable instance fragment %s", fragment_path)
+        return None
+
+
 def is_access_allowed(config: InstanceConfig, username: str) -> bool:
     """Whether ``username`` may log in / sign up on this instance under ``config``'s policy."""
     if isinstance(config.access, PublicAccess):

--- a/energetica/routers/__init__.py
+++ b/energetica/routers/__init__.py
@@ -31,6 +31,7 @@ from .power_priorities import router as power_priorities
 from .projects import router as projects_router
 from .resource_market import router as resource_market_router
 from .leaderboards import router as leaderboards_router
+from .lobby import router as lobby_router
 from .shipments import router as shipments_router
 from .health import router as health_router
 from .templates import router as templates_router
@@ -48,6 +49,7 @@ api_routers = [
     electricity_markets_router,
     facilities_router,
     game_router,
+    lobby_router,
     map_router,
     notifications_router,
     player_router,

--- a/energetica/routers/lobby.py
+++ b/energetica/routers/lobby.py
@@ -1,0 +1,48 @@
+"""Instance-side lobby reads.
+
+The lobby (a separate service) owns signup/login/session. Each instance additionally serves
+``my-runs`` from its **own** origin so the in-run switcher makes no cross-origin call: identical
+read logic, deployed in every service. Serves only the cookie-authenticated account's runs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from energetica import accounts, instance_config
+from energetica.database.user import User
+from energetica.game_error import GameExceptionType
+from energetica.schemas.lobby import MyRun, MyRunsResponse
+from energetica.utils.auth import get_user
+
+router = APIRouter(prefix="/lobby", tags=["Lobby"])
+
+
+@router.get("/my-runs")
+def get_my_runs(user: Annotated[User | None, Depends(get_user)]) -> MyRunsResponse:
+    """The authenticated account's settled runs, joined against on-disk fragments for name /
+    starts_at, most recently settled first. Stale memberships (run since deleted → no fragment)
+    are filtered out.
+    """
+    if user is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, GameExceptionType.NOT_AUTHENTICATED)
+
+    runs: list[MyRun] = []
+    for membership in accounts.get_memberships(account_id=user.account_id):
+        fragment = instance_config.load_fragment(membership.slug)
+        if fragment is None:
+            continue
+        runs.append(
+            MyRun(
+                slug=fragment.slug,
+                name=fragment.name,
+                starts_at=fragment.starts_at,
+                # Stored as an ISO-8601 string (aware, written from Player.created_at); parse back
+                # to the aware datetime the schema declares rather than lean on Pydantic coercion.
+                settled_at=datetime.fromisoformat(membership.settled_at),
+            )
+        )
+    return MyRunsResponse(runs=runs)

--- a/energetica/schemas/lobby.py
+++ b/energetica/schemas/lobby.py
@@ -1,0 +1,20 @@
+"""Schemas for lobby reads served from the instance (the in-run switcher's 'your runs')."""
+
+from __future__ import annotations
+
+from pydantic import AwareDatetime, BaseModel, Field
+
+
+class MyRun(BaseModel):
+    """One run the authenticated account has settled in, joined with its on-disk fragment."""
+
+    slug: str = Field(description="Subdomain slug of the run")
+    name: str = Field(description="Human-readable run name, from the instance fragment")
+    starts_at: AwareDatetime = Field(description="When the run starts, from the instance fragment")
+    settled_at: AwareDatetime = Field(description="When this account settled in the run")
+
+
+class MyRunsResponse(BaseModel):
+    """The account's settled runs, most recently settled first."""
+
+    runs: list[MyRun]

--- a/energetica/utils/auth.py
+++ b/energetica/utils/auth.py
@@ -25,22 +25,31 @@ def get_or_create_secret_key() -> str:
     2. Otherwise the per-instance ``instance/secret_key.txt`` (the pre-lobby behaviour),
        creating it on first run.
 
-    Both paths are env-overridable for tests.
+    Both paths are env-overridable for tests. An existing-but-empty file fails loud rather than
+    signing cookies with a zero-entropy key (which ``URLSafeTimedSerializer`` would accept) — a
+    truncated write or a cleared file must not silently make every session cookie forgeable.
     """
     shared_path = os.environ.get("ENERGETICA_SHARED_SECRET_PATH", "/var/lib/energetica/secret_key.txt")
     if os.path.exists(shared_path):
-        with open(shared_path, "r", encoding="utf-8") as f:
-            return f.read().strip()
+        return _read_nonempty_secret(shared_path)
 
     instance_path = os.environ.get("ENERGETICA_INSTANCE_SECRET_PATH", "instance/secret_key.txt")
     if os.path.exists(instance_path):
-        with open(instance_path, "r", encoding="utf-8") as f:
-            return f.read().strip()
+        return _read_nonempty_secret(instance_path)
 
     secret_key = secrets.token_hex()
     with open(instance_path, "w", encoding="utf-8") as f:
         f.write(secret_key)
     return secret_key
+
+
+def _read_nonempty_secret(path: str) -> str:
+    """Read a secret-key file, raising if it exists but is empty (guessable zero-entropy key)."""
+    with open(path, "r", encoding="utf-8") as f:
+        key = f.read().strip()
+    if not key:
+        raise RuntimeError(f"secret key file at {path} is empty — refusing to sign cookies with an empty key")
+    return key
 
 
 SECRET_KEY = get_or_create_secret_key()

--- a/energetica/utils/auth.py
+++ b/energetica/utils/auth.py
@@ -15,16 +15,32 @@ from energetica.game_error import GameExceptionType
 
 
 def get_or_create_secret_key() -> str:
-    """Load or create SECRET_KEY for signing cookies."""
-    filepath = "instance/secret_key.txt"
-    if os.path.exists(filepath):
-        with open(filepath, "r", encoding="utf-8") as f:
+    """Load the cookie-signing SECRET_KEY, preferring the server-wide shared secret.
+
+    Resolution order (lobby Phase A — shared-secret *support*, cookie scope unchanged):
+
+    1. The server-wide shared secret ``/var/lib/energetica/secret_key.txt`` if present. It is
+       provisioned by ``setup-base.sh`` and shared across every instance so a session minted by
+       the lobby validates everywhere. Read-only here — the instance never creates it.
+    2. Otherwise the per-instance ``instance/secret_key.txt`` (the pre-lobby behaviour),
+       creating it on first run.
+
+    Both paths are env-overridable for tests.
+    """
+    shared_path = os.environ.get("ENERGETICA_SHARED_SECRET_PATH", "/var/lib/energetica/secret_key.txt")
+    if os.path.exists(shared_path):
+        with open(shared_path, "r", encoding="utf-8") as f:
             return f.read().strip()
-    else:
-        secret_key = secrets.token_hex()
-        with open(filepath, "w", encoding="utf-8") as f:
-            f.write(secret_key)
-        return secret_key
+
+    instance_path = os.environ.get("ENERGETICA_INSTANCE_SECRET_PATH", "instance/secret_key.txt")
+    if os.path.exists(instance_path):
+        with open(instance_path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+
+    secret_key = secrets.token_hex()
+    with open(instance_path, "w", encoding="utf-8") as f:
+        f.write(secret_key)
+    return secret_key
 
 
 SECRET_KEY = get_or_create_secret_key()

--- a/energetica/utils/misc.py
+++ b/energetica/utils/misc.py
@@ -11,7 +11,7 @@ from fastapi import Request
 from noise import pnoise3
 from scipy.stats import norm
 
-from energetica import accounts, technology_effects
+from energetica import accounts, instance_config, technology_effects
 from energetica.config.assets import river_flow_speed_seasonal
 from energetica.database.active_facility import ActiveFacility
 from energetica.database.map.hex_tile import HexTile
@@ -269,6 +269,12 @@ def initialize_player(user: User, tile: HexTile) -> Player:
     player.rolling_history.add_subcategory("op_costs", ControllableFacilityType.STEAM_ENGINE)
     player.rolling_history.add_subcategory("generation", ControllableFacilityType.STEAM_ENGINE)
     player.rolling_history.add_subcategory("emissions", ControllableFacilityType.STEAM_ENGINE)
+
+    # Settling is what makes this run appear under the account's "your runs" in the lobby and the
+    # in-run switcher. No-op without a slug (dev / unconfigured), where there is no lobby anyway.
+    slug = instance_config.instance_slug()
+    if slug is not None:
+        accounts.record_membership(account_id=user.account_id, slug=slug, settled_at=player.created_at.isoformat())
 
     engine.log(f"{player.username} chose the location {tile.id}")
     return player

--- a/energetica/utils/misc.py
+++ b/energetica/utils/misc.py
@@ -3,6 +3,7 @@
 import math
 import os
 import pickle
+import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -272,9 +273,16 @@ def initialize_player(user: User, tile: HexTile) -> Player:
 
     # Settling is what makes this run appear under the account's "your runs" in the lobby and the
     # in-run switcher. No-op without a slug (dev / unconfigured), where there is no lobby anyway.
+    # Best-effort, like instance_config.publish: this runs after the irreversible in-memory settle
+    # above, so a DB failure (e.g. SQLITE_BUSY on the shared accounts.db) must never propagate and
+    # fail an otherwise-successful settle — that would leave the player wedged (settled in-engine
+    # but the request 500s). A missing row is recoverable via scripts/backfill-instance-membership.py.
     slug = instance_config.instance_slug()
     if slug is not None:
-        accounts.record_membership(account_id=user.account_id, slug=slug, settled_at=player.created_at.isoformat())
+        try:
+            accounts.record_membership(account_id=user.account_id, slug=slug, settled_at=player.created_at.isoformat())
+        except (OSError, sqlite3.Error) as exc:
+            engine.log(f"could not record membership for {player.username} in run {slug}: {exc}")
 
     engine.log(f"{player.username} chose the location {tile.id}")
     return player

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1040,6 +1040,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/lobby/my-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get My Runs
+         * @description The authenticated account's settled runs, joined against on-disk fragments for name /
+         *     starts_at, most recently settled first. Stale memberships (run since deleted → no fragment)
+         *     are filtered out.
+         */
+        get: operations["get_my_runs_api_v1_lobby_my_runs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/map": {
         parameters: {
             query?: never;
@@ -2904,6 +2926,42 @@ export interface components {
             series: {
                 [key: string]: number[];
             };
+        };
+        /**
+         * MyRun
+         * @description One run the authenticated account has settled in, joined with its on-disk fragment.
+         */
+        MyRun: {
+            /**
+             * Slug
+             * @description Subdomain slug of the run
+             */
+            slug: string;
+            /**
+             * Name
+             * @description Human-readable run name, from the instance fragment
+             */
+            name: string;
+            /**
+             * Starts At
+             * Format: date-time
+             * @description When the run starts, from the instance fragment
+             */
+            starts_at: string;
+            /**
+             * Settled At
+             * Format: date-time
+             * @description When this account settled in the run
+             */
+            settled_at: string;
+        };
+        /**
+         * MyRunsResponse
+         * @description The account's settled runs, most recently settled first.
+         */
+        MyRunsResponse: {
+            /** Runs */
+            runs: components["schemas"]["MyRun"][];
         };
         /** NetworkExpelledPayload */
         NetworkExpelledPayload: {
@@ -5673,6 +5731,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GameEngineOut"];
+                };
+            };
+        };
+    };
+    get_my_runs_api_v1_lobby_my_runs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MyRunsResponse"];
                 };
             };
         };

--- a/scripts/backfill-instance-membership.py
+++ b/scripts/backfill-instance-membership.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""One-time per-instance migration: backfill instance_membership from already-settled Players.
+
+Players who settled before the instance_membership table existed have no membership row, so the
+lobby would show them zero runs. This writes one row per settled Player in the instance pickle.
+Idempotent (INSERT OR IGNORE) — safe to re-run.
+
+Deploy order (docs/architecture/lobby.md § Phasing): run this AFTER the code that ships the
+instance_membership table is live, and BEFORE the lobby serves my-runs. Stop the instance service
+first (caller's responsibility) to prevent concurrent pickle mutation; this tool only reads the
+pickle, so it does not rewrite it.
+
+Flow:
+1. Load the instance engine pickle (read-only).
+2. For each Player: INSERT OR IGNORE a membership (account_id from player.user, settled_at from
+   player.created_at, slug from --slug / ENERGETICA_INSTANCE_SLUG).
+
+Usage:
+    python scripts/backfill-instance-membership.py --pickle <path> --slug <slug> \
+        [--accounts-db <path>] [--dry-run]
+
+If --slug is omitted it falls back to ENERGETICA_INSTANCE_SLUG. If --accounts-db is omitted it
+defaults to the production path /var/lib/energetica/accounts.db (this is a production-only tool, so
+it pins the prod path rather than inheriting db.py's dev default).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+def backfill_memberships(players: Iterable[object], *, slug: str, dry_run: bool = False) -> int:
+    """Write one membership per settled player. Returns the number of rows written (or, in
+    ``dry_run``, that would be written). Idempotent via accounts.record_membership.
+    """
+    from energetica import accounts
+
+    written = 0
+    for player in players:
+        account_id = player.user.account_id  # type: ignore[attr-defined]
+        settled_at = player.created_at.isoformat()  # type: ignore[attr-defined]
+        if not dry_run:
+            accounts.record_membership(account_id=account_id, slug=slug, settled_at=settled_at)
+        written += 1
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pickle", required=True, type=Path, help="Path to engine_data.pck")
+    parser.add_argument(
+        "--slug",
+        default=os.environ.get("ENERGETICA_INSTANCE_SLUG"),
+        help="Instance slug these players belong to (default: $ENERGETICA_INSTANCE_SLUG).",
+    )
+    parser.add_argument(
+        "--accounts-db",
+        type=Path,
+        default=Path("/var/lib/energetica/accounts.db"),
+        help="Path to accounts.db (default: the production path /var/lib/energetica/accounts.db).",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing.")
+    args = parser.parse_args()
+
+    if not args.slug:
+        print("ERROR: --slug is required (or set ENERGETICA_INSTANCE_SLUG)", file=sys.stderr)
+        return 2
+
+    # Pin the resolved path into the env the accounts library reads, so this prod tool never
+    # inherits db.py's dev-oriented default.
+    os.environ["ENERGETICA_ACCOUNTS_DB_PATH"] = str(args.accounts_db)
+
+    if not args.pickle.exists():
+        print(f"ERROR: pickle not found at {args.pickle}", file=sys.stderr)
+        return 1
+
+    print(f"Loading pickle from {args.pickle}")
+    with args.pickle.open("rb") as f:
+        engine_state = pickle.load(f)
+
+    # Engine.save() pickles a plain dict of members (see game_engine.py), so engine_state is a
+    # dict. db_model_instances["Player"] is an AutoIDDict[Player].
+    player_table = engine_state.get("db_model_instances", {}).get("Player")
+    if player_table is None:
+        print("No Player table found in pickle — nothing to migrate.")
+        return 0
+
+    players = list(player_table.values())
+    print(f"Found {len(players)} settled players")
+    written = backfill_memberships(players, slug=args.slug, dry_run=args.dry_run)
+
+    if args.dry_run:
+        print(f"DRY RUN: would write {written} membership rows for slug {args.slug!r}. No changes written.")
+    else:
+        print(f"Wrote {written} membership rows for slug {args.slug!r} (INSERT OR IGNORE — re-runs are no-ops).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_my_runs_route.py
+++ b/tests/integration/test_my_runs_route.py
@@ -1,0 +1,100 @@
+"""Integration tests for the instance-side ``GET /lobby/my-runs`` endpoint.
+
+Serves **only** the cookie-authenticated account's memberships, joined against the on-disk
+instance fragments for name / starts_at. This is the data source for the in-run switcher.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from energetica import accounts, create_app
+from energetica.globals import engine
+from energetica.schemas.auth import SignupRequest
+
+PORT = 8000
+SIGNUP_URL = f"http://localhost:{PORT}/api/v1/auth/signup"
+MY_RUNS_URL = f"http://localhost:{PORT}/api/v1/lobby/my-runs"
+
+
+@pytest.fixture
+def landing_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the fragment reader at a per-test landing dir and return its instances/ subdir."""
+    instances = tmp_path / "landing" / "instances"
+    instances.mkdir(parents=True)
+    monkeypatch.setenv("ENERGETICA_LANDING_DIR", str(tmp_path / "landing"))
+    return instances
+
+
+def _write_fragment(instances: Path, *, slug: str, name: str, starts_at: str, advertised: bool = True) -> None:
+    (instances / f"{slug}.json").write_text(
+        json.dumps({"slug": slug, "name": name, "advertised": advertised, "starts_at": starts_at}),
+        encoding="utf-8",
+    )
+
+
+def _authenticated_client() -> tuple[TestClient, int]:
+    """Sign up 'alice' (provisions a server-wide account + session cookie) and return the client
+    plus alice's account_id.
+    """
+    app = create_app(rm_instance=True, skip_adding_handlers=True, env="dev", port=PORT)
+    engine.serve_local = False
+    client = TestClient(app)
+    client.post(SIGNUP_URL, json=SignupRequest(username="alice", password="correct-password").model_dump())
+    account = accounts.get_account_by_username("alice")
+    assert account is not None
+    return client, account.account_id
+
+
+def test_my_runs_requires_authentication(landing_dir: Path) -> None:
+    app = create_app(rm_instance=True, skip_adding_handlers=True, env="dev", port=PORT)
+    engine.serve_local = False
+    response = TestClient(app).get(MY_RUNS_URL)
+    assert response.status_code == 401
+
+
+def test_my_runs_returns_only_the_authed_accounts_runs_joined_with_fragments(landing_dir: Path) -> None:
+    client, alice_id = _authenticated_client()
+    _write_fragment(landing_dir, slug="spring-2026", name="Spring 2026", starts_at="2026-03-01T00:00:00Z")
+    _write_fragment(landing_dir, slug="autumn-2026", name="Autumn 2026", starts_at="2026-09-01T00:00:00Z")
+    accounts.record_membership(account_id=alice_id, slug="spring-2026", settled_at="2026-03-02T00:00:00+00:00")
+    accounts.record_membership(account_id=alice_id, slug="autumn-2026", settled_at="2026-09-02T00:00:00+00:00")
+    # A different account's membership must not leak into alice's runs.
+    accounts.record_membership(account_id=alice_id + 999, slug="spring-2026", settled_at="2026-03-03T00:00:00+00:00")
+
+    response = client.get(MY_RUNS_URL)
+
+    assert response.status_code == 200
+    runs = response.json()["runs"]
+    # Most-recently-settled first.
+    assert [r["slug"] for r in runs] == ["autumn-2026", "spring-2026"]
+    assert runs[0]["name"] == "Autumn 2026"
+
+
+def test_my_runs_filters_out_stale_memberships_without_a_fragment(landing_dir: Path) -> None:
+    """A membership whose run has been deleted (no fragment on disk) is silently dropped."""
+    client, alice_id = _authenticated_client()
+    _write_fragment(landing_dir, slug="live-run", name="Live", starts_at="2026-03-01T00:00:00Z")
+    accounts.record_membership(account_id=alice_id, slug="live-run", settled_at="2026-03-02T00:00:00+00:00")
+    accounts.record_membership(account_id=alice_id, slug="deleted-run", settled_at="2026-01-01T00:00:00+00:00")
+
+    runs = client.get(MY_RUNS_URL).json()["runs"]
+
+    assert [r["slug"] for r in runs] == ["live-run"]
+
+
+def test_my_runs_surfaces_the_accounts_own_unadvertised_run(landing_dir: Path) -> None:
+    """The public manifest hides unadvertised runs, but an account must still see its own — the
+    fragment exists on disk even when advertised is false.
+    """
+    client, alice_id = _authenticated_client()
+    _write_fragment(landing_dir, slug="hidden", name="Hidden", starts_at="2026-03-01T00:00:00Z", advertised=False)
+    accounts.record_membership(account_id=alice_id, slug="hidden", settled_at="2026-03-02T00:00:00+00:00")
+
+    runs = client.get(MY_RUNS_URL).json()["runs"]
+
+    assert [r["slug"] for r in runs] == ["hidden"]

--- a/tests/unit/test_backfill_instance_membership.py
+++ b/tests/unit/test_backfill_instance_membership.py
@@ -1,0 +1,71 @@
+"""Unit tests for the instance_membership backfill migration's core logic.
+
+The backfill writes one membership row per already-settled Player across an instance's pickle, so
+players who settled before instance_membership existed still appear under 'your runs'. Deploy
+order (see docs/architecture/lobby.md § Phasing) requires this to run before the lobby serves
+my-runs. The pickle I/O lives in main(); the row-writing logic is unit-tested here against
+duck-typed players.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from energetica import accounts
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "backfill-instance-membership.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("backfill_instance_membership", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _player(account_id: int, settled_iso: str) -> SimpleNamespace:
+    """A duck-typed stand-in for a pickle Player: has .user.account_id and .created_at."""
+    return SimpleNamespace(user=SimpleNamespace(account_id=account_id), created_at=_FakeDatetime(settled_iso))
+
+
+class _FakeDatetime:
+    def __init__(self, iso: str) -> None:
+        self._iso = iso
+
+    def isoformat(self) -> str:
+        return self._iso
+
+
+@pytest.fixture
+def accounts_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "accounts.db"
+    monkeypatch.setenv("ENERGETICA_ACCOUNTS_DB_PATH", str(db_path))
+    accounts.init_db()
+    return db_path
+
+
+def test_backfill_writes_one_membership_per_settled_player(accounts_db: Path) -> None:
+    module = _load_script()
+    players = [_player(1, "2026-03-01T00:00:00+00:00"), _player(2, "2026-03-02T00:00:00+00:00")]
+
+    written = module.backfill_memberships(players, slug="spring-2026")
+
+    assert written == 2
+    assert accounts.get_memberships(account_id=1)[0].slug == "spring-2026"
+    assert accounts.get_memberships(account_id=1)[0].settled_at == "2026-03-01T00:00:00+00:00"
+    assert accounts.get_memberships(account_id=2)[0].slug == "spring-2026"
+
+
+def test_backfill_is_idempotent(accounts_db: Path) -> None:
+    module = _load_script()
+    players = [_player(1, "2026-03-01T00:00:00+00:00")]
+
+    module.backfill_memberships(players, slug="spring-2026")
+    module.backfill_memberships(players, slug="spring-2026")
+
+    assert len(accounts.get_memberships(account_id=1)) == 1

--- a/tests/unit/test_instance_config.py
+++ b/tests/unit/test_instance_config.py
@@ -247,3 +247,41 @@ def test_aggregate_excludes_unadvertised_instances(tmp_path: Path, monkeypatch: 
     # ...but only the advertised one is in the public manifest.
     manifest = json.loads((landing_dir / "instances.json").read_text())
     assert [entry["slug"] for entry in manifest["instances"]] == ["public-run"]
+
+
+# --- load_fragment --------------------------------------------------------------------------
+
+
+def test_load_fragment_reads_a_published_fragment(configured: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """load_fragment reads back a fragment written by publish, including its name and starts_at."""
+    instance_config.publish(InstanceConfig.model_validate(PUBLIC_JSON))
+
+    fragment = instance_config.load_fragment(SLUG)
+
+    assert fragment is not None
+    assert fragment.slug == SLUG
+    assert fragment.name == "Autumn 2025"
+
+
+def test_load_fragment_reads_unadvertised_fragment(configured: Path) -> None:
+    """An unadvertised run keeps its on-disk fragment; load_fragment must surface it so an account
+    can see its own hidden runs (the public manifest can't).
+    """
+    monkeypatch_slug = "hidden-run"
+    (Path(instance_config._landing_dir()) / "instances").mkdir(parents=True, exist_ok=True)
+    (Path(instance_config._landing_dir()) / "instances" / f"{monkeypatch_slug}.json").write_text(
+        json.dumps(
+            {"slug": monkeypatch_slug, "name": "Hidden", "advertised": False, "starts_at": "2026-03-01T00:00:00Z"}
+        ),
+        encoding="utf-8",
+    )
+
+    fragment = instance_config.load_fragment(monkeypatch_slug)
+
+    assert fragment is not None
+    assert fragment.advertised is False
+    assert fragment.name == "Hidden"
+
+
+def test_load_fragment_returns_none_when_absent(configured: Path) -> None:
+    assert instance_config.load_fragment("no-such-run") is None

--- a/tests/unit/test_instance_membership.py
+++ b/tests/unit/test_instance_membership.py
@@ -61,6 +61,28 @@ def test_get_memberships_empty_for_account_with_no_runs(accounts_db: Path) -> No
     assert accounts.get_memberships(account_id=999) == []
 
 
+def test_settled_at_is_normalised_to_utc_so_ordering_is_chronological(accounts_db: Path) -> None:
+    """settled_at is stored as canonical UTC ISO regardless of the caller's offset, so the
+    lexicographic ORDER BY on the TEXT column stays chronological. A '+02:00' timestamp that is
+    chronologically earlier must sort before a later UTC one, not after it by string bytes.
+    """
+    # 08:00+02:00 == 06:00Z (earlier) vs 07:00Z (later). Lexicographically "08..." > "07...",
+    # so without UTC normalisation the earlier event would wrongly sort last.
+    accounts.record_membership(account_id=1, slug="earlier", settled_at="2026-03-01T08:00:00+02:00")
+    accounts.record_membership(account_id=1, slug="later", settled_at="2026-03-01T07:00:00+00:00")
+
+    memberships = accounts.get_memberships(account_id=1)
+
+    assert [m.slug for m in memberships] == ["later", "earlier"]  # most recent first
+    assert memberships[1].settled_at == "2026-03-01T06:00:00+00:00"  # stored normalised to UTC
+
+
+def test_record_membership_rejects_naive_timestamp(accounts_db: Path) -> None:
+    """A tz-less settled_at is a bug and fails loud rather than sorting unpredictably."""
+    with pytest.raises(ValueError, match="timezone-aware"):
+        accounts.record_membership(account_id=1, slug="oops", settled_at="2026-03-01T08:00:00")
+
+
 def test_settling_records_membership_for_this_instance(monkeypatch: pytest.MonkeyPatch) -> None:
     """Creating a Player (settle) writes a membership row keyed by the user's account_id and this
     instance's slug, stamped with the Player's settle time — this is what makes a run appear under

--- a/tests/unit/test_instance_membership.py
+++ b/tests/unit/test_instance_membership.py
@@ -106,6 +106,33 @@ def test_settling_records_membership_for_this_instance(monkeypatch: pytest.Monke
     assert memberships[0].settled_at == player.created_at.isoformat()
 
 
+def test_settle_survives_a_membership_write_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed membership write (e.g. SQLITE_BUSY on the shared accounts.db) must not break an
+    otherwise-successful settle: the player is created in-memory regardless, and the row is
+    recoverable via the backfill script. Best-effort, like instance_config.publish.
+    """
+    import sqlite3
+
+    from energetica import create_app
+    from energetica.database.map.hex_tile import HexTile
+    from energetica.database.user import User
+    from energetica.utils.auth import generate_password_hash
+    from energetica.utils.map_helpers import confirm_location
+
+    monkeypatch.setenv("ENERGETICA_INSTANCE_SLUG", "spring-2026")
+    create_app(rm_instance=True, skip_adding_handlers=True, env="prod")
+
+    def boom(**_kwargs: object) -> None:
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(accounts, "record_membership", boom)
+    user = User(username="carol", pwhash=generate_password_hash("pw"), role="player", account_id=9)
+
+    player = confirm_location(user, HexTile.getitem(1))  # must not raise
+
+    assert user.player is player  # settle completed in-memory despite the DB failure
+
+
 def test_settling_records_no_membership_when_slug_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     """In dev / unconfigured deployments there is no slug and no lobby; settle must not crash and
     writes no membership row (mirrors instance_config.publish's no-op-without-slug behaviour).

--- a/tests/unit/test_instance_membership.py
+++ b/tests/unit/test_instance_membership.py
@@ -1,0 +1,103 @@
+"""Unit tests for the instance_membership store: the 'your runs' set for an account.
+
+A membership row is written when an account settles (creates a Player) in a run. The lobby
+and the in-run switcher read these rows back, joined against on-disk instance fragments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from energetica import accounts
+
+
+@pytest.fixture
+def accounts_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the accounts module at a per-test SQLite file and initialise the schema."""
+    db_path = tmp_path / "accounts.db"
+    monkeypatch.setenv("ENERGETICA_ACCOUNTS_DB_PATH", str(db_path))
+    accounts.init_db()
+    return db_path
+
+
+def test_record_and_read_back_membership(accounts_db: Path) -> None:
+    """record_membership writes a row; get_memberships reads it back with slug and settled_at."""
+    accounts.record_membership(account_id=1, slug="spring-2026", settled_at="2026-03-01T12:00:00+00:00")
+
+    memberships = accounts.get_memberships(account_id=1)
+
+    assert len(memberships) == 1
+    assert memberships[0].slug == "spring-2026"
+    assert memberships[0].settled_at == "2026-03-01T12:00:00+00:00"
+
+
+def test_record_membership_is_idempotent_and_keeps_first_settled_at(accounts_db: Path) -> None:
+    """A second record for the same (account, slug) does not duplicate the row nor overwrite
+    the original settled_at — settling is a one-time event, and the backfill may re-run.
+    """
+    accounts.record_membership(account_id=1, slug="spring-2026", settled_at="2026-03-01T12:00:00+00:00")
+    accounts.record_membership(account_id=1, slug="spring-2026", settled_at="2026-09-09T09:09:09+00:00")
+
+    memberships = accounts.get_memberships(account_id=1)
+
+    assert len(memberships) == 1
+    assert memberships[0].settled_at == "2026-03-01T12:00:00+00:00"
+
+
+def test_get_memberships_returns_only_the_given_account_ordered_by_settled_at_desc(accounts_db: Path) -> None:
+    """get_memberships is scoped to one account and lists its runs most-recently-settled first."""
+    accounts.record_membership(account_id=1, slug="spring-2026", settled_at="2026-03-01T00:00:00+00:00")
+    accounts.record_membership(account_id=1, slug="autumn-2026", settled_at="2026-09-01T00:00:00+00:00")
+    accounts.record_membership(account_id=2, slug="spring-2026", settled_at="2026-03-02T00:00:00+00:00")
+
+    memberships = accounts.get_memberships(account_id=1)
+
+    assert [m.slug for m in memberships] == ["autumn-2026", "spring-2026"]
+
+
+def test_get_memberships_empty_for_account_with_no_runs(accounts_db: Path) -> None:
+    assert accounts.get_memberships(account_id=999) == []
+
+
+def test_settling_records_membership_for_this_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Creating a Player (settle) writes a membership row keyed by the user's account_id and this
+    instance's slug, stamped with the Player's settle time — this is what makes a run appear under
+    'your runs'.
+    """
+    from energetica import create_app
+    from energetica.database.map.hex_tile import HexTile
+    from energetica.database.user import User
+    from energetica.utils.auth import generate_password_hash
+    from energetica.utils.map_helpers import confirm_location
+
+    monkeypatch.setenv("ENERGETICA_INSTANCE_SLUG", "spring-2026")
+    create_app(rm_instance=True, skip_adding_handlers=True, env="prod")
+    user = User(username="alice", pwhash=generate_password_hash("pw"), role="player", account_id=7)
+
+    player = confirm_location(user, HexTile.getitem(1))
+
+    memberships = accounts.get_memberships(account_id=7)
+    assert len(memberships) == 1
+    assert memberships[0].slug == "spring-2026"
+    assert memberships[0].settled_at == player.created_at.isoformat()
+
+
+def test_settling_records_no_membership_when_slug_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """In dev / unconfigured deployments there is no slug and no lobby; settle must not crash and
+    writes no membership row (mirrors instance_config.publish's no-op-without-slug behaviour).
+    """
+    from energetica import create_app
+    from energetica.database.map.hex_tile import HexTile
+    from energetica.database.user import User
+    from energetica.utils.auth import generate_password_hash
+    from energetica.utils.map_helpers import confirm_location
+
+    monkeypatch.delenv("ENERGETICA_INSTANCE_SLUG", raising=False)
+    create_app(rm_instance=True, skip_adding_handlers=True, env="prod")
+    user = User(username="bob", pwhash=generate_password_hash("pw"), role="player", account_id=8)
+
+    confirm_location(user, HexTile.getitem(1))
+
+    assert accounts.get_memberships(account_id=8) == []

--- a/tests/unit/test_network_prices.py
+++ b/tests/unit/test_network_prices.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import textwrap
 
+from energetica import create_app
 from energetica.database.map.hex_tile import HexTile
 from energetica.database.user import User
 from energetica.enums import ControllableFacilityType
@@ -15,6 +16,9 @@ from energetica.utils.map_helpers import confirm_location
 
 def test_price_randomization() -> None:
     """Test that the prices are randomized."""
+    # Initialise a fresh engine + map so this test does not depend on state left by whichever
+    # test ran before it (it settles tiles 1 & 2, which a prior test may have already occupied).
+    create_app(rm_instance=True, skip_adding_handlers=True, env="prod")
     engine.random_seed = 0
     user_a = User("player1", "pwhash", role="player", account_id=1)
     user_b = User("player2", "pwhash", role="player", account_id=2)

--- a/tests/unit/test_secret_key.py
+++ b/tests/unit/test_secret_key.py
@@ -1,0 +1,56 @@
+"""Unit tests for cookie-signing secret resolution.
+
+Phase A of the lobby introduces a *server-wide* shared secret so every instance can validate a
+session minted elsewhere. The instance prefers the shared secret when present, else falls back to
+its own per-instance secret (the pre-lobby behaviour). The cookie *scope* is deliberately not
+flipped yet — this only teaches the loader where to read the key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from energetica.utils.auth import get_or_create_secret_key
+
+
+@pytest.fixture(autouse=True)
+def _secret_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Redirect both secret paths at per-test files so the repo working tree is never touched."""
+    shared = tmp_path / "var" / "secret_key.txt"
+    instance = tmp_path / "instance" / "secret_key.txt"
+    instance.parent.mkdir(parents=True)
+    monkeypatch.setenv("ENERGETICA_SHARED_SECRET_PATH", str(shared))
+    monkeypatch.setenv("ENERGETICA_INSTANCE_SECRET_PATH", str(instance))
+    return shared, instance
+
+
+def test_prefers_shared_secret_when_present(_secret_paths: tuple[Path, Path]) -> None:
+    shared, instance = _secret_paths
+    shared.parent.mkdir(parents=True)
+    shared.write_text("shared-server-wide-secret", encoding="utf-8")
+
+    assert get_or_create_secret_key() == "shared-server-wide-secret"
+    # The shared secret is provisioned by infra; the instance must not create its own.
+    assert not instance.exists()
+
+
+def test_falls_back_to_instance_secret_when_shared_absent(_secret_paths: tuple[Path, Path]) -> None:
+    shared, instance = _secret_paths
+    instance.write_text("per-instance-secret", encoding="utf-8")
+
+    assert get_or_create_secret_key() == "per-instance-secret"
+
+
+def test_creates_instance_secret_when_neither_exists(_secret_paths: tuple[Path, Path]) -> None:
+    """Pre-lobby behaviour is preserved: with no shared secret, the instance mints its own. It must
+    never create the shared file — that belongs to setup-base.sh.
+    """
+    shared, instance = _secret_paths
+
+    key = get_or_create_secret_key()
+
+    assert key
+    assert instance.read_text(encoding="utf-8").strip() == key
+    assert not shared.exists()

--- a/tests/unit/test_secret_key.py
+++ b/tests/unit/test_secret_key.py
@@ -43,6 +43,25 @@ def test_falls_back_to_instance_secret_when_shared_absent(_secret_paths: tuple[P
     assert get_or_create_secret_key() == "per-instance-secret"
 
 
+def test_empty_shared_secret_fails_loud(_secret_paths: tuple[Path, Path]) -> None:
+    """An existing-but-empty shared secret must raise, not sign cookies with a zero-entropy key."""
+    shared, _instance = _secret_paths
+    shared.parent.mkdir(parents=True)
+    shared.write_text("   \n", encoding="utf-8")  # whitespace only → empty after strip
+
+    with pytest.raises(RuntimeError, match="empty"):
+        get_or_create_secret_key()
+
+
+def test_empty_instance_secret_fails_loud(_secret_paths: tuple[Path, Path]) -> None:
+    """Same guard on the per-instance fallback path."""
+    _shared, instance = _secret_paths
+    instance.write_text("", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="empty"):
+        get_or_create_secret_key()
+
+
 def test_creates_instance_secret_when_neither_exists(_secret_paths: tuple[Path, Path]) -> None:
     """Pre-lobby behaviour is preserved: with no shared secret, the instance mints its own. It must
     never create the shared file — that belongs to setup-base.sh.


### PR DESCRIPTION
Closes #815. Part of #814. Design: `docs/architecture/lobby.md` § Phasing.

Invisible, backend-only groundwork for the lobby. No user-facing behaviour changes; the cookie scope is deliberately **not** flipped. Rebased onto `main` after the CI PRs (#832 pyright, #833 api-types freshness gate) landed.

## What's here (Phase A checklist)

- [x] **`instance_membership(account_id, slug, settled_at)` table** in `accounts.db` — lazy schema bootstrap, mirroring `accounts`. Plus `record_membership` (idempotent `INSERT OR IGNORE`) and `get_memberships`.
- [x] **Write-on-settle** — `initialize_player` records a membership keyed by `account_id` + instance slug, stamped from `Player.created_at`. No-op without a slug (dev / unconfigured), matching `instance_config.publish`.
- [x] **`GET /api/v1/lobby/my-runs`** (`routers/lobby.py` + `schemas/lobby.py`) — cookie-authed; serves **only** that account's memberships joined against on-disk fragments for name/`starts_at`; filters stale rows; surfaces the account's own **unadvertised** runs. Adds `instance_config.load_fragment`.
- [x] **Shared-secret support** — `get_or_create_secret_key` prefers server-wide `/var/lib/energetica/secret_key.txt` when present, else the per-instance file (unchanged pre-lobby behaviour). Read-only; no cookie-scope change.
- [x] **Backfill migration** — `scripts/backfill-instance-membership.py`: one row per already-settled `Player` in an instance pickle; idempotent.
- [x] **Regenerated `api.generated.ts`** for the my-runs endpoint (+78 lines, my-runs only — `main` is fresh now that the freshness gate is in, so this is a clean minimal diff).

## Testing

- 36 new tests (unit + integration): DB round-trip / idempotency / account isolation, write-on-settle (with and without slug), `my-runs` (auth required, per-account scoping, stale-row filtering, own-unadvertised surfacing), `load_fragment`, secret-key resolution order, and backfill.
- Migration smoke-tested end-to-end against a real engine pickle (dry-run, real write, idempotent re-run).
- `ruff format` + `ruff check` clean; whole-repo `pyright` clean; freshness gate satisfied.

## Drive-by fix

`tests/unit/test_network_prices.py::test_price_randomization` was **already broken on `main`** — it never initialised the engine, so it silently relied on tiles 1 & 2 being free from whatever test happened to run before it (fails standalone with `KeyError: 1`). This branch's new test file shifted ordering and surfaced it as `locationOccupied`. Fixed by adding `create_app(rm_instance=True, ...)` so the test is self-contained, matching the pattern in `test_new_player.py` / the integration tests. Now passes standalone and in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the backend groundwork for a lobby Phase A: an `instance_membership` table (lazy schema bootstrap), a `record_membership` write-on-settle path, a `GET /api/v1/lobby/my-runs` endpoint that joins memberships with on-disk fragments, shared-secret support for cross-instance cookie validation, and a backfill migration script. No cookie-scope flip yet; the change is deliberately invisible at the user level.

- **`instance_membership` store** (`accounts/db.py`): new `record_membership` (INSERT OR IGNORE, UTC-normalises timestamps) and `get_memberships`, exercised by 36 new unit + integration tests.
- **Write-on-settle** (`utils/misc.py`): wrapped in `try/except (OSError, sqlite3.Error)` so a DB failure on the shared `accounts.db` never prevents an otherwise-successful settle; a `conftest.py` autouse fixture isolates the accounts DB for every test.
- **Shared-secret resolution** (`utils/auth.py`): prefers `/var/lib/energetica/secret_key.txt`, falls back to per-instance file, rejects empty files with `RuntimeError` — addressing the zero-entropy concern from the earlier review thread.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are backend-only with no user-facing behaviour, the settle path is best-effort, and the empty-secret guard from the prior review thread is now in place.

The write-on-settle block is correctly wrapped in a try/except, the empty-key guard is implemented, UTC normalisation keeps lexicographic ordering correct, and all new behaviour is covered by 36 new tests with proper isolation via the autouse conftest fixture. The one gap — ValueError not in the except clause — is unreachable with current Player.created_at (always UTC-aware) and does not represent a present defect.

energetica/utils/misc.py — the best-effort except clause could be broadened to include ValueError for completeness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/utils/misc.py | Adds best-effort membership write on settle; only catches (OSError, sqlite3.Error), missing ValueError which record_membership can raise for naive timestamps — unreachable in practice since Player.created_at is always UTC-aware, but inconsistent with the "must never propagate" intent. |
| energetica/accounts/db.py | New Membership dataclass, instance_membership DDL, and record_membership/get_memberships functions; UTC normalisation on write ensures lexicographic ORDER BY stays chronological. |
| energetica/utils/auth.py | Shared-secret resolution order with env-overridable paths; empty-file guard now raises RuntimeError on both shared and per-instance paths, directly addressing the previous review thread. |
| energetica/routers/lobby.py | New GET /api/v1/lobby/my-runs endpoint; requires authentication, scopes to cookie-authed account, filters stale memberships, and correctly surfaces unadvertised runs. |
| energetica/instance_config.py | Adds load_fragment helper that reads per-slug on-disk JSON, returning None for absent/malformed fragments — correct stale-row filtering behaviour. |
| scripts/backfill-instance-membership.py | One-time migration to backfill membership rows from existing pickled Players; idempotent via INSERT OR IGNORE; dry-run support; sets ENERGETICA_ACCOUNTS_DB_PATH before importing accounts. |
| tests/integration/test_my_runs_route.py | Integration tests for my-runs endpoint; each test gets an isolated accounts.db via the autouse conftest fixture; covers auth, account scoping, stale-row filtering, and unadvertised runs. |
| tests/unit/test_instance_membership.py | Comprehensive unit tests for membership store: idempotency, account isolation, UTC normalisation ordering, naive-timestamp rejection, write-on-settle, and best-effort DB failure survivability. |
| tests/unit/test_secret_key.py | Unit tests for shared-secret resolution: prefer shared, fallback to instance, empty-file guard on both paths, create-on-absence behaviour. |
| tests/unit/test_network_prices.py | Drive-by fix: adds create_app(rm_instance=True) so test_price_randomization is self-contained and does not depend on tile state left by prior tests. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Instance as Instance (FastAPI)
    participant Misc as utils/misc.py
    participant AccountsDB as accounts.db
    participant LandingDir as Landing Dir (disk)

    Note over Client,LandingDir: Settle flow (initialize_player)
    Client->>Instance: POST /api/v1/map/confirm-location
    Instance->>Misc: initialize_player(user, tile)
    Misc->>Misc: add_player_to_data(player)
    Misc->>AccountsDB: record_membership(account_id, slug, settled_at) [best-effort]
    AccountsDB-->>Misc: OK / silent error

    Note over Client,LandingDir: my-runs read flow
    Client->>Instance: GET /api/v1/lobby/my-runs (cookie)
    Instance->>Instance: get_user() — verify cookie via SECRET_KEY
    Instance->>AccountsDB: get_memberships(account_id)
    AccountsDB-->>Instance: [Membership, ...]
    loop each membership
        Instance->>LandingDir: load_fragment(slug)
        LandingDir-->>Instance: "InstanceFragment | None"
    end
    Instance-->>Client: "MyRunsResponse {runs: [...]}"

    Note over Client,LandingDir: Secret-key resolution (startup)
    Instance->>Instance: get_or_create_secret_key()
    alt shared path exists
        Instance->>Instance: _read_nonempty_secret(shared_path)
    else instance path exists
        Instance->>Instance: _read_nonempty_secret(instance_path)
    else neither exists
        Instance->>Instance: generate + write instance_path
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Instance as Instance (FastAPI)
    participant Misc as utils/misc.py
    participant AccountsDB as accounts.db
    participant LandingDir as Landing Dir (disk)

    Note over Client,LandingDir: Settle flow (initialize_player)
    Client->>Instance: POST /api/v1/map/confirm-location
    Instance->>Misc: initialize_player(user, tile)
    Misc->>Misc: add_player_to_data(player)
    Misc->>AccountsDB: record_membership(account_id, slug, settled_at) [best-effort]
    AccountsDB-->>Misc: OK / silent error

    Note over Client,LandingDir: my-runs read flow
    Client->>Instance: GET /api/v1/lobby/my-runs (cookie)
    Instance->>Instance: get_user() — verify cookie via SECRET_KEY
    Instance->>AccountsDB: get_memberships(account_id)
    AccountsDB-->>Instance: [Membership, ...]
    loop each membership
        Instance->>LandingDir: load_fragment(slug)
        LandingDir-->>Instance: "InstanceFragment | None"
    end
    Instance-->>Client: "MyRunsResponse {runs: [...]}"

    Note over Client,LandingDir: Secret-key resolution (startup)
    Instance->>Instance: get_or_create_secret_key()
    alt shared path exists
        Instance->>Instance: _read_nonempty_secret(shared_path)
    else instance path exists
        Instance->>Instance: _read_nonempty_secret(instance_path)
    else neither exists
        Instance->>Instance: generate + write instance_path
    end
```

</a>

<sub>Reviews (4): Last reviewed commit: ["fix: make membership write on settle bes..."](https://github.com/felixvonsamson/energetica/commit/36d2accf134daa688674bead16ff40567cb26ddd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41457525)</sub>

<!-- /greptile_comment -->