### PR TITLE
chore(lint): ban pointless React fragments

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -103,6 +103,7 @@ export default defineConfig([
             ],
             // React extras (recommended rules come from react.configs.flat.recommended above)
             "react/no-unescaped-entities": "off",
+            "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
             "react/no-array-index-key": "warn",
             "react/no-unstable-nested-components": "warn",
             "react/self-closing-comp": "warn",

--- a/frontend/src/components/charts/cash-flow-chart.tsx
+++ b/frontend/src/components/charts/cash-flow-chart.tsx
@@ -173,7 +173,7 @@ export function CashFlowChart({
         isShowingPercent,
     ]);
 
-    if (!chartConfig) return <></>;
+    if (!chartConfig) return null;
 
     return (
         <EChartsTimeSeries

--- a/frontend/src/components/dashboard/progress-lists.tsx
+++ b/frontend/src/components/dashboard/progress-lists.tsx
@@ -313,7 +313,7 @@ function ClimateEventRecoveryItem({
             }
             speed={undefined}
             endTick={recovery.end_tick}
-            actions={<></>}
+            actions={null}
             info={<CashFlow amountPerTick={-recovery.recovery_cost} />}
         />
     );
@@ -338,7 +338,7 @@ function ShipmentItem({ shipment }: { shipment: Shipment }) {
             }
             speed={shipment.speed}
             endTick={shipment.arrival_tick}
-            actions={<></>}
+            actions={null}
         />
     );
 }

--- a/frontend/src/components/layout/breadcrumbs.tsx
+++ b/frontend/src/components/layout/breadcrumbs.tsx
@@ -74,20 +74,18 @@ export function Breadcrumbs() {
     return (
         <>
             {breadcrumbs.length > 0 && (
-                <>
-                    <Breadcrumb>
-                        <BreadcrumbList>
-                            {breadcrumbs.map((crumb, index) => (
-                                <div key={crumb} className="contents">
-                                    {index > 0 && <BreadcrumbSeparator />}
-                                    <BreadcrumbItem>
-                                        <BreadcrumbPage>{crumb}</BreadcrumbPage>
-                                    </BreadcrumbItem>
-                                </div>
-                            ))}
-                        </BreadcrumbList>
-                    </Breadcrumb>
-                </>
+                <Breadcrumb>
+                    <BreadcrumbList>
+                        {breadcrumbs.map((crumb, index) => (
+                            <div key={crumb} className="contents">
+                                {index > 0 && <BreadcrumbSeparator />}
+                                <BreadcrumbItem>
+                                    <BreadcrumbPage>{crumb}</BreadcrumbPage>
+                                </BreadcrumbItem>
+                            </div>
+                        ))}
+                    </BreadcrumbList>
+                </Breadcrumb>
             )}
         </>
     );

--- a/frontend/src/components/ui/asset-name.tsx
+++ b/frontend/src/components/ui/asset-name.tsx
@@ -112,13 +112,11 @@ export function TechnologyName({
 }: TechnologyNameProps) {
     if (level !== null) {
         return (
-            <>
-                <AssetName
-                    assetId={technology}
-                    {...props}
-                    suffix={` Level ${level}`}
-                />
-            </>
+            <AssetName
+                assetId={technology}
+                {...props}
+                suffix={` Level ${level}`}
+            />
         );
     }
 

--- a/frontend/src/routes-lobby/login.tsx
+++ b/frontend/src/routes-lobby/login.tsx
@@ -166,7 +166,7 @@ function LoginForm({ returnSlug }: { returnSlug: string | undefined }) {
                             ) : (
                                 <LogIn className="w-5 h-5" />
                             )}
-                            <>Log in</>
+                            Log in
                         </Button>
                     </form>
 

--- a/frontend/src/routes-lobby/signup.tsx
+++ b/frontend/src/routes-lobby/signup.tsx
@@ -196,7 +196,7 @@ function SignUpForm({ returnSlug }: { returnSlug: string | undefined }) {
                             ) : (
                                 <UserPlus className="w-5 h-5" />
                             )}
-                            <>Create account</>
+                            Create account
                         </Button>
                     </form>
 

--- a/frontend/src/routes/app/dashboard.tsx
+++ b/frontend/src/routes/app/dashboard.tsx
@@ -168,18 +168,16 @@ function DashboardContent() {
 
             {/* Construction - only show if there are any construction projects */}
             {hasConstructionProjects && (
-                <>
-                    <DashboardSection
-                        title={
-                            <>
-                                <HardHat className="inline w-4 h-4" /> Under
-                                Construction
-                            </>
-                        }
-                    >
-                        <ProjectList projectCategory={"construction"} />
-                    </DashboardSection>
-                </>
+                <DashboardSection
+                    title={
+                        <>
+                            <HardHat className="inline w-4 h-4" /> Under
+                            Construction
+                        </>
+                    }
+                >
+                    <ProjectList projectCategory={"construction"} />
+                </DashboardSection>
             )}
 
             {/* Under research - only show if player has laboratory and has research projects */}


### PR DESCRIPTION
## What

Adds an ESLint rule to prevent pointless `<>…</>` fragments across the frontend, and cleans up the existing offenders.

```js
// frontend/eslint.config.js
"react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
```

## How it's enforced

No new CI job or hook was needed — both paths already run ESLint with `--max-warnings 0`:

- **CI** — `bun run lint` in the `frontend-checks` job now fails on a pointless fragment.
- **Pre-commit** — lint-staged runs `eslint --fix` on staged `.tsx` files. The rule is auto-fixable, so most offenders are stripped and reformatted automatically on commit; the non-auto-fixable cases (e.g. `return <></>`) block the commit for a manual fix.

`allowExpressions: true` keeps the rule targeted: it still allows `<>{expr}</>` (a legitimate way to coerce a value to a single `ReactElement`) while flagging fragments wrapping a single element, text-only fragments, and empty fragments.

## Cleanup

Turning the rule on surfaced **8 pre-existing violations**, all fixed here:

- Empty-fragment returns → `null` (`cash-flow-chart.tsx`)
- Empty-fragment props → `null` (`progress-lists.tsx` ×2)
- Single-child wrapper fragments unwrapped (`breadcrumbs.tsx`, `asset-name.tsx`, `dashboard.tsx`)
- Text-only fragments unwrapped (`login.tsx`, `signup.tsx`)

## Verification

`bun run lint`, `bun run format:check`, and `bun run typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bans useless React fragments and cleans up the existing cases.

- Adds `react/jsx-no-useless-fragment` to the frontend ESLint config.
- Replaces empty fragment renders with `null`.
- Unwraps redundant single-child and text-only fragments in React components.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The `null` replacements are consumed through normal React rendering paths.
- The unwrapped fragments do not change the inspected component contracts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/eslint.config.js | Adds the React rule that rejects useless JSX fragments while keeping expression fragments allowed. |
| frontend/src/components/charts/cash-flow-chart.tsx | Returns `null` instead of an empty fragment when chart configuration is unavailable. |
| frontend/src/components/dashboard/progress-lists.tsx | Passes `null` for empty progress-card actions instead of empty fragments. |
| frontend/src/components/layout/breadcrumbs.tsx | Removes a redundant fragment around the breadcrumb tree. |
| frontend/src/components/ui/asset-name.tsx | Removes a redundant fragment around the `AssetName` returned by `TechnologyName`. |
| frontend/src/routes-lobby/login.tsx | Unwraps the login button text from a fragment. |
| frontend/src/routes-lobby/signup.tsx | Unwraps the sign-up button text from a fragment. |
| frontend/src/routes/app/dashboard.tsx | Removes a redundant fragment around the construction dashboard section. |

<sub>Reviews (1): Last reviewed commit: ["chore(lint): ban pointless React fragmen..."](https://github.com/felixvonsamson/energetica/commit/1e39571b5b6f44a7fcd5dece89bfc6ea70b7d313) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42178493)</sub>

<!-- /greptile_comment -->