### PR TITLE
Lobby Phase B (infra): vhost, unit, setup + deploy scripts

### DIFF
--- a/scripts/DEPLOYMENT.md
+++ b/scripts/DEPLOYMENT.md
@@ -15,9 +15,11 @@ On the VPS, as root:
 
 ```bash
 sudo bash scripts/infra/setup-base.sh --deploy-user deploy   # Apache, Python, certbot, firewall,
-                                                             # `energetica` group/user, shared dirs
+                                                             # `energetica` group/user, shared dirs,
+                                                             # shared secret + server.json
 sudo bash scripts/infra/setup-landing.sh --domain energetica-game.org   # apex vhost + TLS
-sudo bash scripts/infra/setup-instance.sh autumn-2025 8001 --domain energetica-game.org  # vhost+TLS+unit
+sudo bash scripts/infra/setup-lobby.sh --domain energetica-game.org     # lobby vhost+TLS+unit
+sudo bash scripts/infra/setup-instance.sh autumn-2025 8002 --domain energetica-game.org  # vhost+TLS+unit
 ```
 
 `setup-instance.sh` provisions the box (directory, venv, `/etc/energetica/{slug}/instance.json`,
@@ -35,6 +37,7 @@ From your local machine:
 ```bash
 ./scripts/deploy-instance.sh --server energetica-game --instance autumn-2025 --domain energetica-game.org
 ./scripts/deploy-landing.sh  --server energetica-game --domain energetica-game.org
+./scripts/deploy-lobby.sh    --server energetica-game --domain energetica-game.org
 ./scripts/list-instances.sh  --server energetica-game
 ```
 
@@ -47,13 +50,24 @@ From your local machine:
   instance-owned `instances.json` and `instances/` dir. No service restart — the landing is
   pure static.
 
+- `deploy-lobby.sh` builds the lobby bundle (no apex baking — the lobby derives it from
+  its own hostname at runtime), rsyncs the backend + `dist-lobby/` to
+  `/var/www/energetica-lobby`, reinstalls deps, restarts `energetica-lobby`, and
+  health-checks the vhost. **Hard precondition:** it refuses to deploy while the
+  `instance_membership` table is absent from `accounts.db` — Phase A (write-on-settle +
+  `scripts/backfill-instance-membership.py`) must be live first, else the lobby silently
+  shows every existing player zero runs (`docs/architecture/lobby.md` § Phasing).
+
 `instance.json` lives outside the deploy dir (`/etc/energetica/{instance}/`) and is
-admin-owned, so deploys never touch it.
+admin-owned, so deploys never touch it. The server-wide `/etc/energetica/server.json`
+(the lobby's signup toggle) is likewise admin-owned; `sudo`-edit it and the lobby picks
+the change up on the next request — no restart.
 
 ### Options
 
 `deploy-instance.sh`: `--yes` (skip confirm), `--skip-build`, `--skip-deps`, `--user <ssh-user>`.
 `deploy-landing.sh`: `--yes`, `--skip-build`, `--user <ssh-user>`.
+`deploy-lobby.sh`: `--yes`, `--skip-build`, `--skip-deps`, `--user <ssh-user>`.
 
 All inputs also accept env vars (`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_DOMAIN`), so the
 scripts run unattended from CI.

--- a/scripts/DEPLOYMENT.md
+++ b/scripts/DEPLOYMENT.md
@@ -24,7 +24,12 @@ sudo bash scripts/infra/setup-instance.sh autumn-2025 8002 --domain energetica-g
 
 `setup-instance.sh` provisions the box (directory, venv, `/etc/energetica/{slug}/instance.json`,
 vhost+TLS, enabled-but-unstarted unit) but ships **no** code and does **not** start the
-service. The first deploy is what ships the backend and starts it.
+service. The first deploy is what ships the backend and starts it. `setup-lobby.sh` works
+the same way for the lobby service.
+
+Every service needs its own uvicorn port: the lobby defaults to **8001** (`--port`
+overrides), so give each instance a different one. `setup-lobby.sh` refuses a port
+already claimed by another `energetica-*` unit.
 
 DNS for the apex and each `{instance}.{domain}` subdomain must resolve to the server before
 running the setup scripts (certbot uses the webroot challenge). For a private/unadvertised

--- a/scripts/deploy-instance.sh
+++ b/scripts/deploy-instance.sh
@@ -47,7 +47,7 @@ log_info()    { echo -e "${BLUE}ℹ $1${NC}"; }
 
 # Validate the slug here too: it is interpolated into remote paths and `systemctl`
 # commands, so a malformed value would target the wrong path or split the remote command.
-if ! [[ "$INSTANCE" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]] || [ "$INSTANCE" = "landing" ] || [ "$INSTANCE" = "lobby" ]; then
+if ! [[ "$INSTANCE" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]] || [ "$INSTANCE" = "landing" ] || [ "$INSTANCE" = "lobby" ]; then
     log_error "Invalid instance slug: '$INSTANCE' (lowercase kebab-case, not 'landing'/'lobby')"
     exit 1
 fi

--- a/scripts/deploy-instance.sh
+++ b/scripts/deploy-instance.sh
@@ -47,8 +47,8 @@ log_info()    { echo -e "${BLUE}ℹ $1${NC}"; }
 
 # Validate the slug here too: it is interpolated into remote paths and `systemctl`
 # commands, so a malformed value would target the wrong path or split the remote command.
-if ! [[ "$INSTANCE" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]] || [ "$INSTANCE" = "landing" ]; then
-    log_error "Invalid instance slug: '$INSTANCE' (lowercase kebab-case, not 'landing')"
+if ! [[ "$INSTANCE" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]] || [ "$INSTANCE" = "landing" ] || [ "$INSTANCE" = "lobby" ]; then
+    log_error "Invalid instance slug: '$INSTANCE' (lowercase kebab-case, not 'landing'/'lobby')"
     exit 1
 fi
 

--- a/scripts/deploy-lobby.sh
+++ b/scripts/deploy-lobby.sh
@@ -158,7 +158,7 @@ fi
 log_success "Service is running"
 
 # --- 8. Health check ------------------------------------------------------------------
-# The lobby exposes no /healthz, so three probes cover the chain:
+# The lobby exposes no /healthz, so four probes cover the chain:
 #   - SPA shell 200 → Apache serves the bundle;
 #   - unauthenticated my-runs 401 → vhost → proxy → uvicorn wiring is up;
 #   - login with a nonexistent user → 401 USER_NOT_FOUND proves the accounts.db READ
@@ -166,22 +166,33 @@ log_success "Service is running"
 #     state, so it cannot prove the db is reachable — a broken path answers 500 here).
 #     The probe username is 22 chars, above signup's 18-char cap, so it can never be a
 #     real account.
+#   - instances.json 200 → the manifest Alias off the landing dir serves the picker's
+#     "open runs". The Phase A precondition implies at least one instance deployment
+#     already published the manifest, so a 404/403 means the Alias or the file's
+#     permissions are broken, not a fresh box.
 log_step "Waiting for https://$FQDN to answer..."
 HEALTH_DEADLINE=$(( $(date +%s) + 120 ))
 HEALTH_OK=false
 while [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ]; do
     SPA_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://$FQDN/" || true)
     API_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://$FQDN/api/v1/lobby/my-runs" || true)
+    MANIFEST_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://$FQDN/instances.json" || true)
     LOGIN_BODY=$(curl -s --max-time 5 -H 'Content-Type: application/json' \
         -d '{"username":"__deploy_healthcheck__","password":"deploy-probe"}' \
         "https://$FQDN/api/v1/auth/login" || true)
-    if [ "$SPA_CODE" = "200" ] && [ "$API_CODE" = "401" ] && echo "$LOGIN_BODY" | grep -q "USER_NOT_FOUND"; then
+    if [ "$SPA_CODE" = "200" ] && [ "$API_CODE" = "401" ] && [ "$MANIFEST_CODE" = "200" ] \
+        && echo "$LOGIN_BODY" | grep -q "USER_NOT_FOUND"; then
         HEALTH_OK=true; break
     fi
     sleep 5
 done
-[ "$HEALTH_OK" = true ] || { log_error "lobby did not become healthy within 120s (spa=$SPA_CODE my-runs=$API_CODE login=$LOGIN_BODY)"; echo "Logs: ssh $SSH 'sudo journalctl -u energetica-lobby -f'"; exit 1; }
-log_success "Lobby healthy (SPA 200, my-runs 401, accounts.db reachable)"
+if [ "$HEALTH_OK" != true ]; then
+    log_error "lobby did not become healthy within 120s (spa=$SPA_CODE my-runs=$API_CODE manifest=$MANIFEST_CODE login=$LOGIN_BODY)"
+    [ "$MANIFEST_CODE" = "200" ] || echo "instances.json is published by each instance backend on startup — if missing, restart an instance; if it 403s, check its permissions in /var/www/energetica-landing/."
+    echo "Logs: ssh $SSH 'sudo journalctl -u energetica-lobby -f'"
+    exit 1
+fi
+log_success "Lobby healthy (SPA 200, my-runs 401, manifest 200, accounts.db reachable)"
 
 echo
 log_success "Deployed lobby → https://$FQDN"

--- a/scripts/deploy-lobby.sh
+++ b/scripts/deploy-lobby.sh
@@ -60,9 +60,11 @@ fi
 # Read-only sqlite check, run as the service user (the only non-root reader of
 # accounts.db; setup-lobby.sh grants exactly this). ANY failure — missing table,
 # missing db, missing sudo grant — refuses the deploy: an unverifiable precondition
-# is treated as an unmet one.
+# is treated as an unmet one. /usr/bin/python3 is fully qualified to match the
+# sudoers grant exactly (an unqualified `python3` resolves via PATH and may not
+# match the granted pathname on every host).
 log_step "Checking deploy precondition (instance_membership table in accounts.db)..."
-if ! ssh "$SSH" 'sudo -u energetica python3 -c '\''
+if ! ssh "$SSH" 'sudo -u energetica /usr/bin/python3 -c '\''
 import sqlite3, sys
 try:
     conn = sqlite3.connect("file:/var/lib/energetica/accounts.db?mode=ro", uri=True)
@@ -125,7 +127,11 @@ log_success "Backend synced"
 
 # --- 5. rsync lobby bundle (hashed assets need pruning → --delete) ------------------
 log_step "Syncing lobby bundle..."
-rsync -az --delete ./frontend/dist-lobby/ "$SSH:$REMOTE_PATH/dist-lobby/" >/dev/null
+# --chmod: Apache reads the bundle via the energetica group (the tree is 2750
+# deploy:energetica), and `rsync -a` would otherwise preserve local build permissions —
+# a restrictive local umask would ship files www-data cannot read (SPA 403s after an
+# apparently successful deploy). World bits are moot: others cannot traverse the root.
+rsync -az --delete --chmod=D755,F644 ./frontend/dist-lobby/ "$SSH:$REMOTE_PATH/dist-lobby/" >/dev/null
 log_success "Lobby bundle synced"
 
 # --- 6. Install deps into the server venv -------------------------------------------
@@ -152,22 +158,30 @@ fi
 log_success "Service is running"
 
 # --- 8. Health check ------------------------------------------------------------------
-# The lobby exposes no /healthz; an unauthenticated my-runs returning 401 proves the whole
-# chain (Apache vhost → proxy → uvicorn → accounts.db read path) is up, and the SPA shell
-# returning 200 proves the bundle is served.
+# The lobby exposes no /healthz, so three probes cover the chain:
+#   - SPA shell 200 → Apache serves the bundle;
+#   - unauthenticated my-runs 401 → vhost → proxy → uvicorn wiring is up;
+#   - login with a nonexistent user → 401 USER_NOT_FOUND proves the accounts.db READ
+#     path works (my-runs alone rejects at the cookie check, before touching any shared
+#     state, so it cannot prove the db is reachable — a broken path answers 500 here).
+#     The probe username is 22 chars, above signup's 18-char cap, so it can never be a
+#     real account.
 log_step "Waiting for https://$FQDN to answer..."
 HEALTH_DEADLINE=$(( $(date +%s) + 120 ))
 HEALTH_OK=false
 while [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ]; do
-    API_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://$FQDN/api/v1/lobby/my-runs" || true)
     SPA_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://$FQDN/" || true)
-    if [ "$API_CODE" = "401" ] && [ "$SPA_CODE" = "200" ]; then
+    API_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://$FQDN/api/v1/lobby/my-runs" || true)
+    LOGIN_BODY=$(curl -s --max-time 5 -H 'Content-Type: application/json' \
+        -d '{"username":"__deploy_healthcheck__","password":"deploy-probe"}' \
+        "https://$FQDN/api/v1/auth/login" || true)
+    if [ "$SPA_CODE" = "200" ] && [ "$API_CODE" = "401" ] && echo "$LOGIN_BODY" | grep -q "USER_NOT_FOUND"; then
         HEALTH_OK=true; break
     fi
     sleep 5
 done
-[ "$HEALTH_OK" = true ] || { log_error "lobby did not become healthy within 120s (api=$API_CODE spa=$SPA_CODE)"; echo "Logs: ssh $SSH 'sudo journalctl -u energetica-lobby -f'"; exit 1; }
-log_success "Lobby healthy (api 401 unauthenticated, SPA 200)"
+[ "$HEALTH_OK" = true ] || { log_error "lobby did not become healthy within 120s (spa=$SPA_CODE my-runs=$API_CODE login=$LOGIN_BODY)"; echo "Logs: ssh $SSH 'sudo journalctl -u energetica-lobby -f'"; exit 1; }
+log_success "Lobby healthy (SPA 200, my-runs 401, accounts.db reachable)"
 
 echo
 log_success "Deployed lobby → https://$FQDN"

--- a/scripts/deploy-lobby.sh
+++ b/scripts/deploy-lobby.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+set -euo pipefail
+
+# Energetica — deploy the lobby service (backend + SPA bundle, rsync only, no git).
+#
+#   ./scripts/deploy-lobby.sh --server <ssh-host> --domain <apex> \
+#        [--user <ssh-user>] [--yes] [--skip-build] [--skip-deps]
+#
+# Builds the lobby bundle locally, rsyncs the Python backend + dist-lobby to
+# /var/www/energetica-lobby, (re)installs deps into the server venv, restarts the
+# service, and health-checks the live vhost.
+#
+# HARD PRECONDITION (checked before anything ships): the instance_membership table must
+# exist in the server-wide accounts.db — i.e. Phase A (write-on-settle + backfill) is
+# live on the box. Deploying the lobby before it means every existing player sees ZERO
+# runs with no error (docs/architecture/lobby.md § Phasing), so this refuses, not warns.
+#
+# The first run after setup-lobby.sh is what actually STARTS the lobby.
+
+REMOTE_HOST="${DEPLOY_HOST:-}"
+REMOTE_USER="${DEPLOY_USER:-deploy}"
+DOMAIN="${DEPLOY_DOMAIN:-}"
+AUTO_CONFIRM=false
+SKIP_BUILD=false
+SKIP_DEPS=false
+REMOTE_PATH=/var/www/energetica-lobby
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server) REMOTE_HOST="$2"; shift 2 ;;
+        --domain) DOMAIN="$2"; shift 2 ;;
+        --user) REMOTE_USER="$2"; shift 2 ;;
+        --yes) AUTO_CONFIRM=true; shift ;;
+        --skip-build) SKIP_BUILD=true; shift ;;
+        --skip-deps) SKIP_DEPS=true; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log_step()    { echo -e "${YELLOW}→ $1${NC}"; }
+log_success() { echo -e "${GREEN}✓ $1${NC}"; }
+log_error()   { echo -e "${RED}✗ $1${NC}"; }
+log_info()    { echo -e "${BLUE}ℹ $1${NC}"; }
+
+[ -n "$REMOTE_HOST" ] || { log_error "--server is required (or set DEPLOY_HOST)"; exit 1; }
+[ -n "$DOMAIN" ]      || { log_error "--domain is required (or set DEPLOY_DOMAIN)"; exit 1; }
+
+FQDN="lobby.$DOMAIN"
+SSH="${REMOTE_USER}@${REMOTE_HOST}"
+
+# No StrictHostKeyChecking override: SSH's default surfaces an unexpected/first-seen host key
+# instead of silently trusting it (CI pre-populates known_hosts).
+if ! ssh -o ConnectTimeout=5 "$SSH" exit 2>/dev/null; then
+    log_error "Cannot SSH to $SSH"
+    exit 1
+fi
+
+# --- 1. Deploy precondition: Phase A backfill is live ----------------------------
+# Read-only sqlite check, run as the service user (the only non-root reader of
+# accounts.db; setup-lobby.sh grants exactly this). ANY failure — missing table,
+# missing db, missing sudo grant — refuses the deploy: an unverifiable precondition
+# is treated as an unmet one.
+log_step "Checking deploy precondition (instance_membership table in accounts.db)..."
+if ! ssh "$SSH" 'sudo -u energetica python3 -c '\''
+import sqlite3, sys
+try:
+    conn = sqlite3.connect("file:/var/lib/energetica/accounts.db?mode=ro", uri=True)
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = ? AND name = ?",
+        ("table", "instance_membership"),
+    ).fetchone()
+except Exception as exc:
+    print(f"cannot read accounts.db: {exc}", file=sys.stderr)
+    sys.exit(2)
+sys.exit(0 if row else 1)
+'\'''; then
+    log_error "instance_membership is not present in /var/lib/energetica/accounts.db (or it could not be verified)."
+    echo "Phase A must be deployed first: its write-on-settle code creates the table and"
+    echo "scripts/backfill-instance-membership.py backfills existing players. Without it the"
+    echo "lobby would show every existing player zero runs, silently. Refusing to deploy."
+    exit 1
+fi
+log_success "Phase A precondition met"
+
+# --- 2. Build ---------------------------------------------------------------------
+if [ "$SKIP_BUILD" = false ]; then
+    log_step "Building lobby bundle..."
+    # No VITE_APEX_DOMAIN here: the lobby derives the apex from its own hostname at
+    # runtime (frontend/src/lib/lobby.ts), so the bundle is domain-agnostic.
+    ( cd frontend && bun run build:lobby )
+    log_success "Lobby bundle built"
+else
+    log_info "Skipping build (--skip-build)"
+fi
+
+# --- 3. Confirm --------------------------------------------------------------------
+echo
+log_step "Deployment summary:"
+echo "  Lobby:   https://$FQDN"
+echo "  Remote:  $SSH:$REMOTE_PATH"
+echo "  Steps:   rsync backend → rsync lobby bundle → pip install → restart → health check"
+echo
+if [ "$AUTO_CONFIRM" = false ]; then
+    read -r -p "Continue? (y/n) " -n 1 -r; echo
+    [[ $REPLY =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
+fi
+
+# --- 4. rsync backend code ----------------------------------------------------------
+# Ship the Python backend (energetica/ + lobby/ + main_lobby.py). Same exclusions as
+# deploy-instance.sh, plus dist-lobby (synced separately with --delete below).
+log_step "Syncing backend code..."
+rsync -az --delete \
+    --exclude='.git' \
+    --exclude='.venv' \
+    --exclude='instance/' \
+    --exclude='frontend' \
+    --exclude='node_modules' \
+    --exclude='__pycache__' \
+    --exclude='*.pyc' \
+    --exclude='energetica/static/app' \
+    --exclude='dist-lobby/' \
+    ./ "$SSH:$REMOTE_PATH/" >/dev/null
+log_success "Backend synced"
+
+# --- 5. rsync lobby bundle (hashed assets need pruning → --delete) ------------------
+log_step "Syncing lobby bundle..."
+rsync -az --delete ./frontend/dist-lobby/ "$SSH:$REMOTE_PATH/dist-lobby/" >/dev/null
+log_success "Lobby bundle synced"
+
+# --- 6. Install deps into the server venv -------------------------------------------
+if [ "$SKIP_DEPS" = false ]; then
+    log_step "Installing Python deps into server venv..."
+    ssh "$SSH" "sudo -u energetica $REMOTE_PATH/.venv/bin/pip install -q -r $REMOTE_PATH/requirements.txt"
+    log_success "Deps installed"
+else
+    log_info "Skipping deps (--skip-deps)"
+fi
+
+# --- 7. Restart (first deploy: starts) -----------------------------------------------
+log_step "Restarting energetica-lobby..."
+if ! ssh "$SSH" "sudo systemctl restart energetica-lobby"; then
+    log_error "Restart command failed"
+    echo "Logs: ssh $SSH 'sudo journalctl -u energetica-lobby -n 50'"
+    exit 1
+fi
+if ! ssh "$SSH" "systemctl is-active --quiet energetica-lobby"; then
+    log_error "Service failed to start"
+    echo "Logs: ssh $SSH 'sudo journalctl -u energetica-lobby -n 50'"
+    exit 1
+fi
+log_success "Service is running"
+
+# --- 8. Health check ------------------------------------------------------------------
+# The lobby exposes no /healthz; an unauthenticated my-runs returning 401 proves the whole
+# chain (Apache vhost → proxy → uvicorn → accounts.db read path) is up, and the SPA shell
+# returning 200 proves the bundle is served.
+log_step "Waiting for https://$FQDN to answer..."
+HEALTH_DEADLINE=$(( $(date +%s) + 120 ))
+HEALTH_OK=false
+while [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ]; do
+    API_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://$FQDN/api/v1/lobby/my-runs" || true)
+    SPA_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "https://$FQDN/" || true)
+    if [ "$API_CODE" = "401" ] && [ "$SPA_CODE" = "200" ]; then
+        HEALTH_OK=true; break
+    fi
+    sleep 5
+done
+[ "$HEALTH_OK" = true ] || { log_error "lobby did not become healthy within 120s (api=$API_CODE spa=$SPA_CODE)"; echo "Logs: ssh $SSH 'sudo journalctl -u energetica-lobby -f'"; exit 1; }
+log_success "Lobby healthy (api 401 unauthenticated, SPA 200)"
+
+echo
+log_success "Deployed lobby → https://$FQDN"
+log_info "Logs: ssh $SSH 'sudo journalctl -u energetica-lobby -f'"

--- a/scripts/infra/apache-lobby.conf
+++ b/scripts/infra/apache-lobby.conf
@@ -62,9 +62,14 @@
     # Content-hashed bundles (the filename IS a content hash) never change in place, so
     # cache them forever — a content change ships a new filename. "Header set" (not
     # "always") is deliberate: it writes onsuccess only, so a 404 for a pruned/missing
-    # hashed asset is NOT given the year-long immutable directive.
+    # hashed asset is NOT given the year-long immutable directive. FallbackResource is
+    # disabled here so a missing asset really 404s: the vhost-wide SPA fallback below
+    # would otherwise answer it with index.html-as-200 — which the browser would try to
+    # execute as JS/CSS and could cache under the immutable directive (same reasoning as
+    # the /app-scoped fallback in apache-instance.conf).
     <LocationMatch "^/assets/">
         Header set Cache-Control "public, max-age=31536000, immutable"
+        FallbackResource disabled
     </LocationMatch>
     # The SPA shell must ALWAYS be revalidated (deploy-lobby.sh rsyncs with --delete, so a
     # deploy renames the hashed bundles and prunes the old ones). ETag makes it a cheap 304.

--- a/scripts/infra/apache-lobby.conf
+++ b/scripts/infra/apache-lobby.conf
@@ -1,0 +1,102 @@
+# Apache vhost for the lobby service: lobby.@DOMAIN@
+#
+# Rendered by scripts/infra/setup-lobby.sh, which substitutes the placeholders
+# @DOMAIN@ (apex domain) and @PORT@ (lobby uvicorn port).
+# ${APACHE_LOG_DIR} is a literal Apache runtime variable — do NOT substitute it.
+#
+# Apache serves the lobby SPA bundle (dist-lobby) directly from disk and proxies only
+# /api to the lobby uvicorn process (main_lobby.py). The public instance manifest is
+# Alias'd from the shared landing DocumentRoot so the picker fetches it same-origin —
+# no CORS, and the lobby always sees the live manifest the instances publish.
+# See docs/architecture/lobby.md § Request routing (lobby vhost).
+
+<VirtualHost *:80>
+    ServerName lobby.@DOMAIN@
+    DocumentRoot /var/www/energetica-lobby
+
+    # ACME http-01 challenges (certbot --webroot -w /var/www/energetica-lobby) must be
+    # served over plain HTTP and never redirected, or certificate issuance/renewal breaks.
+    <Directory "/var/www/energetica-lobby/.well-known/acme-challenge">
+        Require all granted
+    </Directory>
+
+    RewriteEngine On
+    RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/
+    RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName lobby.@DOMAIN@
+
+    # The lobby bundle is built with base "/" (like the landing), so assets resolve
+    # directly under DocumentRoot (/assets/index-abc123.js).
+    DocumentRoot /var/www/energetica-lobby/dist-lobby
+
+    SSLEngine on
+    SSLCertificateFile /etc/letsencrypt/live/lobby.@DOMAIN@/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/lobby.@DOMAIN@/privkey.pem
+    SSLProtocol -all +TLSv1.2 +TLSv1.3
+    SSLCipherSuite HIGH:!aNULL:!MD5
+
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "SAMEORIGIN"
+
+    <Directory "/var/www/energetica-lobby/dist-lobby">
+        Require all granted
+        Options -Indexes
+    </Directory>
+
+    # --- Instance manifest (same-origin, from the shared landing dir) --------------
+    # The picker's "open runs" read. The manifest is world-readable by design (it lists
+    # only advertised instances) and is written by the instance backends into the landing
+    # DocumentRoot; aliasing the live file avoids both CORS and a second copy to keep fresh.
+    Alias /instances.json /var/www/energetica-landing/instances.json
+    <Directory "/var/www/energetica-landing">
+        <Files "instances.json">
+            Require all granted
+        </Files>
+    </Directory>
+
+    # --- Caching ------------------------------------------------------------------
+    # Content-hashed bundles (the filename IS a content hash) never change in place, so
+    # cache them forever — a content change ships a new filename. "Header set" (not
+    # "always") is deliberate: it writes onsuccess only, so a 404 for a pruned/missing
+    # hashed asset is NOT given the year-long immutable directive.
+    <LocationMatch "^/assets/">
+        Header set Cache-Control "public, max-age=31536000, immutable"
+    </LocationMatch>
+    # The SPA shell must ALWAYS be revalidated (deploy-lobby.sh rsyncs with --delete, so a
+    # deploy renames the hashed bundles and prunes the old ones). ETag makes it a cheap 304.
+    <FilesMatch "\.html$">
+        Header set Cache-Control "no-cache"
+    </FilesMatch>
+    # Same short TTL as the landing vhost: admin edits to an instance.json propagate to
+    # the picker within a minute without explicit cache-busting.
+    <LocationMatch "^/instances\.json$">
+        Header set Cache-Control "max-age=60"
+    </LocationMatch>
+
+    # --- Dynamic traffic proxied to the lobby uvicorn ------------------------------
+    ProxyPreserveHost On
+    ProxyTimeout 300
+
+    # mod_proxy doesn't forward the original scheme, so tell the backend it's HTTPS.
+    # energetica/utils/session.py keys the session cookie's Secure flag off this header;
+    # without it the parent-domain cookie is issued without Secure even though the site
+    # is HTTPS-only.
+    RequestHeader set X-Forwarded-Proto "https"
+
+    # /api/v1/auth/* (login, signup, change-password, logout) + /api/v1/lobby/my-runs.
+    # The lobby has no Socket.IO and no bare /logout route (logout is POST under /api).
+    ProxyPass        /api http://127.0.0.1:@PORT@/api
+    ProxyPassReverse /api http://127.0.0.1:@PORT@/api
+
+    # --- SPA routing --------------------------------------------------------------
+    # /login, /signup and the picker (/) are client-side routes; real files (assets,
+    # the aliased instances.json) and the proxied /api are matched before the fallback.
+    FallbackResource /index.html
+
+    ErrorLog ${APACHE_LOG_DIR}/energetica-lobby-error.log
+    CustomLog ${APACHE_LOG_DIR}/energetica-lobby-access.log combined
+</VirtualHost>

--- a/scripts/infra/energetica-lobby.service
+++ b/scripts/infra/energetica-lobby.service
@@ -1,0 +1,39 @@
+# systemd unit template for the lobby service (server-wide SSO + instance picker).
+#
+# Rendered by scripts/infra/setup-lobby.sh into /etc/systemd/system/energetica-lobby.service,
+# substituting @DOMAIN@ and @PORT@.
+#
+# The Environment= lines are load-bearing — they are the contract between the deployment
+# and lobby/config.py + energetica/{utils/session.py,accounts/db.py,instance_config.py,
+# server_config.py}:
+#   * ENERGETICA_APEX_DOMAIN is MANDATORY in production. Without it the session cookie
+#     falls back to host-only scope (lobby.{apex} only) and never reaches the run
+#     subdomains — SSO silently doesn't happen (ADR-0002).
+#   * The others match the code defaults, but are set explicitly so the unit is the
+#     single source of truth for where the lobby reads shared state.
+# See docs/architecture/lobby.md § The lobby service.
+
+[Unit]
+Description=Energetica lobby service (server-wide SSO + picker)
+After=network.target
+
+[Service]
+Type=simple
+# Runs as the shared service user so it can read the server-wide accounts.db and
+# secret_key.txt in /var/lib/energetica (group-scoped, no world access).
+User=energetica
+Group=energetica
+WorkingDirectory=/var/www/energetica-lobby
+
+Environment=ENERGETICA_APEX_DOMAIN=@DOMAIN@
+Environment=ENERGETICA_SHARED_SECRET_PATH=/var/lib/energetica/secret_key.txt
+Environment=ENERGETICA_ACCOUNTS_DB_PATH=/var/lib/energetica/accounts.db
+Environment=ENERGETICA_LANDING_DIR=/var/www/energetica-landing
+Environment=ENERGETICA_SERVER_CONFIG_PATH=/etc/energetica/server.json
+
+ExecStart=/var/www/energetica-lobby/.venv/bin/python main_lobby.py --port @PORT@
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/infra/setup-base.sh
+++ b/scripts/infra/setup-base.sh
@@ -136,6 +136,29 @@ log_success "/var/lib/energetica (2770 energetica:energetica)"
 install -d -o root -g energetica -m 0750 /etc/energetica
 log_success "/etc/energetica (0750 root:energetica)"
 
+# Server-wide cookie-signing secret (ADR-0002): minted once per server, read by the lobby
+# and — from the Phase C cutover — every instance, so a session minted by the lobby
+# validates everywhere. root:energetica 0640 → services read via group, only an admin
+# rotates it. Never overwritten on re-run (rotating it invalidates every live session).
+if [ -s /var/lib/energetica/secret_key.txt ]; then
+    log_success "Shared secret already exists — leaving it untouched"
+else
+    (umask 037; python3 -c 'import secrets; print(secrets.token_hex(32))' > /var/lib/energetica/secret_key.txt)
+    chown root:energetica /var/lib/energetica/secret_key.txt
+    log_success "/var/lib/energetica/secret_key.txt (0640 root:energetica)"
+fi
+
+# Server-wide config: the lobby's signup toggle (energetica/server_config.py — reads fresh
+# per request, fails closed when missing/malformed). Admin-edited like instance.json.
+if [ -f /etc/energetica/server.json ]; then
+    log_success "/etc/energetica/server.json already exists — leaving admin's copy untouched"
+else
+    echo '{"signups_enabled": true}' > /etc/energetica/server.json
+    chown root:energetica /etc/energetica/server.json
+    chmod 0640 /etc/energetica/server.json
+    log_success "/etc/energetica/server.json (signups_enabled=true, 0640 root:energetica)"
+fi
+
 # --- Certbot Apache-reload hook (shared by landing + every instance) -----------
 log_section "CERTBOT RENEWAL HOOK"
 install -d /etc/letsencrypt/renewal-hooks/deploy

--- a/scripts/infra/setup-instance.sh
+++ b/scripts/infra/setup-instance.sh
@@ -57,8 +57,8 @@ if ! [[ "$DOMAIN" =~ ^([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$ ]
     log_error "Invalid domain: '$DOMAIN' (expected a hostname like energetica-game.org)"
     exit 1
 fi
-if ! [[ "$INSTANCE" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
-    log_error "Instance slug must be lowercase kebab-case ([a-z0-9][a-z0-9-]*[a-z0-9]): '$INSTANCE'"
+if ! [[ "$INSTANCE" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then
+    log_error "Instance slug must be lowercase kebab-case, max 63 chars (a DNS label): '$INSTANCE'"
     exit 1
 fi
 if [ "$INSTANCE" = "landing" ]; then

--- a/scripts/infra/setup-instance.sh
+++ b/scripts/infra/setup-instance.sh
@@ -65,6 +65,10 @@ if [ "$INSTANCE" = "landing" ]; then
     log_error "'landing' is reserved for the apex landing site"
     exit 1
 fi
+if [ "$INSTANCE" = "lobby" ]; then
+    log_error "'lobby' is reserved for the lobby service (setup-lobby.sh)"
+    exit 1
+fi
 if ! [[ "$PORT" =~ ^[0-9]+$ ]] || [ "$PORT" -lt 1024 ] || [ "$PORT" -gt 65535 ]; then
     log_error "Port must be an integer 1024-65535: '$PORT'"
     exit 1

--- a/scripts/infra/setup-lobby.sh
+++ b/scripts/infra/setup-lobby.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+set -euo pipefail
+
+# Energetica — provision the lobby service (server-wide SSO + instance picker). Run ONCE
+# per VPS, as root, AFTER setup-base.sh and setup-landing.sh.
+#
+#   sudo bash scripts/infra/setup-lobby.sh --domain <apex-domain> \
+#        [--port 8001] [--deploy-user <user>] [--yes]
+#
+# Creates the lobby dir + venv, the Apache vhost (lobby.{apex}) + TLS, and the
+# energetica-lobby.service unit (enabled, NOT started). Like setup-instance.sh it ships
+# no code — the first ./scripts/deploy-lobby.sh rsyncs the backend + bundle and starts
+# the service.
+#
+# Requires DNS for lobby.{apex-domain} to already resolve here (for TLS issuance), and
+# the shared secret + server.json from setup-base.sh (re-run it first on a box that
+# predates them — it is idempotent).
+
+DOMAIN="${ENERGETICA_DOMAIN:-}"
+DEPLOY_USER="${DEPLOY_USER:-deploy}"
+PORT=8001
+AUTO_CONFIRM=false
+APP_DIR=/var/www/energetica-lobby
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --domain) DOMAIN="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --deploy-user) DEPLOY_USER="$2"; shift 2 ;;
+        --yes) AUTO_CONFIRM=true; shift ;;
+        *) echo "Unknown option: $1"; echo "Usage: sudo bash setup-lobby.sh --domain <apex-domain> [--port 8001] [--deploy-user <user>] [--yes]"; exit 1 ;;
+    esac
+done
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log_step()    { echo -e "${YELLOW}→ $1${NC}"; }
+log_success() { echo -e "${GREEN}✓ $1${NC}"; }
+log_error()   { echo -e "${RED}✗ $1${NC}"; }
+log_section() { echo; echo -e "${BLUE}━━━ $1 ━━━${NC}"; }
+
+[ "$EUID" -eq 0 ] || { log_error "Must run as root"; exit 1; }
+[ -n "$DOMAIN" ] || { log_error "--domain is required"; exit 1; }
+# Restrict to a real hostname: guarantees no sed-metachar reaches the vhost substitution, and
+# rejects typos that would otherwise only surface as a certbot/Apache failure later.
+if ! [[ "$DOMAIN" =~ ^([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$ ]]; then
+    log_error "Invalid domain: '$DOMAIN' (expected a hostname like energetica-game.org)"
+    exit 1
+fi
+if ! [[ "$PORT" =~ ^[0-9]+$ ]] || [ "$PORT" -lt 1024 ] || [ "$PORT" -gt 65535 ]; then
+    log_error "Port must be an integer 1024-65535: '$PORT'"
+    exit 1
+fi
+getent group energetica >/dev/null || { log_error "group 'energetica' missing — run setup-base.sh first"; exit 1; }
+[ -d /var/www/energetica-landing/instances ] || { log_error "landing not set up — run setup-landing.sh first"; exit 1; }
+# The lobby signs the parent-domain cookie with the shared secret and gates signup on
+# server.json — both provisioned by setup-base.sh. A box set up before they existed needs
+# a (idempotent) re-run, so fail here with that pointer rather than starting a lobby that
+# cannot mint sessions / never accepts signups.
+[ -s /var/lib/energetica/secret_key.txt ] || { log_error "shared secret missing — re-run setup-base.sh first"; exit 1; }
+[ -f /etc/energetica/server.json ] || { log_error "/etc/energetica/server.json missing — re-run setup-base.sh first"; exit 1; }
+
+FQDN="lobby.$DOMAIN"
+VHOST=/etc/apache2/sites-available/energetica-lobby.conf
+UNIT=/etc/systemd/system/energetica-lobby.service
+
+log_section "PROVISION LOBBY (port $PORT, $FQDN)"
+if [ "$AUTO_CONFIRM" = false ]; then
+    read -r -p "DNS for $FQDN points here? Continue? (y/n) " -n 1 -r; echo
+    [[ $REPLY =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
+fi
+
+# --- Directories + venv -----------------------------------------------------------
+log_section "DIRECTORIES & VENV"
+# Lobby dir: deploy (owner) rsyncs code + bundle; the service and Apache (group
+# energetica, via setgid) read it. 2750 = rwx owner, r-x group, none world.
+install -d -o "$DEPLOY_USER" -g energetica -m 2750 "$APP_DIR"
+log_success "$APP_DIR (code + bundle, deploy-owned)"
+
+if [ -x "$APP_DIR/.venv/bin/python" ]; then
+    log_success "venv already present at $APP_DIR/.venv"
+else
+    log_step "Creating venv (populated by first deploy)..."
+    # Same least-privilege dance as setup-instance.sh: the venv is owned by the service
+    # user (which runs `sudo -u energetica pip install` during deploys) inside the
+    # deploy-owned code dir.
+    install -d -o energetica -g energetica -m 0750 "$APP_DIR/.venv"
+    sudo -u energetica python3 -m venv "$APP_DIR/.venv"
+    log_success "venv at $APP_DIR/.venv"
+fi
+
+# --- Deploy-precondition sudo grant ------------------------------------------------
+log_section "DEPLOY SUDOERS"
+# deploy-lobby.sh hard-refuses to deploy while Phase A's instance_membership backfill has
+# not run (else the lobby would silently show every existing player zero runs), and only
+# the service user can read /var/lib/energetica/accounts.db — so the deploy user needs to
+# run that one read-only python check as energetica. `python3 -c *` as energetica grants
+# nothing the base pip rule doesn't already imply (pip installs execute arbitrary code as
+# energetica), and stays scoped to the service account — never root.
+SUDOERS_FILE=/etc/sudoers.d/energetica-deploy-lobby
+cat > "$SUDOERS_FILE" <<EOF
+$DEPLOY_USER ALL=(energetica) NOPASSWD: /usr/bin/python3 -c *, /bin/python3 -c *
+EOF
+chmod 440 "$SUDOERS_FILE"
+if visudo -cf "$SUDOERS_FILE" >/dev/null; then
+    log_success "Configured passwordless sudo for $DEPLOY_USER (python3 -c as energetica)"
+else
+    rm -f "$SUDOERS_FILE"
+    log_error "sudoers syntax invalid — removed $SUDOERS_FILE; deploy-lobby.sh's precondition check will fail closed"
+fi
+
+# --- Temporary HTTP vhost for ACME -------------------------------------------------
+log_section "TLS PROVISIONING"
+log_step "Writing temporary HTTP vhost for certbot..."
+cat > "$VHOST" <<EOF
+<VirtualHost *:80>
+    ServerName $FQDN
+    DocumentRoot $APP_DIR
+</VirtualHost>
+EOF
+a2ensite energetica-lobby >/dev/null
+systemctl reload apache2
+
+if [ -f "/etc/letsencrypt/live/$FQDN/fullchain.pem" ]; then
+    log_success "Certificate for $FQDN already exists — skipping issuance"
+else
+    log_step "Obtaining certificate via webroot..."
+    certbot certonly --webroot -w "$APP_DIR" -d "$FQDN" --non-interactive --agree-tos --register-unsafely-without-email
+    log_success "Certificate obtained"
+fi
+
+# --- Full vhost ---------------------------------------------------------------------
+log_section "LOBBY VHOST"
+sed -e "s/@DOMAIN@/$DOMAIN/g" \
+    -e "s/@PORT@/$PORT/g" \
+    "$SCRIPT_DIR/apache-lobby.conf" > "$VHOST"
+a2ensite energetica-lobby >/dev/null
+apache2ctl configtest
+systemctl reload apache2
+log_success "Vhost active: https://$FQDN"
+
+# --- systemd unit (enabled, not started — no code yet) ------------------------------
+log_section "SYSTEMD UNIT"
+sed -e "s/@DOMAIN@/$DOMAIN/g" \
+    -e "s/@PORT@/$PORT/g" \
+    "$SCRIPT_DIR/energetica-lobby.service" > "$UNIT"
+systemctl daemon-reload
+systemctl enable energetica-lobby >/dev/null
+log_success "energetica-lobby.service enabled (not started)"
+
+log_section "LOBBY PROVISIONED"
+echo "Ship code and start the service from your machine:"
+echo "  ./scripts/deploy-lobby.sh --server <ssh-host> --domain $DOMAIN"
+echo
+echo "Deploy precondition: Phase A (instance_membership table + backfill) must already be"
+echo "live in /var/lib/energetica/accounts.db — deploy-lobby.sh refuses otherwise."

--- a/scripts/infra/setup-lobby.sh
+++ b/scripts/infra/setup-lobby.sh
@@ -64,6 +64,22 @@ FQDN="lobby.$DOMAIN"
 VHOST=/etc/apache2/sites-available/energetica-lobby.conf
 UNIT=/etc/systemd/system/energetica-lobby.service
 
+# The port must be exclusively the lobby's. A collision with an instance would be
+# insidious: the lobby unit crash-loops on bind while Apache proxies lobby.{apex}/api to
+# the *instance* backend — which also answers /api/v1/lobby/my-runs with a 401, so even
+# the deploy health check would pass against the wrong app and SSO would silently never
+# work. Check the rendered units (source of truth) and — unless the listener is our own
+# already-provisioned lobby (re-run) — the live sockets.
+PORT_CONFLICT="$(grep -lE -- "--port $PORT( |\$)" /etc/systemd/system/energetica-*.service 2>/dev/null | grep -v '/energetica-lobby\.service$' || true)"
+if [ -n "$PORT_CONFLICT" ]; then
+    log_error "Port $PORT is already claimed by: $PORT_CONFLICT — pass a free --port"
+    exit 1
+fi
+if [ ! -f "$UNIT" ] && ss -ltnH "sport = :$PORT" 2>/dev/null | grep -q .; then
+    log_error "Port $PORT is already listening on this host — pass a free --port"
+    exit 1
+fi
+
 log_section "PROVISION LOBBY (port $PORT, $FQDN)"
 if [ "$AUTO_CONFIRM" = false ]; then
     read -r -p "DNS for $FQDN points here? Continue? (y/n) " -n 1 -r; echo
@@ -111,19 +127,23 @@ fi
 
 # --- Temporary HTTP vhost for ACME -------------------------------------------------
 log_section "TLS PROVISIONING"
-log_step "Writing temporary HTTP vhost for certbot..."
-cat > "$VHOST" <<EOF
+if [ -f "/etc/letsencrypt/live/$FQDN/fullchain.pem" ]; then
+    # Don't touch the vhost when the cert is already there: on a re-run the live HTTPS
+    # vhost would otherwise be clobbered by the bare HTTP one and a mid-script failure
+    # (certbot rate limit, configtest) would leave the lobby down and $APP_DIR exposed
+    # over plain HTTP until an operator restores it. The full vhost is rendered below
+    # either way.
+    log_success "Certificate for $FQDN already exists — skipping issuance"
+else
+    log_step "Writing temporary HTTP vhost for certbot..."
+    cat > "$VHOST" <<EOF
 <VirtualHost *:80>
     ServerName $FQDN
     DocumentRoot $APP_DIR
 </VirtualHost>
 EOF
-a2ensite energetica-lobby >/dev/null
-systemctl reload apache2
-
-if [ -f "/etc/letsencrypt/live/$FQDN/fullchain.pem" ]; then
-    log_success "Certificate for $FQDN already exists — skipping issuance"
-else
+    a2ensite energetica-lobby >/dev/null
+    systemctl reload apache2
     log_step "Obtaining certificate via webroot..."
     certbot certonly --webroot -w "$APP_DIR" -d "$FQDN" --non-interactive --agree-tos --register-unsafely-without-email
     log_success "Certificate obtained"


### PR DESCRIPTION
Part of #816 (lobby Phase B). Stacks on #837 (frontend bundle), which stacks on #836 (backend).

## What this adds

`scripts/infra/` gains the lobby siblings of the landing/instance files, plus `scripts/deploy-lobby.sh`:

- **`apache-lobby.conf`** — serves `dist-lobby` (SPA `FallbackResource`, disabled under `/assets/` so pruned hashed assets 404 instead of being cached as HTML), proxies `/api` to the lobby uvicorn, and **`Alias`es the live `instances.json` from the shared landing dir** (same-origin manifest for the picker — no CORS, no second copy). `X-Forwarded-Proto` set so the parent-domain cookie gets `Secure`.
- **`energetica-lobby.service`** — `ENERGETICA_APEX_DOMAIN` (cookie scope, ADR-0002) + explicit shared-state paths (`secret_key.txt`, `accounts.db`, landing dir, `server.json`); runs `main_lobby.py` as the shared service user.
- **`setup-lobby.sh`** — dir + venv + TLS + vhost + unit (enabled, not started), preconditions on the setup-base/landing artifacts, **port-uniqueness check** (a collision with an instance is insidious: the lobby unit crash-loops while Apache proxies lobby `/api` to the *game* backend, which also answers `my-runs` with 401 — even the health check would pass; the old DEPLOYMENT.md example provisioned an instance on the lobby's default 8001). Re-runs no longer clobber the live HTTPS vhost with the temp ACME vhost.
- **`deploy-lobby.sh`** — **hard-refuses (fail-closed, before anything ships) unless `instance_membership` exists in `accounts.db`** — the #816-pinned Phase A precondition (otherwise every existing player silently sees zero runs). Then rsync backend + bundle, pip install, restart, health check (api 401 unauthenticated + SPA 200). No `VITE_APEX_DOMAIN`: the lobby derives its apex from its hostname at runtime.
- **`setup-base.sh`** — also provisions the server-wide signing secret (never rotated on re-run) and `/etc/energetica/server.json` (`{"signups_enabled": true}`); idempotent, so existing boxes just re-run it.
- **`lobby` is now a reserved slug** in `setup-instance.sh` / `deploy-instance.sh` (would collide with the lobby vhost/dir).
- DEPLOYMENT.md updated (lobby setup/deploy sections, one-port-per-service rule).

## Reviewer call-outs (deliberate tradeoffs)

- **Sudoers grant for the precondition check**: the deploy user can't read `accounts.db`, so `setup-lobby.sh` grants `python3 -c *` **as the `energetica` service user only** (never root). This adds no capability beyond the existing pip rule (pip installs already execute arbitrary code as that user), but it *is* a broad-looking line — the alternative is a `/healthz`-style preflight in the lobby backend, which #816 pinned against in favor of refusing at deploy time. Happy to switch if you prefer.
- The deploy health check keys on "`/api/v1/lobby/my-runs` answers 401 unauthenticated" since the lobby app has no `/healthz`; a tiny `/healthz` route would be a nicer contract but touches the #836 backend, so it's left as a possible follow-up.

Everything mirrors the existing landing/instance script patterns (colors, flags, rsync exclusions, sudoers style); `bash -n` clean, template rendering + port-conflict grep + the sqlite precondition snippet tested against fixtures (present / absent table / missing db).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the lobby deployment and provisioning path. The main changes are:

- New lobby Apache vhost, systemd unit, setup script, and deploy script.
- Shared signing secret and server config provisioning in base setup.
- Lobby slug reservation for instance setup and deploy.
- Deployment docs for lobby setup, deploy, and port separation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/deploy-lobby.sh | Adds the lobby deploy flow with Phase A precondition checks, bundle sync, restart, and live health probes. |
| scripts/infra/setup-lobby.sh | Adds lobby provisioning for directories, venv, sudoers, TLS, Apache, and systemd. |
| scripts/infra/apache-lobby.conf | Adds the lobby vhost with SPA serving, API proxying, asset caching, and same-origin manifest aliasing. |
| scripts/infra/energetica-lobby.service | Adds the lobby service unit with explicit shared-state paths and apex-domain configuration. |
| scripts/infra/setup-base.sh | Adds idempotent provisioning for the shared session secret and server-wide config. |
| scripts/deploy-instance.sh | Updates instance deploy validation to reserve the lobby slug. |
| scripts/infra/setup-instance.sh | Updates instance setup validation to reserve the lobby slug and enforce DNS-label length. |
| scripts/DEPLOYMENT.md | Documents the lobby setup and deploy workflow. |

<sub>Reviews (3): Last reviewed commit: ["fix: manifest health probe + 63-char slu..."](https://github.com/felixvonsamson/energetica/commit/b48d8e8ee2016fdf627781536b60a2094982f024) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41960437)</sub>

<!-- /greptile_comment -->