### PR TITLE
fix(deploy): exclude checkpoints/ from rsync so the service can write it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ pyright==1.1.407
 # freshness check (CI) is only reproducible if their versions are fixed.
 pydantic==2.11.5
 fastapi[standard]==0.115.12
-python-socketio[asgi]
+# ASGI/websocket server deps (uvicorn, websockets, wsproto) come from fastapi[standard];
+# python-socketio dropped its 'asgi' extra by 5.16.x, so requesting it only warns.
+python-socketio
 itsdangerous
 pre-commit

--- a/scripts/deploy-instance.sh
+++ b/scripts/deploy-instance.sh
@@ -96,14 +96,18 @@ fi
 
 # --- 3. rsync backend code ------------------------------------------------------
 # Ship the Python backend. Exclude build artifacts, the local venv, the frontend source,
-# and — critically — instance/ (server-side game state) and the app bundle dir (synced
-# separately with --delete below). --delete prunes removed backend files but never touches
-# the excluded paths.
+# and — critically — instance/ and checkpoints/ (server-side game state) and the app bundle
+# dir (synced separately with --delete below). --delete prunes removed backend files but
+# never touches the excluded paths. checkpoints/ MUST be excluded: the service (user
+# `energetica`) writes checkpoints/{new,last}_checkpoint.tar.gz at runtime, but rsync arrives
+# as `deploy` — shipping the dir hands it to deploy:deploy and the service can no longer
+# overwrite it (silent PermissionError on every checkpoint), same reasoning as instance/.
 log_step "Syncing backend code..."
 rsync -az --delete \
     --exclude='.git' \
     --exclude='.venv' \
     --exclude='instance/' \
+    --exclude='checkpoints/' \
     --exclude='frontend' \
     --exclude='node_modules' \
     --exclude='__pycache__' \

--- a/scripts/deploy-lobby.sh
+++ b/scripts/deploy-lobby.sh
@@ -116,6 +116,7 @@ rsync -az --delete \
     --exclude='.git' \
     --exclude='.venv' \
     --exclude='instance/' \
+    --exclude='checkpoints/' \
     --exclude='frontend' \
     --exclude='node_modules' \
     --exclude='__pycache__' \

--- a/scripts/infra/setup-instance.sh
+++ b/scripts/infra/setup-instance.sh
@@ -116,7 +116,13 @@ install -d -o "$DEPLOY_USER" -g energetica -m 2750 "$APP_DIR"
 # Engine working dir: the service writes the pickle/logs here, so it is owned by the
 # service user. Excluded from deploy rsync (game state must survive deploys).
 install -d -o energetica -g energetica -m 2770 "$APP_DIR/instance"
-log_success "$APP_DIR (code, deploy-owned) and $APP_DIR/instance (game state, service-owned)"
+# Checkpoints dir: same deal — create_app() does Path("checkpoints").mkdir(exist_ok=True) and the
+# tick loop writes checkpoints/{new,last}_checkpoint.tar.gz here, but the service user cannot
+# create it under the deploy-owned (non-group-writable) app root. Pre-create it service-owned so
+# the mkdir is a no-op and checkpoints are writable. Excluded from deploy rsync for the same
+# reason as instance/ (runtime state the service owns; a shipped copy would reown it to deploy).
+install -d -o energetica -g energetica -m 2770 "$APP_DIR/checkpoints"
+log_success "$APP_DIR (code, deploy-owned) and $APP_DIR/{instance,checkpoints} (game state, service-owned)"
 
 if [ -x "$APP_DIR/.venv/bin/python" ]; then
     log_success "venv already present at $APP_DIR/.venv"


### PR DESCRIPTION
## Problem

Discovered while investigating a suspected socketio issue on the `energetica-game.org` box (socketio turned out healthy — this was the real bug).

On both production game instances, `checkpoints/last_checkpoint.tar.gz` was frozen at **Jun 30**. The 6-hourly `save_checkpoint()` was failing every cycle with:

```
PermissionError: [Errno 13] Permission denied: 'checkpoints/new_checkpoint.tar.gz'
```

**Root cause:** the deploy rsync excluded `instance/` but **not** `checkpoints/`. A local `checkpoints/` dir shipped on a deploy arrived owned by `deploy` (the rsync user), mode `755`, and `--delete` preserved it. The service runs as `energetica`, so it could no longer write into its own checkpoints dir:

```
instance/     energetica:energetica  drwxrws---   ← service writes fine (excluded from deploy)
checkpoints/  deploy:deploy          drwxr-xr-x   ← service CANNOT write (shipped by deploy)
```

The breakage was silent because `engine.save()` (every 10 min, into the energetica-owned `instance/`) kept working — only the redundant 6-hourly snapshot failed. No game data was lost; the action log and live state stayed intact.

## Fix

- Add `--exclude='checkpoints/'` to `deploy-instance.sh` and `deploy-lobby.sh`, same reasoning as `instance/`: it's gitignored runtime state the service owns and writes, never something a deploy should ship or reown.
- Drop the stale `[asgi]` extra from `python-socketio` (removed in 5.16.x → pip warns every install; the ASGI/websocket deps come from `fastapi[standard]`).

## Production remediation (already applied out of band)

`checkpoints/` on both instances was `chown`ed back to `energetica:energetica` (mode `2770`) to match `instance/`, so the next scheduled checkpoint writes successfully. This PR prevents the next deploy from re-breaking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps runtime checkpoint data out of deploy sync and updates the related setup path.

- Excludes `checkpoints/` from instance and lobby rsync deploys.
- Pre-creates the instance `checkpoints/` directory with service-owned permissions.
- Removes the stale `asgi` extra from `python-socketio`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/deploy-instance.sh | Excludes runtime checkpoint data from the instance deploy sync. |
| scripts/deploy-lobby.sh | Mirrors the checkpoint exclusion in the lobby deploy sync. |
| scripts/infra/setup-instance.sh | Creates the instance checkpoint directory with service-owned permissions. |
| requirements.txt | Removes the stale Socket.IO ASGI extra. |

<sub>Reviews (2): Last reviewed commit: ["fix(setup): pre-create service-owned che..."](https://github.com/felixvonsamson/energetica/commit/56451cc54e7d42e66fdbba44a6a0d4307ad14ba6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42646898)</sub>

<!-- /greptile_comment -->