### PR TITLE
feat(dev): authenticated app work against a live backend

### DIFF
--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -28,7 +28,8 @@ convenience, since it spans both.)
 | I want to…                                   | Command                                          | Backend used            |
 | -------------------------------------------- | ------------------------------------------------ | ----------------------- |
 | Change **lobby** UI against real data        | `cd frontend && BACKEND=game bun run dev:lobby`  | live game lobby         |
-| Change **app** (game) UI against real data   | `cd frontend && BACKEND=game bun run dev:app`    | live game instance      |
+| Change **app** (game) UI against real data (public/pre-login) | `cd frontend && BACKEND=game bun run dev:app` | live game instance |
+| **Authenticated app** work against live data | `BACKEND=game bun run dev`                        | live lobby + instance   |
 | Work on the **landing** site                 | `cd frontend && bun run dev:landing`             | none (static)           |
 | Full **local app** dev (frontend + backend)  | `bun run dev`                                    | local lobby + app       |
 | Just the **lobby**, locally                  | `bun run dev:lobby`                              | local lobby             |
@@ -56,13 +57,41 @@ in for real: its login POST is proxied, and the response's `Set-Cookie` is rewri
 `Secure`/`Domain` (`rewriteSetCookieForLocalhost`), so the session cookie sticks to
 `http://localhost:5174`. Work on lobby UI against live data with your real credentials.
 
-The **app** dev server against a live backend **cannot** authenticate a `localhost` session. The
-app's "log in" bounce leads to the deployment's real lobby, which sets its cookie on `.{apex}` (never
-reachable from `localhost`) and, after login, redirects to the real instance host — not your dev
-server. So `BACKEND=game bun run dev:app` is for the **public / pre-login** surface; for authenticated
-app work run the **full local stack** below (where every `localhost` port shares one cookie jar, so
-login carries across). The app's dev login bounce therefore always points at the *local* lobby,
-regardless of which backend `/api` proxies to.
+The **app** dev server run *alone* against a live backend can't authenticate: its "log in" bounce
+points at the local lobby dev server (:5174), and if nothing is running there the link dead-ends. So
+`BACKEND=game bun run dev:app` on its own is for the **public / pre-login** surface. For authenticated
+app work against live data, run both frontends as one stack (next).
+
+## Authenticated app work against a live backend
+
+```bash
+BACKEND=game bun run dev    # app :5173 + lobby :5174, both proxying to the live game deployment
+```
+
+One launcher, both frontends, same `BACKEND` — no local backends. The flow:
+
+1. Open **http://localhost:5173**, unauthenticated → click "log in" → bounce to the lobby dev server
+   at **http://localhost:5174**.
+2. The lobby dev server proxies your login to the **live** `lobby.{apex}` and logs you in with your
+   real credentials. The live cookie comes back `Domain=.{apex}; Secure`, but the proxy strips both
+   attributes (`rewriteSetCookieForLocalhost`), leaving a **host-only `localhost` cookie**.
+3. Because cookies aren't isolated by port, that one cookie is sent to **:5173** too. Its `/api`
+   proxies to the live instance, whose entry gate validates the token against the deployment's
+   server-wide secret — so you're authenticated as your real account, against live data.
+
+Why both frontends and one launcher: they must share `BACKEND`, or the lobby mints a cookie signed
+by a *different* backend than the app talks to, and the live instance rejects it with a bare 401.
+Running them separately invites that mismatch; the launcher forecloses it.
+
+Two things to know:
+
+- **You operate as your real account on live data** — the entry gate provisions you on the live
+  instance and your writes hit it, exactly as logging into prod does. This is intended, not a
+  sandbox.
+- **One instance only.** The app dev server proxies to a single live instance (the newest
+  advertised, or `VITE_BACKEND_URL` if pinned). The in-run switcher marks that instance and disables
+  hops to your other runs — those are prod origins, not this local dev app. Pin `VITE_BACKEND_URL`
+  to target a specific instance.
 
 ## Full local stack (backend work)
 

--- a/frontend/src/components/layout/run-switcher.tsx
+++ b/frontend/src/components/layout/run-switcher.tsx
@@ -6,6 +6,11 @@
  * picker shows. Each run is a cross-origin `<a href>` to `{slug}.{apex}/app`;
  * the current run is marked and non-navigating. "Open lobby" always appears — a
  * just-provisioned player with no settled run yet still needs a way out.
+ *
+ * In a live-backend dev server (`BACKEND=game bun run dev`) the `/api` proxy is
+ * pinned to one live instance, so the other runs' links would leave the local
+ * dev app for prod — they are disabled, and the pinned instance is marked
+ * current (via {@link devInstanceSlug}).
  */
 
 import { ArrowLeftRight, Check } from "lucide-react";
@@ -20,11 +25,21 @@ import {
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useMyRuns } from "@/hooks/use-my-runs";
-import { currentRunSlug, lobbyHref, runAppHref } from "@/lib/instances";
+import {
+    currentRunSlug,
+    devInstanceSlug,
+    lobbyHref,
+    runAppHref,
+} from "@/lib/instances";
 
 export function RunSwitcher() {
     const { data: runs } = useMyRuns();
-    const here = currentRunSlug();
+    // In a live-backend dev server the hostname is `localhost`, so there is no run in the URL —
+    // fall back to the injected slug the proxy is pinned to. When that is set, hopping to any other
+    // run would leave the local dev app for a prod origin, so those entries are disabled.
+    const pinnedSlug = devInstanceSlug();
+    const here = currentRunSlug() ?? pinnedSlug;
+    const pinnedToLocalDev = pinnedSlug !== null;
 
     return (
         <DropdownMenu>
@@ -51,6 +66,18 @@ export function RunSwitcher() {
                                             {run.name}
                                         </span>
                                         <Check size={16} />
+                                    </DropdownMenuItem>
+                                );
+                            }
+                            if (pinnedToLocalDev) {
+                                return (
+                                    <DropdownMenuItem
+                                        key={run.slug}
+                                        disabled
+                                        className="truncate"
+                                        title="Switching runs is disabled in local dev — this app dev server is pinned to one live instance."
+                                    >
+                                        {run.name}
                                     </DropdownMenuItem>
                                 );
                             }

--- a/frontend/src/lib/instances.ts
+++ b/frontend/src/lib/instances.ts
@@ -135,6 +135,23 @@ export function lobbyHref(path: string): string {
 }
 
 /**
+ * The single live instance the app dev server is pinned to (its `/api` proxy
+ * target), injected at dev-server startup — see `instanceSlugFromBackend` in
+ * `vite.shared.ts`. `null` outside a live-backend dev server (a prod build, or
+ * a local backend with no apex).
+ *
+ * Deliberately separate from {@link currentRunSlug}: the switcher uses this to
+ * identify the pinned run, but the login bounce must NOT treat it as "the run
+ * I'm in" (that would send a `?return=` and auto-bounce back after login) — in
+ * a `localhost` dev app there is no run to return to.
+ */
+export function devInstanceSlug(): string | null {
+    return import.meta.env.DEV
+        ? (import.meta.env.VITE_DEV_INSTANCE_SLUG ?? null)
+        : null;
+}
+
+/**
  * This run's own slug, parsed from the hostname (`{slug}.{apex}`). `null` in
  * dev / the interim, or when the host is not a single valid label under the
  * apex.

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -16,6 +16,13 @@ interface ImportMetaEnv {
      * `lib/lobby.ts`.
      */
     readonly VITE_APP_URL?: string;
+    /**
+     * The single live instance slug the app dev server is pinned to, injected
+     * at dev-server startup (never in a prod build). Lets the in-run switcher
+     * mark that instance and disable hops to the account's other (prod) runs.
+     * See `lib/instances.ts` and `vite.config.ts`.
+     */
+    readonly VITE_DEV_INSTANCE_SLUG?: string | null;
 }
 
 interface ImportMeta {

--- a/frontend/vite.config.landing.ts
+++ b/frontend/vite.config.landing.ts
@@ -14,7 +14,9 @@ import { DEV_PORTS } from "./vite.shared";
 
 export default defineConfig(() => {
     return {
-        server: { port: DEV_PORTS.landing },
+        // Pin the port (see the lobby/app configs): the fixed-port contract in
+        // vite.shared.ts assumes every surface lives at a known localhost origin.
+        server: { port: DEV_PORTS.landing, strictPort: true },
         plugins: [
             // Please make sure that '@tanstack/router-plugin' is passed before '@vitejs/plugin-react'
             tanstackRouter({

--- a/frontend/vite.config.lobby.ts
+++ b/frontend/vite.config.lobby.ts
@@ -73,6 +73,11 @@ export default defineConfig(({ mode }) => {
         },
         server: {
             port: DEV_PORTS.lobby,
+            // Fail loudly on a busy port instead of drifting to the next free one:
+            // the app bundle's login/logout bounce hard-codes this port (LOBBY_DEV_URL
+            // in src/lib/instances.ts), so a silent drift would send auth to a dead
+            // origin. See DEV_PORTS in vite.shared.ts.
+            strictPort: true,
             proxy: {
                 // Lobby API (auth + my-runs). /instances.json is deliberately
                 // not proxied: in production Apache aliases it from the shared

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -159,6 +159,9 @@ export default defineConfig(async ({ mode, command }) => {
         base: command === "serve" ? "/" : "/static/app/",
         server: {
             port: DEV_PORTS.app,
+            // Pin the port (see the lobby config): the fixed-port contract in
+            // vite.shared.ts assumes every surface lives at a known localhost origin.
+            strictPort: true,
             proxy: {
                 // API endpoints
                 "^/api": {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -109,7 +109,6 @@ export default defineConfig(async ({ mode, command }) => {
     // Backend the dev server proxies to: explicit override, else slug discovered from the
     // selected deployment's apex manifest (BACKEND=…), else local :8000. See resolveBackendUrl.
     const backendUrl = await resolveBackendUrl(command, env);
-    const wsUrl = backendUrl.replace(/^http/, "ws");
     // Dev only: which single live instance this app dev server is pinned to, so the in-run
     // switcher can mark it and disable hops to the account's *other* runs (those are prod origins,
     // not this local dev app). null for a local backend or a prod build.
@@ -172,9 +171,14 @@ export default defineConfig(async ({ mode, command }) => {
                     target: backendUrl,
                     changeOrigin: true,
                 },
-                // WebSocket connection
+                // Socket.IO (real-time ticks/invalidations). Targets the HTTP(S)
+                // origin, not a ws:// URL: Socket.IO opens with an HTTP polling
+                // handshake, and http-proxy only drives TLS for an https/http
+                // target on that path — a wss:// target hits the live host on
+                // port 80, gets Apache's 301 → https, and the handshake never
+                // completes. `ws: true` upgrades to wss over the same origin.
                 "^/socket.io": {
-                    target: wsUrl,
+                    target: backendUrl,
                     changeOrigin: true,
                     ws: true,
                 },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,7 @@ import path from "path";
 import {
     DEV_PORTS,
     explicitBackendUrl,
+    instanceSlugFromBackend,
     loadDeploymentEnv,
     rewriteSetCookieForLocalhost,
 } from "./vite.shared";
@@ -109,6 +110,13 @@ export default defineConfig(async ({ mode, command }) => {
     // selected deployment's apex manifest (BACKEND=…), else local :8000. See resolveBackendUrl.
     const backendUrl = await resolveBackendUrl(command, env);
     const wsUrl = backendUrl.replace(/^http/, "ws");
+    // Dev only: which single live instance this app dev server is pinned to, so the in-run
+    // switcher can mark it and disable hops to the account's *other* runs (those are prod origins,
+    // not this local dev app). null for a local backend or a prod build.
+    const devInstanceSlug =
+        command === "serve"
+            ? instanceSlugFromBackend(backendUrl, env.VITE_APEX_DOMAIN)
+            : null;
 
     return {
         plugins: [
@@ -144,6 +152,10 @@ export default defineConfig(async ({ mode, command }) => {
         ],
         resolve: {
             alias: { "@": path.resolve(__dirname, "./src") },
+        },
+        define: {
+            "import.meta.env.VITE_DEV_INSTANCE_SLUG":
+                JSON.stringify(devInstanceSlug),
         },
         base: command === "serve" ? "/" : "/static/app/",
         server: {

--- a/frontend/vite.shared.test.ts
+++ b/frontend/vite.shared.test.ts
@@ -82,7 +82,7 @@ describe("instanceSlugFromBackend", () => {
         ["nested subdomain", `https://a.b.${APEX}`, APEX, null],
         ["an IP address", "http://10.0.0.5", APEX, null],
         ["unparseable URL", "not a url", APEX, null],
-    ])("%s → %s", (_label, url, apex, expected) => {
+    ])("%s", (_label, url, apex, expected) => {
         expect(instanceSlugFromBackend(url, apex)).toBe(expected);
     });
 });

--- a/frontend/vite.shared.test.ts
+++ b/frontend/vite.shared.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { explicitBackendUrl, resolveLobbyProxyTarget } from "./vite.shared";
+import {
+    explicitBackendUrl,
+    instanceSlugFromBackend,
+    resolveLobbyProxyTarget,
+} from "./vite.shared";
 
 const APEX = "energetica-game.org";
 const INSTANCE = "https://mar-27-2026.energetica-game.org";
@@ -57,5 +61,28 @@ describe("resolveLobbyProxyTarget", () => {
         expect(resolveLobbyProxyTarget(env as Record<string, string>)).toBe(
             expected,
         );
+    });
+});
+
+describe("instanceSlugFromBackend", () => {
+    it.each([
+        ["a live instance subdomain", INSTANCE, APEX, "mar-27-2026"],
+        ["single-label slug", `https://prod.${APEX}`, APEX, "prod"],
+        // Not an instance under the apex → no pinned slug.
+        ["local backend", "http://localhost:8000", APEX, null],
+        ["no apex configured", INSTANCE, undefined, null],
+        [
+            "the bare apex (landing, not an instance)",
+            `https://${APEX}`,
+            APEX,
+            null,
+        ],
+        ["a different apex", "https://x.example.com", APEX, null],
+        // A nested/deep subdomain isn't a single valid run label.
+        ["nested subdomain", `https://a.b.${APEX}`, APEX, null],
+        ["an IP address", "http://10.0.0.5", APEX, null],
+        ["unparseable URL", "not a url", APEX, null],
+    ])("%s → %s", (_label, url, apex, expected) => {
+        expect(instanceSlugFromBackend(url, apex)).toBe(expected);
     });
 });

--- a/frontend/vite.shared.ts
+++ b/frontend/vite.shared.ts
@@ -85,6 +85,37 @@ export function resolveLobbyProxyTarget(env: Record<string, string>): string {
 }
 
 /**
+ * The instance slug of a resolved backend URL (`https://{slug}.{apex}` →
+ * `{slug}`), or `null` when the backend isn't a real instance subdomain under
+ * `apex` (a local backend, an IP, a pinned non-deployment host, or no apex).
+ *
+ * Injected into the app bundle at dev-server startup (see `vite.config.ts`) so
+ * the in-run switcher knows which single live instance this dev server is
+ * pinned to — everything else it would link to is a _prod_ origin, not the
+ * local dev app. Build-time only: it reads the config's already-resolved
+ * backend, not a request, so it is not the runtime login derivation retired in
+ * PR #848.
+ */
+export function instanceSlugFromBackend(
+    backendUrl: string,
+    apex: string | undefined,
+): string | null {
+    if (!apex) return null;
+    let hostname: string;
+    try {
+        ({ hostname } = new URL(backendUrl));
+    } catch {
+        return null;
+    }
+    const suffix = `.${apex}`;
+    if (!hostname.endsWith(suffix)) return null;
+    const label = hostname.slice(0, -suffix.length);
+    // Same DNS-label shape the infra enforces (RUN_SLUG_PATTERN in lib/lobby.ts):
+    // a single lowercase kebab-case label, so `{sub}.{deep}.{apex}` is rejected.
+    return /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label) ? label : null;
+}
+
+/**
  * Strip `Secure` and `Domain` from `Set-Cookie` on proxied responses so a
  * session cookie minted by an HTTPS backend round-trips through the
  * `http://localhost` dev origin. Without this, the browser won't persist the

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -42,8 +42,34 @@ start() {
     pids+=("$!")
 }
 
-# Seed the shared accounts store + sample runs once, before any server starts (avoids two
-# backends racing on the same sqlite file). The lobby owns accounts.
+# With BACKEND set, both frontends proxy to a live deployment — no local backends, no shared
+# scratch, no seeding. Running BOTH frontends from one launcher is the point: they inherit the
+# same BACKEND, so the live-signed cookie the lobby dev server mints (Domain/Secure stripped to a
+# host-only localhost cookie, shared across ports) is honoured by the live instance the app dev
+# server proxies to. Splitting them by hand risks a BACKEND mismatch → a locally-signed cookie the
+# live instance rejects with a bare 401. See docs/getting-started/local-development.md.
+if [ -n "${BACKEND:-}" ]; then
+    case "$TARGET" in
+    app)
+        echo "[dev] live app stack (BACKEND=$BACKEND) → app http://localhost:5173  ·  lobby http://localhost:5174  (log in on the lobby)"
+        start bash -c 'cd frontend && exec bun run dev:lobby'
+        start bash -c 'cd frontend && exec bun run dev:app'
+        ;;
+    lobby)
+        echo "[dev] live lobby stack (BACKEND=$BACKEND) → lobby http://localhost:5174"
+        start bash -c 'cd frontend && exec bun run dev:lobby'
+        ;;
+    *)
+        echo "usage: [BACKEND=game] bash scripts/dev.sh [app|lobby]" >&2
+        exit 1
+        ;;
+    esac
+    wait
+    exit 0
+fi
+
+# Local stack: seed the shared accounts store + sample runs once, before any server starts (avoids
+# two backends racing on the same sqlite file). The lobby owns accounts.
 seed_dev_data
 
 case "$TARGET" in

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -24,7 +24,7 @@ source scripts/lib/dev-env.sh
 pids=()
 
 cleanup() {
-    trap - INT TERM EXIT # disarm so this runs once
+    trap - INT TERM HUP EXIT # disarm so this runs once
     echo
     echo "[dev] shutting down…"
     local pid
@@ -35,7 +35,11 @@ cleanup() {
         kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
     done
 }
-trap cleanup INT TERM EXIT
+# HUP is included so closing the terminal (tab/window/SSH pane) still tears the tree down —
+# without it the shell dies on SIGHUP before cleanup runs, and the vite/uvicorn children get
+# reparented to init and orphaned, squatting on the fixed dev ports (strictPort then refuses to
+# reboot the stack until they're killed by hand).
+trap cleanup INT TERM HUP EXIT
 
 start() {
     "$@" &


### PR DESCRIPTION
Follow-up to #848. That PR collapsed the login-URL derivation but left one gap: `BACKEND=game bun run dev:app` can *reach* live data yet can't *authenticate* — its login bounce points at the local lobby dev server, which nothing was running alongside it.

## The insight

The mechanism to authenticate a `localhost` app session against a live backend was already present; it just needed to be launched as **one stack**. Confirmed against the backend (no CORS/CSRF/Origin/TrustedHost gate on lobby login; cookie is `Domain=.{apex}; Secure; SameSite=lax`; entry gate validates against the server-wide shared secret):

1. `BACKEND=game bun run dev` starts **both** frontends — app :5173 + lobby :5174 — proxying to the live deployment, no local backends.
2. Login on the lobby dev server proxies to the live `lobby.{apex}`. The response cookie comes back `Domain=.{apex}; Secure`, but `rewriteSetCookieForLocalhost` strips both → a **host-only `localhost` cookie**.
3. Cookies aren't isolated by port, so `:5173` sends that same live-signed cookie; its `/api` proxies to the live instance, whose entry gate validates it → authenticated as your real account, against live data.

One launcher enforces a shared `BACKEND`, so the lobby can't mint a cookie signed by a different backend than the app talks to (which the live instance would reject with a bare 401).

## Changes

- **`scripts/dev.sh`**: when `BACKEND` is set, run the two frontends only — no local backends, no scratch seeding.
- **Single-instance pinning** (inherent: the app dev server proxies exactly one instance): inject that instance's slug into the app bundle at dev-server startup (`instanceSlugFromBackend` + a Vite `define`). The in-run switcher marks the pinned instance and **disables hops to the account's other runs** — those resolve to prod origins, not the local dev app. Kept in a dedicated `devInstanceSlug()`, separate from `currentRunSlug()`, so it does **not** trigger the `?return` auto-bounce.
- **Tests**: `instanceSlugFromBackend` host matrix (9 cases). Docs: the flow + its two caveats (you operate on live data as your real account; one instance only).

## Verification

`bun run test` (45 pass), `typecheck`, `lint`, `format` all clean; app + lobby prod builds succeed (define → `null` in prod); dev-server boot confirmed to inject the pinned slug into the served bundle; `dev.sh` syntax-checked. The **live login round-trip** itself needs a real deployment + credentials — that's the maintainer's end-to-end test.

## Deliberately deferred

The app can't pass its slug as `?return` (the browser bundle never learns the proxied slug in a way tied to a run you're "in"), so after login you land on the picker and click your run rather than auto-bouncing. Left unwired pending a feel for whether it's worth the injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables fully authenticated app development against a live backend by launching both the app (`:5173`) and lobby (`:5174`) dev servers together under one `BACKEND=game bun run dev` command, exploiting the fact that cookies are not isolated by port on `localhost`. A build-time slug injection (`instanceSlugFromBackend` → `VITE_DEV_INSTANCE_SLUG`) lets the in-run switcher identify and mark the single proxied instance while disabling cross-origin hops to other prod runs.

- **`scripts/dev.sh`**: adds a `BACKEND`-gated branch that starts only the two frontends (no local backends, no seeding); adds `SIGHUP` to the cleanup trap so closing a terminal tears down child processes rather than orphaning them on the now-fixed ports.
- **`vite.config.ts`**: injects the resolved instance slug via `define` (gated to `command === \"serve\"`); fixes the Socket.IO proxy target from a `ws://` URL to the HTTP(S) origin so the polling handshake completes over TLS; adds `strictPort: true` to the app server.
- **`run-switcher.tsx` / `instances.ts`**: introduces `devInstanceSlug()`, deliberately separate from `currentRunSlug()` to prevent the `?return=` auto-bounce, and uses it to mark the pinned instance and disable switching to other prod-origin runs in dev.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are confined to the dev toolchain and have no effect on production builds or the backend.

The slug injection is gated on `command === 'serve'` (null in production builds) and the runtime `devInstanceSlug()` function short-circuits on `import.meta.env.DEV`, so dead-code elimination removes it entirely from prod bundles. The `endsWith`+regex combination in `instanceSlugFromBackend` correctly rejects multi-label subdomains, wrong-apex hosts, IPs, and unparseable URLs, as verified by the 9-case test matrix. The SIGHUP trap addition and Socket.IO proxy fix are both straightforward correctness improvements. No production code paths are changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/dev.sh | Adds SIGHUP to the cleanup trap to prevent orphaned processes when the terminal closes; adds a BACKEND-gated branch that launches both frontends together against a live deployment with no local backends or seeding. |
| frontend/vite.config.ts | Injects the computed live-instance slug into the app bundle via `define`; fixes the Socket.IO proxy target from a `ws://` URL to the HTTP(S) origin so TLS upgrades complete correctly; adds `strictPort: true`. |
| frontend/vite.shared.ts | Adds `instanceSlugFromBackend` that extracts and validates a single-label DNS slug from a backend URL against the configured apex domain; correctly rejects multi-label subdomains, IPs, and mismatched apexes via both `endsWith` and the slug regex. |
| frontend/src/lib/instances.ts | Adds `devInstanceSlug()` — intentionally separate from `currentRunSlug()` to avoid triggering the `?return=` auto-bounce on login — reading the build-time injected `VITE_DEV_INSTANCE_SLUG`, gated on `import.meta.env.DEV` so it is dead-code eliminated in production. |
| frontend/src/components/layout/run-switcher.tsx | Uses `devInstanceSlug()` as a fallback for `currentRunSlug()` to identify the pinned instance; disables all non-current run entries when the dev server is pinned to a live backend, preventing navigations to prod origins. |
| frontend/vite.shared.test.ts | Adds 9 test cases for `instanceSlugFromBackend` covering the happy path, single-char slug, local backend, missing apex, bare apex, wrong apex, nested subdomain, IP address, and unparseable URL. |
| frontend/src/vite-env.d.ts | Declares `VITE_DEV_INSTANCE_SLUG` as optional `string | null`; typed as nullable since Vite's `define` injects `null` for non-live-backend dev servers and prod builds. |
| frontend/vite.config.lobby.ts | Adds `strictPort: true` to prevent silent port drift that would send auth requests to a dead origin since the app bundle hard-codes port 5174 for the login bounce. |
| frontend/vite.config.landing.ts | Adds `strictPort: true` for consistency with the fixed-port contract in `vite.shared.ts`. |
| docs/getting-started/local-development.md | Documents the new authenticated stack, corrects the prior claim that localhost app auth is impossible, and explains the two key caveats (live data, single-instance pin). |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer browser
    participant App as App dev server :5173
    participant Lobby as Lobby dev server :5174
    participant LiveLobby as live lobby apex
    participant LiveApp as live slug apex

    Note over App,Lobby: BACKEND=game bun run dev - one launcher, shared BACKEND

    Dev->>App: GET /app/
    App-->>Dev: app bundle with VITE_DEV_INSTANCE_SLUG injected

    Dev->>Lobby: GET /login (lobbyHref bounce)
    Lobby-->>Dev: lobby login page

    Dev->>Lobby: POST /api/login
    Lobby->>LiveLobby: proxy POST /api/login
    LiveLobby-->>Lobby: 200 + Set-Cookie with Domain and Secure
    Note over Lobby: rewriteSetCookieForLocalhost strips Domain and Secure
    Lobby-->>Dev: 200 + host-only localhost session cookie

    Note over Dev: cookies not port-isolated - port 5173 sends same cookie
    Dev->>App: GET /api/me with session cookie
    App->>LiveApp: proxy GET /api/me
    LiveApp-->>App: 200 authenticated via server-wide secret
    App-->>Dev: authenticated response

    Note over App: devInstanceSlug marks pinned instance, disables other runs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer browser
    participant App as App dev server :5173
    participant Lobby as Lobby dev server :5174
    participant LiveLobby as live lobby apex
    participant LiveApp as live slug apex

    Note over App,Lobby: BACKEND=game bun run dev - one launcher, shared BACKEND

    Dev->>App: GET /app/
    App-->>Dev: app bundle with VITE_DEV_INSTANCE_SLUG injected

    Dev->>Lobby: GET /login (lobbyHref bounce)
    Lobby-->>Dev: lobby login page

    Dev->>Lobby: POST /api/login
    Lobby->>LiveLobby: proxy POST /api/login
    LiveLobby-->>Lobby: 200 + Set-Cookie with Domain and Secure
    Note over Lobby: rewriteSetCookieForLocalhost strips Domain and Secure
    Lobby-->>Dev: 200 + host-only localhost session cookie

    Note over Dev: cookies not port-isolated - port 5173 sends same cookie
    Dev->>App: GET /api/me with session cookie
    App->>LiveApp: proxy GET /api/me
    LiveApp-->>App: 200 authenticated via server-wide secret
    App-->>Dev: authenticated response

    Note over App: devInstanceSlug marks pinned instance, disables other runs
```

</a>

<sub>Reviews (4): Last reviewed commit: ["fix(dev): pin dev-server ports and reap ..."](https://github.com/felixvonsamson/energetica/commit/a0c8b3ba91f215ee043a757148deb35ecf66da63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42829593)</sub>

<!-- /greptile_comment -->