### PR TITLE
fix(socketio): bind MAIN_EVENT_LOOP to the serving loop (restore real-time updates)

### DIFF
--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -40,7 +40,12 @@ _REPO_ROOT = Path(__file__).parent.parent
 # extraction.
 engine = GameEngine()
 globals.engine = engine
-globals.MAIN_EVENT_LOOP = asyncio.get_event_loop()
+# globals.MAIN_EVENT_LOOP is captured in the lifespan (below), NOT here. This module is imported
+# by uvicorn while loading `main:app`; since uvicorn 0.5x that import happens *before* the serving
+# loop is created, so asyncio.get_event_loop() here returns a throwaway loop that never runs.
+# engine.emit() dispatches every socketio broadcast onto MAIN_EVENT_LOOP via
+# run_coroutine_threadsafe(); if it were this dead loop, no server→client event (ticks, cache
+# invalidations, chat) would ever fire — clients connect fine but receive nothing (#817 fallout).
 
 
 def create_app(
@@ -194,6 +199,13 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+        # Capture the serving loop here — the lifespan runs on it. engine.emit() feeds socketio
+        # broadcasts to this loop from the scheduler thread via run_coroutine_threadsafe(); it must
+        # be the loop the socketio server actually runs on. Capturing at import (uvicorn 0.5x loads
+        # the app before the loop exists) instead queued every emit onto a dead loop, so clients
+        # connected successfully but never received ticks/invalidations/chat.
+        globals.MAIN_EVENT_LOOP = asyncio.get_running_loop()
+
         # initialize the schedulers and add the recurrent functions :
         scheduler = AsyncIOScheduler()
 

--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -47,7 +47,7 @@ from energetica.enums import (
     WindFacilityType,
     WorkerType,
 )
-from energetica.globals import MAIN_EVENT_LOOP, engine
+from energetica.globals import engine
 from energetica.schemas.achievements import AchievementMilestoneOut, AchievementOut, AchievementUnlockOut
 from energetica.schemas.browser_notifications import Subscription
 from energetica.schemas.electricity_markets import AskType, BidType
@@ -370,6 +370,10 @@ class Player(DBModel):
 
     def emit(self, event: str, *args: Any) -> None:
         """Emit a socketio event to the player's clients."""
+        # Late import: MAIN_EVENT_LOOP is the serving loop, bound in the lifespan after this module
+        # is imported. Reading it at call time (not a module-level snapshot) gets the live loop.
+        from energetica.globals import MAIN_EVENT_LOOP
+
         for sid in self.socketio_clients:
             asyncio.run_coroutine_threadsafe(engine.socketio.emit(event, *args, to=sid), MAIN_EVENT_LOOP)
 
@@ -509,6 +513,8 @@ class Player(DBModel):
         2. It emits a socketio "invalidate" event to the player's active web clients.
         3. It sends the notification using webpush to the player's subscribed browser(s).
         """
+        from energetica.globals import MAIN_EVENT_LOOP  # serving loop, bound in the lifespan
+
         payload_dict = payload.model_dump(exclude={"type"})
         Notification(type=payload.type, payload=payload_dict, player=self)
         # Real-time invalidation

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -353,6 +353,12 @@ class GameEngine(object):
         """Emit a socketio event to the player's clients."""
         from energetica.globals import MAIN_EVENT_LOOP
 
+        # No serving loop → nothing to broadcast to. This is the case under tests (create_app is
+        # called without running the lifespan that binds the loop) and momentarily before startup.
+        # Unlike Player.emit, this broadcast fires every tick even with zero clients, so it is the
+        # one path that must tolerate a None loop.
+        if MAIN_EVENT_LOOP is None:
+            return
         asyncio.run_coroutine_threadsafe(self.socketio.emit(event, *args), MAIN_EVENT_LOOP)
 
     def invalidate_queries(self, *query_keys: list[str | int]) -> None:

--- a/energetica/globals.py
+++ b/energetica/globals.py
@@ -10,4 +10,7 @@ if TYPE_CHECKING:
     from energetica.game_engine import GameEngine
 
 engine: GameEngine = None  # type: ignore
-MAIN_EVENT_LOOP: AbstractEventLoop
+# Bound to the serving event loop in the app lifespan (energetica.__init__). None until then, so
+# only read it at call time (emit sites late-import it) — never snapshot it at module import, which
+# would capture this None / a pre-serving loop. See the lifespan comment for the full rationale.
+MAIN_EVENT_LOOP: AbstractEventLoop = None  # type: ignore[assignment]


### PR DESCRIPTION
## Symptom

On production, live Socket.IO updates were dead: the always-on money timer and graphs stopped updating every tick, and only a **page refresh** (which refetches over REST) showed fresh state. The browser console showed a clean `✓ Connected successfully` with **no** errors — the socket connected and authenticated fine, it just never received any `tick`. Broken since the instance/SSO rework era.

## Root cause

`engine.emit()` / `Player.emit()` dispatch Socket.IO broadcasts onto `globals.MAIN_EVENT_LOOP` from the scheduler thread via `run_coroutine_threadsafe()`. `MAIN_EVENT_LOOP` was captured at **module-import time** with `asyncio.get_event_loop()`:

```python
globals.MAIN_EVENT_LOOP = asyncio.get_event_loop()  # at import
```

uvicorn loads `main:app` **before** it creates its serving loop. Under **uvicorn 0.5x** (what prod runs now) `get_event_loop()` at that point returns a throwaway loop that is never run; uvicorn then serves on a *different* uvloop loop. So every emit was queued onto a **dead loop** and never executed. No exception was raised (the discarded `Future` swallows it), so `scheduler_exception_count` stayed 0 and it was invisible in logs and `/healthz`.

Under the older uvicorn 0.34.x (local dev) the app happened to be imported *inside* the running loop, so `get_event_loop()` returned the serving loop and it worked — which is why this only bit production.

## Verification

- A legitimately-authenticated websocket client received **0 events in 40s** against prod while the server ticked every ~30s.
- Isolated repro under uvicorn 0.50.2 with a real Socket.IO client: import-time capture → **0 ticks**; lifespan capture → **ticks delivered**.
- Probe confirmed under 0.50.2: `get_event_loop()` at import ≠ `get_running_loop()` in the lifespan; under 0.34.3 they matched.

## Fix

Capture the loop in the app **lifespan** (which runs on the serving loop) via `asyncio.get_running_loop()`. `MAIN_EVENT_LOOP` is a bound `None` placeholder until then, and every emit site reads it at **call time** (`game_engine.emit` already late-imported it; `Player.emit`/`notify` now do too) so nothing snapshots the pre-serving value at module import.

Version-independent and correct by construction: `get_running_loop()` inside the lifespan is always the loop the Socket.IO server runs on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores Socket.IO broadcasts by binding the main event loop during app startup. The main changes are:

- Bind `MAIN_EVENT_LOOP` inside the FastAPI lifespan.
- Read the loop at emit time instead of import time.
- Skip broad engine broadcasts when no serving loop is available.
- Initialize the global loop placeholder to `None` until startup.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/__init__.py | Moves event loop capture into the FastAPI lifespan before scheduler startup. |
| energetica/database/player.py | Updates player-specific socket emissions to read the current loop at call time. |
| energetica/game_engine.py | Adds a guard so engine-wide broadcasts return when no serving loop is bound. |
| energetica/globals.py | Initializes the shared loop global as unset until the lifespan binds it. |

<sub>Reviews (2): Last reviewed commit: ["fix(socketio): no-op broadcast when the ..."](https://github.com/felixvonsamson/energetica/commit/5700df0e4846bcb9d951e45c491ec7c7436c6751) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42651676)</sub>

<!-- /greptile_comment -->