### PR TITLE
fix(deploy): re-assert landing dir setgid/group-write after rsync

### DIFF
--- a/scripts/deploy-landing.sh
+++ b/scripts/deploy-landing.sh
@@ -72,6 +72,17 @@ rsync -az --delete \
     ./frontend/dist-landing/ "$SSH:$LANDING_DIR/" >/dev/null
 log_success "Landing bundle deployed"
 
+# rsync -a applies the source dir's mode to $LANDING_DIR itself, stripping the setgid +
+# group-write bits setup-landing.sh set (2775). Those bits are load-bearing: the instance
+# backends (group energetica) atomically write instances.json *into this dir*, so without
+# group-write the aggregate write fails with EPERM — and because the instances/ fragment dir
+# is --excluded (keeps its 2775), per-instance fragments still write while the aggregate
+# manifest silently goes stale (a new instance never appears in the lobby picker). openrsync
+# (macOS) lacks --chmod, so re-assert the mode over ssh after the sync. The deploy user owns
+# $LANDING_DIR, so it can restore the setgid bit.
+ssh "$SSH" "chmod 2775 '$LANDING_DIR'"
+log_success "Landing dir perms re-asserted (2775, setgid energetica)"
+
 # The landing + wiki pages reference /static/images/... (e.g. landing_page banners, wiki
 # figures). The apex is pure-static, so unlike the game vhost (which Aliases /static/images
 # into the instance code dir) these must be shipped into the landing DocumentRoot itself.


### PR DESCRIPTION
## Problem

`deploy-landing.sh`'s `rsync -a dist-landing/ → energetica-landing/` applies the local source dir's plain `0755` mode onto the landing root, **stripping the `2775` setgid + group-write** bits that `setup-landing.sh` sets.

Those bits are load-bearing: instance backends (group `energetica`) atomically write `instances.json` **into the landing root dir**, so without group-write the aggregate write fails with `EPERM`:

```
could not publish instance fragment for hertz: [Errno 13] Permission denied:
'/var/www/energetica-landing/instances.json.<rand>.tmp'
```

Because the `instances/` fragment dir is `--exclude`d (keeps its `2775`), per-instance fragments still write while the aggregate manifest **silently goes stale** — a newly provisioned instance never appears in the lobby picker until the perms are restored by hand.

**Hit in production** while standing up a new instance (`hertz`) shortly after a landing deploy: the fragment `instances/hertz.json` was written but `hertz` was absent from `instances.json`. Root dir was `drwxr-xr-x` with an mtime matching the landing deploy.

## Fix

Re-assert `2775` on the landing root over ssh after the bundle rsync. openrsync (macOS) lacks `--chmod`, so a post-sync `chmod` is the portable fix; the deploy user owns the dir and can restore the setgid bit.

## Validation

Re-ran `deploy-landing.sh --skip-build` against production: the rsync clobbered the dir to `0755`, the new step restored it to `drwxrwsr-x` (2775), and `instances.json` correctly aggregated both live instances. The live box was also manually repaired during the incident, so prod is already healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production permissions regression in `deploy-landing.sh`: `rsync -a` overwrites the landing root's mode with the local source directory's `0755`, stripping the `2775` (setgid + group-write) that `setup-landing.sh` sets so instance backends can atomically write `instances.json` there. The fix adds a single `chmod 2775` via SSH immediately after the rsync, restoring the bits before the next phase of the deploy.

- A post-rsync `ssh "$SSH" "chmod 2775 '$LANDING_DIR'"` re-asserts the landing root mode; the deploy user owns the directory and can legally restore the setgid bit.
- The chmod is placed correctly between the first rsync (bundle) and the mkdir + second rsync (static images), so neither the `mkdir -p` nor the images sync can re-clobber `$LANDING_DIR`'s mode.
- The quoting pattern (`"chmod 2775 '$LANDING_DIR'"`) is consistent with the existing `mkdir -p` call on line 92 and safe because `LANDING_DIR` is a hardcoded constant, not user input.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line targeted fix with zero logic complexity, well-explained in comments, and validated against production.

The change adds a single idempotent `chmod 2775` over SSH after rsync, directly matching the mode that `setup-landing.sh` sets. The deploy user owns the directory and is permitted to restore the setgid bit without root. Placement between the two rsyncs is correct: the first rsync (bundle) is what strips the bit, and the second rsync (static images) only touches a subdirectory, so it cannot re-clobber `$LANDING_DIR`. The hardcoded `LANDING_DIR` constant means the SSH command string has no injection surface. No other files are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/deploy-landing.sh | Adds a post-rsync `chmod 2775` over SSH to restore the landing root's setgid+group-write mode that rsync clobbers; placement is correct and quoting is safe. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant L as Local Machine
    participant R as Remote Server

    L->>R: rsync -az --delete dist-landing/ → energetica-landing/
    Note over R: LANDING_DIR mode clobbered to 0755<br/>(setgid + group-write stripped)
    L->>R: ssh chmod 2775 /var/www/energetica-landing ⬅ NEW
    Note over R: Mode restored to 2775<br/>(setgid energetica, group-write)
    L->>R: ssh mkdir -p energetica-landing/static/images
    L->>R: rsync -az --delete static/images/ → energetica-landing/static/images/
    Note over R: Only subdirectory affected,<br/>LANDING_DIR mode stays 2775
    Note over R: instance backends can write instances.json ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant L as Local Machine
    participant R as Remote Server

    L->>R: rsync -az --delete dist-landing/ → energetica-landing/
    Note over R: LANDING_DIR mode clobbered to 0755<br/>(setgid + group-write stripped)
    L->>R: ssh chmod 2775 /var/www/energetica-landing ⬅ NEW
    Note over R: Mode restored to 2775<br/>(setgid energetica, group-write)
    L->>R: ssh mkdir -p energetica-landing/static/images
    L->>R: rsync -az --delete static/images/ → energetica-landing/static/images/
    Note over R: Only subdirectory affected,<br/>LANDING_DIR mode stays 2775
    Note over R: instance backends can write instances.json ✓
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(deploy): re-assert landing dir setgi..."](https://github.com/felixvonsamson/energetica/commit/2d800a37a0f20359d9c72dc396fc58601aa1cdb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42060277)</sub>

<!-- /greptile_comment -->