### PR TITLE
feat(844): add lobby change-password UI

### DIFF
--- a/frontend/src/components/ui/info-banner.tsx
+++ b/frontend/src/components/ui/info-banner.tsx
@@ -1,11 +1,11 @@
-import { Info, AlertTriangle, XCircle } from "lucide-react";
+import { Info, AlertTriangle, XCircle, CheckCircle } from "lucide-react";
 import { type ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
 interface InfoBannerProps {
     children: ReactNode;
-    variant?: "info" | "warning" | "error";
+    variant?: "info" | "warning" | "error" | "success";
     className?: string;
 }
 
@@ -33,6 +33,12 @@ export function InfoBanner({
             icon: "text-destructive",
             text: "text-destructive",
             IconComponent: XCircle,
+        },
+        success: {
+            container: "bg-success/10 border-success",
+            icon: "text-success",
+            text: "text-success",
+            IconComponent: CheckCircle,
         },
     };
 

--- a/frontend/src/hooks/use-lobby.ts
+++ b/frontend/src/hooks/use-lobby.ts
@@ -9,7 +9,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { lobbyApi, lobbyAuthApi, type MyRunsResponse } from "@/lib/api/lobby";
 import { ApiClientError } from "@/lib/api-client";
 import { fetchInstances, type InstanceFragment } from "@/lib/instances";
-import type { LoginRequest, SignupRequest } from "@/types/auth";
+import type {
+    ChangePasswordRequest,
+    LoginRequest,
+    SignupRequest,
+} from "@/types/auth";
 
 /**
  * Query keys local to the lobby bundle. Deliberately not part of the game's
@@ -83,6 +87,19 @@ export function useLobbySignup() {
         // Returned for the same navigate-after-await reason as useLobbyLogin.
         onSuccess: () =>
             queryClient.invalidateQueries({ queryKey: lobbyQueryKeys.myRuns }),
+    });
+}
+
+/**
+ * Mutation hook for changing the authenticated account's password.
+ *
+ * No cache work on success: the password change leaves the session (and the
+ * my-runs auth probe) untouched — the same cookie stays valid.
+ */
+export function useLobbyChangePassword() {
+    return useMutation({
+        mutationFn: (data: ChangePasswordRequest) =>
+            lobbyAuthApi.changePassword(data),
     });
 }
 

--- a/frontend/src/routeTree.lobby.gen.ts
+++ b/frontend/src/routeTree.lobby.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes-lobby/__root'
 import { Route as SignupRouteImport } from './routes-lobby/signup'
 import { Route as LogoutRouteImport } from './routes-lobby/logout'
 import { Route as LoginRouteImport } from './routes-lobby/login'
+import { Route as AccountRouteImport } from './routes-lobby/account'
 import { Route as IndexRouteImport } from './routes-lobby/index'
 
 const SignupRoute = SignupRouteImport.update({
@@ -29,6 +30,11 @@ const LoginRoute = LoginRouteImport.update({
   path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AccountRoute = AccountRouteImport.update({
+  id: '/account',
+  path: '/account',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -37,12 +43,14 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/account': typeof AccountRoute
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/signup': typeof SignupRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/account': typeof AccountRoute
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/signup': typeof SignupRoute
@@ -50,20 +58,22 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/account': typeof AccountRoute
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/signup': typeof SignupRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/logout' | '/signup'
+  fullPaths: '/' | '/account' | '/login' | '/logout' | '/signup'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/logout' | '/signup'
-  id: '__root__' | '/' | '/login' | '/logout' | '/signup'
+  to: '/' | '/account' | '/login' | '/logout' | '/signup'
+  id: '__root__' | '/' | '/account' | '/login' | '/logout' | '/signup'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AccountRoute: typeof AccountRoute
   LoginRoute: typeof LoginRoute
   LogoutRoute: typeof LogoutRoute
   SignupRoute: typeof SignupRoute
@@ -92,6 +102,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/account': {
+      id: '/account'
+      path: '/account'
+      fullPath: '/account'
+      preLoaderRoute: typeof AccountRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -104,6 +121,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AccountRoute: AccountRoute,
   LoginRoute: LoginRoute,
   LogoutRoute: LogoutRoute,
   SignupRoute: SignupRoute,

--- a/frontend/src/routes-lobby/__root.tsx
+++ b/frontend/src/routes-lobby/__root.tsx
@@ -1,5 +1,5 @@
 import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
-import { LogOut } from "lucide-react";
+import { LogOut, UserCog } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
@@ -34,16 +34,28 @@ function RootComponent() {
                 <div className="flex flex-row items-center gap-1">
                     <ThemeToggle />
                     {myRuns != null && (
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => logout.mutate()}
-                            disabled={logout.isPending}
-                            className="gap-1.5"
-                        >
-                            <LogOut className="w-4 h-4" />
-                            Log out
-                        </Button>
+                        <>
+                            <Link to="/account">
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="gap-1.5"
+                                >
+                                    <UserCog className="w-4 h-4" />
+                                    Account
+                                </Button>
+                            </Link>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => logout.mutate()}
+                                disabled={logout.isPending}
+                                className="gap-1.5"
+                            >
+                                <LogOut className="w-4 h-4" />
+                                Log out
+                            </Button>
+                        </>
                     )}
                 </div>
             </header>

--- a/frontend/src/routes-lobby/account.tsx
+++ b/frontend/src/routes-lobby/account.tsx
@@ -1,0 +1,223 @@
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { KeyRound } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { InfoBanner } from "@/components/ui/info-banner";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyBrand } from "@/components/ui/typography";
+import { useLobbyChangePassword, useMyRuns } from "@/hooks/use-lobby";
+import { getUserFriendlyError, isErrorType } from "@/lib/error-utils";
+
+export const Route = createFileRoute("/account")({
+    component: AccountPage,
+    staticData: { title: "Account" },
+});
+
+function AccountPage() {
+    const navigate = useNavigate();
+    const { data: myRuns, isPending } = useMyRuns();
+    const isLoggedOut = !isPending && myRuns == null;
+
+    // Account settings are auth-only — bounce a logged-out visitor to login.
+    useEffect(() => {
+        if (isLoggedOut) {
+            void navigate({ to: "/login" });
+        }
+    }, [isLoggedOut, navigate]);
+
+    if (isPending || isLoggedOut) {
+        return (
+            <div className="flex justify-center py-24">
+                <Spinner />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex items-center justify-center px-4 py-12">
+            <ChangePasswordForm />
+        </div>
+    );
+}
+
+function ChangePasswordForm() {
+    const changePassword = useLobbyChangePassword();
+
+    const [oldPassword, setOldPassword] = useState("");
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [oldPasswordError, setOldPasswordError] = useState<string | null>(
+        null,
+    );
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState(false);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setOldPasswordError(null);
+        setError(null);
+        setSuccess(false);
+
+        if (!oldPassword || !newPassword || !confirmPassword) {
+            setError("Please fill in all fields");
+            return;
+        }
+
+        // Mirrors the backend ChangePasswordRequest constraint (new_password ≥ 7).
+        if (newPassword.length < 7) {
+            setError("New password must be at least 7 characters");
+            return;
+        }
+
+        if (newPassword !== confirmPassword) {
+            setError("New passwords do not match");
+            return;
+        }
+
+        if (newPassword === oldPassword) {
+            setError("New password must differ from your current password");
+            return;
+        }
+
+        try {
+            await changePassword.mutateAsync({
+                old_password: oldPassword,
+                new_password: newPassword,
+            });
+            setSuccess(true);
+            setOldPassword("");
+            setNewPassword("");
+            setConfirmPassword("");
+        } catch (err) {
+            if (isErrorType(err, "OLD_PASSWORD_INCORRECT")) {
+                setOldPasswordError(getUserFriendlyError(err));
+            } else {
+                setError(getUserFriendlyError(err));
+            }
+        }
+    };
+
+    return (
+        <div className="w-full max-w-md">
+            {/* Branding */}
+            <div className="text-center mb-8">
+                <TypographyBrand className="text-5xl text-primary mb-4 block">
+                    Energetica
+                </TypographyBrand>
+                <Link
+                    to="/"
+                    className="text-base text-primary hover:opacity-80 transition-opacity underline"
+                >
+                    Back to your runs
+                </Link>
+            </div>
+
+            {/* Change Password Card */}
+            <Card className="shadow-lg">
+                <CardHeader className="text-center">
+                    <CardTitle className="text-3xl">Change password</CardTitle>
+                </CardHeader>
+
+                <CardContent>
+                    {success && (
+                        <InfoBanner variant="success" className="mb-6">
+                            Your password has been changed. It applies the next
+                            time you log in.
+                        </InfoBanner>
+                    )}
+
+                    {error && (
+                        <InfoBanner variant="error" className="mb-6">
+                            {error}
+                        </InfoBanner>
+                    )}
+
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <div>
+                            <Label htmlFor="oldPassword" className="mb-2">
+                                Current password
+                            </Label>
+                            <Input
+                                type="password"
+                                id="oldPassword"
+                                name="oldPassword"
+                                value={oldPassword}
+                                onChange={(e) => setOldPassword(e.target.value)}
+                                placeholder="Enter current password"
+                                disabled={changePassword.isPending}
+                                autoComplete="current-password"
+                                aria-invalid={
+                                    oldPasswordError ? true : undefined
+                                }
+                                // eslint-disable-next-line jsx-a11y/no-autofocus
+                                autoFocus
+                            />
+                            {oldPasswordError && (
+                                <p className="mt-1 text-sm text-destructive">
+                                    {oldPasswordError}
+                                </p>
+                            )}
+                        </div>
+
+                        <div>
+                            <Label htmlFor="newPassword" className="mb-2">
+                                New password (minimum 7 characters)
+                            </Label>
+                            <Input
+                                type="password"
+                                id="newPassword"
+                                name="newPassword"
+                                value={newPassword}
+                                onChange={(e) => setNewPassword(e.target.value)}
+                                placeholder="Choose a new password"
+                                disabled={changePassword.isPending}
+                                minLength={7}
+                                autoComplete="new-password"
+                            />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="confirmPassword" className="mb-2">
+                                Confirm new password
+                            </Label>
+                            <Input
+                                type="password"
+                                id="confirmPassword"
+                                name="confirmPassword"
+                                value={confirmPassword}
+                                onChange={(e) =>
+                                    setConfirmPassword(e.target.value)
+                                }
+                                placeholder="Confirm your new password"
+                                disabled={changePassword.isPending}
+                                minLength={7}
+                                autoComplete="new-password"
+                            />
+                        </div>
+
+                        <Button
+                            type="submit"
+                            variant={
+                                changePassword.isPending ? "outline" : "default"
+                            }
+                            size="lg"
+                            disabled={changePassword.isPending}
+                            className="w-full flex items-center justify-center gap-2"
+                        >
+                            {changePassword.isPending ? (
+                                <Spinner />
+                            ) : (
+                                <KeyRound className="w-5 h-5" />
+                            )}
+                            <>Change password</>
+                        </Button>
+                    </form>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/frontend/src/routes-lobby/account.tsx
+++ b/frontend/src/routes-lobby/account.tsx
@@ -125,8 +125,7 @@ function ChangePasswordForm() {
                 <CardContent>
                     {success && (
                         <InfoBanner variant="success" className="mb-6">
-                            Your password has been changed. It applies the next
-                            time you log in.
+                            Your password has been changed successfully.
                         </InfoBanner>
                     )}
 
@@ -194,7 +193,6 @@ function ChangePasswordForm() {
                                 }
                                 placeholder="Confirm your new password"
                                 disabled={changePassword.isPending}
-                                minLength={7}
                                 autoComplete="new-password"
                             />
                         </div>
@@ -213,7 +211,7 @@ function ChangePasswordForm() {
                             ) : (
                                 <KeyRound className="w-5 h-5" />
                             )}
-                            <>Change password</>
+                            Change password
                         </Button>
                     </form>
                 </CardContent>


### PR DESCRIPTION
Closes #844.

## Context

The Phase C cutover (#817, merged in #841) removed the instance change-password dialog — the instance has no credential endpoints anymore. The lobby backend already serves `POST /api/v1/auth/change-password` and `lobbyAuthApi.changePassword` could call it, but there was **no lobby UI**, so accounts had no way to change their password.

## Change

- New auth-gated `/account` route (`frontend/src/routes-lobby/account.tsx`) with a change-password form wired to `lobbyAuthApi.changePassword` via a new `useLobbyChangePassword` hook. Logged-out visitors bounce to `/login`.
- New **Account** link in the lobby header (`__root.tsx`), shown when authenticated, alongside Log out.
- The form mirrors the existing signup/login pages: branded header, shared `Card`/`Input`/`Label`/`InfoBanner` primitives, `KeyRound` submit affordance.
- Client-side validation mirroring the backend `ChangePasswordRequest` constraints: new password ≥ 7 chars, confirmation must match, must differ from current. Backend `OLD_PASSWORD_INCORRECT` surfaces inline under the current-password field.
- Added a `success` variant to `InfoBanner` (green + check) for the confirmation state.

## Verification

Drove the full flow in a real browser against the **production** `lobby.energetica-game.org` backend (via `VITE_BACKEND_URL=https://lobby.energetica-game.org bun run dev:lobby`):

- ✅ Login → Account link → form renders
- ✅ Client-side mismatch / length validation
- ✅ Wrong current password → inline `OLD_PASSWORD_INCORRECT`
- ✅ Successful change → green success banner, fields cleared
- ✅ Change reverted and re-login with the original credential confirmed (HTTP 200)
- ✅ Header fits at 375px mobile width
- ✅ `typecheck`, `lint`, `format` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a lobby `/account` page with a change-password form, filling a gap left by the Phase C cutover that removed instance-level credential endpoints. An `Account` link appears in the header for authenticated users, and `InfoBanner` gains a green `success` variant for the confirmation state.

- **New `account.tsx` route**: Auth-gated via `useMyRuns` + `useEffect` redirect; client-side validation (length ≥ 7, match, differs from current) mirrors the backend's `ChangePasswordRequest` constraints; `OLD_PASSWORD_INCORRECT` surfaces under the current-password field, all other errors into the banner.
- **`useLobbyChangePassword` hook**: Thin mutation wrapper around `lobbyAuthApi.changePassword`; no cache work needed since the session cookie stays valid after a password change.
- **`InfoBanner` `success` variant**: Follows the existing pattern using the `--color-success` CSS token already defined in both light and dark themes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds a self-contained, auth-gated UI feature with no modifications to backend calls, shared state, or existing auth flows.

All changed code is additive: a new route, a new hook, a new CSS variant, and a header link. The auth guard correctly prevents unauthenticated access, client-side validation mirrors the backend constraints, and error paths are fully handled. No existing logic is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/routes-lobby/account.tsx | New `/account` route with a change-password form; auth redirect via `useEffect`, client-side validation mirrors backend constraints, error/success state handled correctly. |
| frontend/src/components/ui/info-banner.tsx | Adds `success` variant using the existing `--color-success` CSS token; consistent with `info`/`warning`/`error` variants. |
| frontend/src/hooks/use-lobby.ts | Adds `useLobbyChangePassword` mutation hook; no cache invalidation needed since the session cookie remains valid after a password change. |
| frontend/src/routes-lobby/__root.tsx | Adds an Account link to the authenticated header alongside Log out; follows the existing `Link > Button` pattern used elsewhere in lobby routes. |
| frontend/src/routeTree.lobby.gen.ts | Auto-generated route tree; adds `/account` entry correctly. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant AccountPage
    participant useMyRuns
    participant ChangePasswordForm
    participant useLobbyChangePassword
    participant LobbyAPI as POST /auth/change-password

    User->>AccountPage: navigate to /account
    AccountPage->>useMyRuns: query my-runs
    alt not authenticated
        useMyRuns-->>AccountPage: null
        AccountPage->>User: redirect to /login
    else authenticated
        useMyRuns-->>AccountPage: myRuns data
        AccountPage->>ChangePasswordForm: render form
        User->>ChangePasswordForm: "fill & submit"
        ChangePasswordForm->>ChangePasswordForm: client-side validation
        alt validation fails
            ChangePasswordForm-->>User: inline error
        else valid
            ChangePasswordForm->>useLobbyChangePassword: mutateAsync()
            useLobbyChangePassword->>LobbyAPI: POST old+new password
            alt OLD_PASSWORD_INCORRECT
                LobbyAPI-->>useLobbyChangePassword: 400 error
                useLobbyChangePassword-->>ChangePasswordForm: throw
                ChangePasswordForm-->>User: inline error under current-password field
            else success
                LobbyAPI-->>useLobbyChangePassword: 200 OK
                useLobbyChangePassword-->>ChangePasswordForm: resolved
                ChangePasswordForm-->>User: green success banner, fields cleared
            end
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant AccountPage
    participant useMyRuns
    participant ChangePasswordForm
    participant useLobbyChangePassword
    participant LobbyAPI as POST /auth/change-password

    User->>AccountPage: navigate to /account
    AccountPage->>useMyRuns: query my-runs
    alt not authenticated
        useMyRuns-->>AccountPage: null
        AccountPage->>User: redirect to /login
    else authenticated
        useMyRuns-->>AccountPage: myRuns data
        AccountPage->>ChangePasswordForm: render form
        User->>ChangePasswordForm: "fill & submit"
        ChangePasswordForm->>ChangePasswordForm: client-side validation
        alt validation fails
            ChangePasswordForm-->>User: inline error
        else valid
            ChangePasswordForm->>useLobbyChangePassword: mutateAsync()
            useLobbyChangePassword->>LobbyAPI: POST old+new password
            alt OLD_PASSWORD_INCORRECT
                LobbyAPI-->>useLobbyChangePassword: 400 error
                useLobbyChangePassword-->>ChangePasswordForm: throw
                ChangePasswordForm-->>User: inline error under current-password field
            else success
                LobbyAPI-->>useLobbyChangePassword: 200 OK
                useLobbyChangePassword-->>ChangePasswordForm: resolved
                ChangePasswordForm-->>User: green success banner, fields cleared
            end
        end
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(844): address review — success copy,..."](https://github.com/felixvonsamson/energetica/commit/cb80be22e857401b54dcd9d6ac1e30684900bf7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42062688)</sub>

<!-- /greptile_comment -->