### PR TITLE
fix(lobby): trigger password-manager update on password change

### DIFF
--- a/energetica/my_runs.py
+++ b/energetica/my_runs.py
@@ -34,10 +34,15 @@ def _parse_settled_at(raw: str) -> datetime | None:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
 
 
-def resolve_my_runs(account_id: int) -> MyRunsResponse:
+def resolve_my_runs(account_id: int, username: str) -> MyRunsResponse:
     """The account's settled runs, joined with each run's on-disk fragment for name / starts_at,
     most recently settled first. Stale memberships (run since deleted → no fragment) are dropped,
     and an account's own *unadvertised* runs are surfaced (their fragment exists on disk).
+
+    ``username`` is echoed back so the change-password form can carry an ``autocomplete="username"``
+    field — password managers only offer to *update* the right stored credential when the change
+    form identifies which account it belongs to. Both callers already hold it, so it is passed in
+    rather than re-read from the store.
     """
     runs: list[MyRun] = []
     for membership in accounts.get_memberships(account_id=account_id):
@@ -54,4 +59,4 @@ def resolve_my_runs(account_id: int) -> MyRunsResponse:
             )
             continue
         runs.append(MyRun(slug=fragment.slug, name=fragment.name, starts_at=fragment.starts_at, settled_at=settled_at))
-    return MyRunsResponse(runs=runs)
+    return MyRunsResponse(username=username, runs=runs)

--- a/energetica/routers/lobby.py
+++ b/energetica/routers/lobby.py
@@ -30,4 +30,4 @@ def get_my_runs(user: Annotated[User | None, Depends(get_user)]) -> MyRunsRespon
     if user is None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, GameExceptionType.NOT_AUTHENTICATED)
 
-    return resolve_my_runs(user.account_id)
+    return resolve_my_runs(user.account_id, user.username)

--- a/energetica/schemas/auth.py
+++ b/energetica/schemas/auth.py
@@ -18,11 +18,6 @@ class SignupRequest(BaseModel):
     password: str = Field(min_length=7)
 
 
-class ChangePasswordRequest(BaseModel):  # TODO(mglst): use PUT or something
-    old_password: str
-    new_password: str = Field(min_length=7)
-
-
 class UserOut(BaseModel):
     """Response model for authenticated user information."""
 

--- a/energetica/schemas/lobby.py
+++ b/energetica/schemas/lobby.py
@@ -17,4 +17,5 @@ class MyRun(BaseModel):
 class MyRunsResponse(BaseModel):
     """The account's settled runs, most recently settled first."""
 
+    username: str = Field(description="The authenticated account's username")
     runs: list[MyRun]

--- a/frontend/src/hooks/use-lobby.ts
+++ b/frontend/src/hooks/use-lobby.ts
@@ -9,11 +9,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { lobbyApi, lobbyAuthApi, type MyRunsResponse } from "@/lib/api/lobby";
 import { ApiClientError } from "@/lib/api-client";
 import { fetchInstances, type InstanceFragment } from "@/lib/instances";
-import type {
-    ChangePasswordRequest,
-    LoginRequest,
-    SignupRequest,
-} from "@/types/auth";
+import type { LoginRequest, SignupRequest } from "@/types/auth";
 
 /**
  * Query keys local to the lobby bundle. Deliberately not part of the game's
@@ -90,18 +86,9 @@ export function useLobbySignup() {
     });
 }
 
-/**
- * Mutation hook for changing the authenticated account's password.
- *
- * No cache work on success: the password change leaves the session (and the
- * my-runs auth probe) untouched — the same cookie stays valid.
- */
-export function useLobbyChangePassword() {
-    return useMutation({
-        mutationFn: (data: ChangePasswordRequest) =>
-            lobbyAuthApi.changePassword(data),
-    });
-}
+// Change-password has no hook: the account page submits it as a native <form> POST
+// (see frontend/src/routes-lobby/account.tsx) so Safari/Apple Passwords detects the
+// credential change (issue #849). It never goes through this fetch/React Query layer.
 
 /** Mutation hook for global logout (clears the parent-domain cookie). */
 export function useLobbyLogout() {

--- a/frontend/src/lib/api/lobby.ts
+++ b/frontend/src/lib/api/lobby.ts
@@ -39,14 +39,10 @@ export const lobbyAuthApi = {
             data,
         ),
 
-    /** Change the authenticated account's password. */
-    changePassword: (
-        data: ApiRequestBody<"/api/v1/auth/change-password", "post">,
-    ) =>
-        apiClient.post<ApiResponse<"/api/v1/auth/change-password", "post">>(
-            "/auth/change-password",
-            data,
-        ),
+    // Change-password is deliberately absent here: the account page posts it as a
+    // native <form> (frontend/src/routes-lobby/account.tsx) rather than via this fetch
+    // client, so Safari/Apple Passwords sees the submit navigation and offers to update
+    // the saved credential (issue #849). There is no JSON change-password endpoint.
 
     /** Global logout — clears the single parent-domain session cookie. */
     logout: () =>

--- a/frontend/src/routes-lobby/account.tsx
+++ b/frontend/src/routes-lobby/account.tsx
@@ -9,10 +9,40 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyBrand } from "@/components/ui/typography";
-import { useLobbyChangePassword, useMyRuns } from "@/hooks/use-lobby";
-import { getUserFriendlyError, isErrorType } from "@/lib/error-utils";
+import { useMyRuns } from "@/hooks/use-lobby";
+
+/**
+ * The change-password form posts _natively_ to this lobby-backend route rather
+ * than through the SPA's fetch client. That native submit navigation is what
+ * makes Safari / Apple Passwords offer to update the saved credential — an
+ * intercepted `fetch` (`preventDefault`) gives WebKit nothing to detect (issue
+ * #849). The backend answers every outcome with a 303 back to `/account?pw=…`,
+ * which we render as a banner.
+ *
+ * Absolute `/api` path: Apache proxies `/api` on the lobby vhost to the lobby
+ * uvicorn.
+ */
+const CHANGE_PASSWORD_ACTION = "/api/v1/auth/change-password-form";
+
+const MIN_PASSWORD_LENGTH = 7;
+
+/** Post-redirect status the backend sets via `?pw=`. */
+type PwStatus = "changed" | "old-incorrect" | "too-short";
+
+function validateAccountSearch(search: Record<string, unknown>): {
+    pw?: PwStatus;
+} {
+    const { pw } = search;
+    return {
+        pw:
+            pw === "changed" || pw === "old-incorrect" || pw === "too-short"
+                ? pw
+                : undefined,
+    };
+}
 
 export const Route = createFileRoute("/account")({
+    validateSearch: validateAccountSearch,
     component: AccountPage,
     staticData: { title: "Account" },
 });
@@ -29,7 +59,9 @@ function AccountPage() {
         }
     }, [isLoggedOut, navigate]);
 
-    if (isPending || isLoggedOut) {
+    // `myRuns == null` collapses both the pending and logged-out cases, and
+    // narrows the type so the form can read `myRuns.username` below.
+    if (isPending || myRuns == null) {
         return (
             <div className="flex justify-center py-24">
                 <Spinner />
@@ -39,66 +71,67 @@ function AccountPage() {
 
     return (
         <div className="flex items-center justify-center px-4 py-12">
-            <ChangePasswordForm />
+            <ChangePasswordForm username={myRuns.username} />
         </div>
     );
 }
 
-function ChangePasswordForm() {
-    const changePassword = useLobbyChangePassword();
+function ChangePasswordForm({ username }: { username: string }) {
+    const navigate = useNavigate();
+    const { pw } = Route.useSearch();
+
+    // Capture the post-redirect status once, then strip `?pw` so a manual refresh
+    // doesn't replay the banner. `replace` is a client-side history swap — it cannot
+    // affect the password-manager prompt, which already fired on the POST→GET nav.
+    const [status] = useState<PwStatus | undefined>(pw);
+    useEffect(() => {
+        if (pw !== undefined) {
+            void navigate({ to: "/account", search: {}, replace: true });
+        }
+    }, [pw, navigate]);
 
     const [oldPassword, setOldPassword] = useState("");
     const [newPassword, setNewPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
-    const [oldPasswordError, setOldPasswordError] = useState<string | null>(
-        null,
-    );
-    const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState(false);
+    const [clientError, setClientError] = useState<string | null>(null);
+    const [submitting, setSubmitting] = useState(false);
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setOldPasswordError(null);
-        setError(null);
-        setSuccess(false);
+    const success = status === "changed";
+    const oldPasswordError =
+        status === "old-incorrect"
+            ? "The current password you entered is incorrect."
+            : null;
+    const generalError =
+        clientError ??
+        (status === "too-short"
+            ? `New password must be at least ${MIN_PASSWORD_LENGTH} characters`
+            : null);
 
-        if (!oldPassword || !newPassword || !confirmPassword) {
-            setError("Please fill in all fields");
-            return;
-        }
-
-        // Mirrors the backend ChangePasswordRequest constraint (new_password ≥ 7).
-        if (newPassword.length < 7) {
-            setError("New password must be at least 7 characters");
-            return;
-        }
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        // Client-side gate for the checks the server can't infer from a single submit.
+        // On failure we preventDefault + show an inline error; on success we do NOT
+        // preventDefault, so the browser performs the native submit the password manager
+        // needs to see. (Empty fields and min-length are enforced by native `required` /
+        // `minLength`, which block the submit before this handler even fires.)
+        setClientError(null);
 
         if (newPassword !== confirmPassword) {
-            setError("New passwords do not match");
+            e.preventDefault();
+            setClientError("New passwords do not match");
             return;
         }
-
         if (newPassword === oldPassword) {
-            setError("New password must differ from your current password");
+            e.preventDefault();
+            setClientError(
+                "New password must differ from your current password",
+            );
             return;
         }
 
-        try {
-            await changePassword.mutateAsync({
-                old_password: oldPassword,
-                new_password: newPassword,
-            });
-            setSuccess(true);
-            setOldPassword("");
-            setNewPassword("");
-            setConfirmPassword("");
-        } catch (err) {
-            if (isErrorType(err, "OLD_PASSWORD_INCORRECT")) {
-                setOldPasswordError(getUserFriendlyError(err));
-            } else {
-                setError(getUserFriendlyError(err));
-            }
-        }
+        // Disable the button for the brief moment before the navigation lands. Only the
+        // button, never the inputs: a disabled input is omitted from the native form
+        // submission, which would drop the very fields we're posting.
+        setSubmitting(true);
     };
 
     return (
@@ -129,13 +162,39 @@ function ChangePasswordForm() {
                         </InfoBanner>
                     )}
 
-                    {error && (
+                    {generalError && (
                         <InfoBanner variant="error" className="mb-6">
-                            {error}
+                            {generalError}
                         </InfoBanner>
                     )}
 
-                    <form onSubmit={handleSubmit} className="space-y-6">
+                    <form
+                        method="POST"
+                        action={CHANGE_PASSWORD_ACTION}
+                        onSubmit={handleSubmit}
+                        className="space-y-6"
+                    >
+                        {/* Read-only username so password managers (Apple
+                            Passwords especially) know *which* saved credential
+                            this current-password → new-password change updates.
+                            Without an autocomplete="username" field they won't
+                            offer to update the stored password. */}
+                        <div>
+                            <Label htmlFor="username" className="mb-2">
+                                Account
+                            </Label>
+                            <Input
+                                type="text"
+                                id="username"
+                                name="username"
+                                value={username}
+                                autoComplete="username"
+                                readOnly
+                                tabIndex={-1}
+                                className="text-muted-foreground"
+                            />
+                        </div>
+
                         <div>
                             <Label htmlFor="oldPassword" className="mb-2">
                                 Current password
@@ -143,11 +202,11 @@ function ChangePasswordForm() {
                             <Input
                                 type="password"
                                 id="oldPassword"
-                                name="oldPassword"
+                                name="old_password"
                                 value={oldPassword}
                                 onChange={(e) => setOldPassword(e.target.value)}
                                 placeholder="Enter current password"
-                                disabled={changePassword.isPending}
+                                required
                                 autoComplete="current-password"
                                 aria-invalid={
                                     oldPasswordError ? true : undefined
@@ -164,17 +223,18 @@ function ChangePasswordForm() {
 
                         <div>
                             <Label htmlFor="newPassword" className="mb-2">
-                                New password (minimum 7 characters)
+                                New password (minimum {MIN_PASSWORD_LENGTH}{" "}
+                                characters)
                             </Label>
                             <Input
                                 type="password"
                                 id="newPassword"
-                                name="newPassword"
+                                name="new_password"
                                 value={newPassword}
                                 onChange={(e) => setNewPassword(e.target.value)}
                                 placeholder="Choose a new password"
-                                disabled={changePassword.isPending}
-                                minLength={7}
+                                required
+                                minLength={MIN_PASSWORD_LENGTH}
                                 autoComplete="new-password"
                             />
                         </div>
@@ -186,27 +246,25 @@ function ChangePasswordForm() {
                             <Input
                                 type="password"
                                 id="confirmPassword"
-                                name="confirmPassword"
+                                name="confirm_password"
                                 value={confirmPassword}
                                 onChange={(e) =>
                                     setConfirmPassword(e.target.value)
                                 }
                                 placeholder="Confirm your new password"
-                                disabled={changePassword.isPending}
+                                required
                                 autoComplete="new-password"
                             />
                         </div>
 
                         <Button
                             type="submit"
-                            variant={
-                                changePassword.isPending ? "outline" : "default"
-                            }
+                            variant={submitting ? "outline" : "default"}
                             size="lg"
-                            disabled={changePassword.isPending}
+                            disabled={submitting}
                             className="w-full flex items-center justify-center gap-2"
                         >
-                            {changePassword.isPending ? (
+                            {submitting ? (
                                 <Spinner />
                             ) : (
                                 <KeyRound className="w-5 h-5" />

--- a/frontend/src/routes-lobby/account.tsx
+++ b/frontend/src/routes-lobby/account.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { KeyRound } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -95,6 +95,11 @@ function ChangePasswordForm({ username }: { username: string }) {
     const [confirmPassword, setConfirmPassword] = useState("");
     const [clientError, setClientError] = useState<string | null>(null);
     const [submitting, setSubmitting] = useState(false);
+    // Synchronous double-submit guard. `submitting` (state) can't do this: it updates on
+    // the next render, so a second submit fired before the disabled button reaches the DOM
+    // would still POST. Two POSTs would change the password on the first, then fail the old
+    // check against the new hash on the second → a spurious `old-incorrect` after success.
+    const submittedRef = useRef(false);
 
     const success = status === "changed";
     const oldPasswordError =
@@ -113,6 +118,14 @@ function ChangePasswordForm({ username }: { username: string }) {
         // preventDefault, so the browser performs the native submit the password manager
         // needs to see. (Empty fields and min-length are enforced by native `required` /
         // `minLength`, which block the submit before this handler even fires.)
+
+        // Swallow any submit after the first accepted one, synchronously — before the browser
+        // starts the navigation a rapid second submit would otherwise ride in on.
+        if (submittedRef.current) {
+            e.preventDefault();
+            return;
+        }
+
         setClientError(null);
 
         if (newPassword !== confirmPassword) {
@@ -128,9 +141,11 @@ function ChangePasswordForm({ username }: { username: string }) {
             return;
         }
 
-        // Disable the button for the brief moment before the navigation lands. Only the
+        // Accepted: latch the guard synchronously so any follow-up submit is dropped above,
+        // and disable the button for the brief moment before the navigation lands. Only the
         // button, never the inputs: a disabled input is omitted from the native form
         // submission, which would drop the very fields we're posting.
+        submittedRef.current = true;
         setSubmitting(true);
     };
 

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -1754,26 +1754,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/auth/change-password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Change Password
-         * @description Change the authenticated account's password in the server-wide store.
-         */
-        post: operations["change_password_api_v1_auth_change_password_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/auth/logout": {
         parameters: {
             query?: never;
@@ -2931,6 +2911,11 @@ export interface components {
          * @description The account's settled runs, most recently settled first.
          */
         MyRunsResponse: {
+            /**
+             * Username
+             * @description The authenticated account's username
+             */
+            username: string;
             /** Runs */
             runs: components["schemas"]["MyRun"][];
         };
@@ -4209,13 +4194,6 @@ export interface components {
             construction: components["schemas"]["WorkerInfo"];
             /** @description Laboratory/research workers */
             laboratory: components["schemas"]["WorkerInfo"];
-        };
-        /** ChangePasswordRequest */
-        ChangePasswordRequest: {
-            /** Old Password */
-            old_password: string;
-            /** New Password */
-            new_password: string;
         };
         /** LoginRequest */
         LoginRequest: {
@@ -6760,37 +6738,6 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                 };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    change_password_api_v1_auth_change_password_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ChangePasswordRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -19,13 +19,3 @@ export type LoginRequest = ApiRequestBody<"/api/v1/auth/login", "post">;
  * Creates a new user account with registration information.
  */
 export type SignupRequest = ApiRequestBody<"/api/v1/auth/signup", "post">;
-
-/**
- * Request body for POST /api/v1/auth/change-password
- *
- * Changes the user's password after verifying the old password.
- */
-export type ChangePasswordRequest = ApiRequestBody<
-    "/api/v1/auth/change-password",
-    "post"
->;

--- a/lobby/routers.py
+++ b/lobby/routers.py
@@ -11,14 +11,14 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from energetica import accounts, server_config
 from energetica.accounts import Account
 from energetica.game_error import GameError, GameExceptionType
 from energetica.my_runs import resolve_my_runs
-from energetica.schemas.auth import ChangePasswordRequest, LoginRequest, SignupRequest
+from energetica.schemas.auth import LoginRequest, SignupRequest
 from energetica.schemas.lobby import MyRunsResponse
 from energetica.utils.session import check_password_hash, generate_password_hash
 from lobby.deps import require_current_account
@@ -26,6 +26,10 @@ from lobby.session import clear_lobby_session_cookie, set_lobby_session_cookie
 
 auth_router = APIRouter(prefix="/auth", tags=["Authentication"])
 lobby_router = APIRouter(prefix="/lobby", tags=["Lobby"])
+
+# Mirrors SignupRequest.password's floor — kept in sync by hand since the form endpoint below
+# validates raw Form fields, not the pydantic model.
+MIN_PASSWORD_LENGTH = 7
 
 
 @auth_router.post("/login", status_code=status.HTTP_200_OK)
@@ -61,16 +65,32 @@ def signup(request: Request, request_data: SignupRequest) -> Response:
     return set_lobby_session_cookie(response, account_id, request)
 
 
-@auth_router.post("/change-password", status_code=status.HTTP_204_NO_CONTENT)
-def change_password(
-    request_data: ChangePasswordRequest,
+@auth_router.post("/change-password-form", include_in_schema=False)
+def change_password_form(
     account: Annotated[Account, Depends(require_current_account)],
+    old_password: Annotated[str, Form()],
+    new_password: Annotated[str, Form()],
 ) -> Response:
-    """Change the authenticated account's password in the server-wide store."""
-    if not check_password_hash(plain_password=request_data.old_password, hashed_password=account.pwhash):
-        raise GameError(GameExceptionType.OLD_PASSWORD_INCORRECT)
-    accounts.update_password(username=account.username, new_pwhash=generate_password_hash(request_data.new_password))
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    """Change the authenticated account's password via a **native form submission** (Post/Redirect/Get).
+
+    Submitted as a real ``<form method=POST>`` — deliberately not the JSON fetch the rest of the SPA
+    uses — because that is what makes Safari / Apple Passwords offer to *update* the saved credential:
+    WebKit hooks the form-submit navigation and the submitted current-/new-password fields, whereas an
+    intercepted ``fetch`` (``preventDefault``) gives it nothing to detect. So every outcome here is a
+    303 redirect back into the lobby SPA (``/account?pw=…``) — never a JSON body a native submit would
+    render as raw text — and the account page turns ``?pw`` into a banner. ``include_in_schema=False``
+    keeps this redirect route out of the generated typed client (the frontend posts it natively).
+
+    Password-manager detection needs the *navigation*, so client-side validation (match, min length)
+    runs first and only the server-only check — is the old password correct — can reach here in the
+    normal flow; ``too-short`` is a defensive fallback for a submit that bypassed the client.
+    """
+    if not check_password_hash(plain_password=old_password, hashed_password=account.pwhash):
+        return RedirectResponse("/account?pw=old-incorrect", status_code=status.HTTP_303_SEE_OTHER)
+    if len(new_password) < MIN_PASSWORD_LENGTH:
+        return RedirectResponse("/account?pw=too-short", status_code=status.HTTP_303_SEE_OTHER)
+    accounts.update_password(username=account.username, new_pwhash=generate_password_hash(new_password))
+    return RedirectResponse("/account?pw=changed", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @auth_router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
@@ -82,4 +102,4 @@ def logout(account: Annotated[Account, Depends(require_current_account)]) -> Res
 @lobby_router.get("/my-runs")
 def get_my_runs(account: Annotated[Account, Depends(require_current_account)]) -> MyRunsResponse:
     """The authenticated account's settled runs (same read the instance serves in-run)."""
-    return resolve_my_runs(account.account_id)
+    return resolve_my_runs(account.account_id, account.username)

--- a/tests/integration/test_lobby_app.py
+++ b/tests/integration/test_lobby_app.py
@@ -14,7 +14,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from energetica import accounts
-from energetica.schemas.auth import ChangePasswordRequest, LoginRequest, SignupRequest
+from energetica.schemas.auth import LoginRequest, SignupRequest
 from energetica.utils.session import SESSION_COOKIE_NAME, decode_session_token
 from lobby import create_lobby_app
 
@@ -143,31 +143,53 @@ def test_my_runs_returns_authed_accounts_runs(signups_enabled: None, landing_dir
     resp = client.get(f"{BASE}/lobby/my-runs")
 
     assert resp.status_code == 200
+    assert resp.json()["username"] == "alice"
     assert [run["slug"] for run in resp.json()["runs"]] == ["spring-2026"]
 
 
 # --- change password + logout ---------------------------------------------------------------
 
 
-def test_change_password_wrong_old_rejected(signups_enabled: None) -> None:
+# Change-password is a native <form> POST (form-encoded, not JSON) that Post/Redirect/Gets
+# back into the SPA so Safari/Apple Passwords sees the submit navigation (issue #849). Assert
+# the 303 + its `?pw=` destination (follow_redirects=False — the redirect target is the SPA
+# shell, not served by this app), never a JSON body a native submit would render as raw text.
+
+
+def test_change_password_wrong_old_redirects_with_error(signups_enabled: None) -> None:
     client = _client()
     _signup(client)
     resp = client.post(
-        f"{BASE}/auth/change-password",
-        json=ChangePasswordRequest(old_password="wrong", new_password="brand-new-password").model_dump(),
+        f"{BASE}/auth/change-password-form",
+        data={"old_password": "wrong", "new_password": "brand-new-password"},
+        follow_redirects=False,
     )
-    assert resp.status_code == 400
-    assert resp.json()["game_exception_type"] == "OLD_PASSWORD_INCORRECT"
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/account?pw=old-incorrect"
+
+
+def test_change_password_too_short_redirects_with_error(signups_enabled: None) -> None:
+    client = _client()
+    _signup(client)
+    resp = client.post(
+        f"{BASE}/auth/change-password-form",
+        data={"old_password": "correct-password", "new_password": "short"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/account?pw=too-short"
 
 
 def test_change_password_then_login_with_new(signups_enabled: None) -> None:
     client = _client()
     _signup(client)
     resp = client.post(
-        f"{BASE}/auth/change-password",
-        json=ChangePasswordRequest(old_password="correct-password", new_password="brand-new-password").model_dump(),
+        f"{BASE}/auth/change-password-form",
+        data={"old_password": "correct-password", "new_password": "brand-new-password"},
+        follow_redirects=False,
     )
-    assert resp.status_code == 204
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/account?pw=changed"
 
     client.cookies.clear()
     old = client.post(

--- a/tests/integration/test_my_runs_route.py
+++ b/tests/integration/test_my_runs_route.py
@@ -71,6 +71,9 @@ def test_my_runs_returns_only_the_authed_accounts_runs_joined_with_fragments(lan
     response = client.get(MY_RUNS_URL)
 
     assert response.status_code == 200
+    # The instance echoes the provisioned User's username (== the account's) for the
+    # change-password form's autocomplete="username" field.
+    assert response.json()["username"] == "alice"
     runs = response.json()["runs"]
     # Most-recently-settled first.
     assert [r["slug"] for r in runs] == ["autumn-2026", "spring-2026"]

--- a/tests/unit/test_my_runs.py
+++ b/tests/unit/test_my_runs.py
@@ -44,11 +44,13 @@ def test_joins_memberships_with_fragments_most_recent_first(stores: Path) -> Non
     accounts.record_membership(account_id=account_id, slug="spring-2026", settled_at="2026-03-02T00:00:00+00:00")
     accounts.record_membership(account_id=account_id, slug="autumn-2026", settled_at="2026-09-02T00:00:00+00:00")
 
-    response = resolve_my_runs(account_id)
+    response = resolve_my_runs(account_id, "alice")
 
     # ORDER BY settled_at DESC → autumn (settled later) first.
     assert [run.slug for run in response.runs] == ["autumn-2026", "spring-2026"]
     assert response.runs[0].name == "Autumn 2026"
+    # Echoed back for the change-password form's autocomplete="username" field.
+    assert response.username == "alice"
 
 
 def test_surfaces_unadvertised_runs(stores: Path) -> None:
@@ -59,7 +61,7 @@ def test_surfaces_unadvertised_runs(stores: Path) -> None:
     _fragment(stores, slug="secret-run", name="Secret", starts_at="2026-01-01T00:00:00Z", advertised=False)
     accounts.record_membership(account_id=account_id, slug="secret-run", settled_at="2026-01-02T00:00:00+00:00")
 
-    assert [run.slug for run in resolve_my_runs(account_id).runs] == ["secret-run"]
+    assert [run.slug for run in resolve_my_runs(account_id, "alice").runs] == ["secret-run"]
 
 
 def test_filters_stale_membership_without_fragment(stores: Path) -> None:
@@ -69,12 +71,12 @@ def test_filters_stale_membership_without_fragment(stores: Path) -> None:
     # Run since deleted: membership row remains but its fragment is gone.
     accounts.record_membership(account_id=account_id, slug="deleted-run", settled_at="2026-04-02T00:00:00+00:00")
 
-    assert [run.slug for run in resolve_my_runs(account_id).runs] == ["live-run"]
+    assert [run.slug for run in resolve_my_runs(account_id, "alice").runs] == ["live-run"]
 
 
 def test_empty_when_no_memberships(stores: Path) -> None:
     account_id = accounts.create_account(username="alice", pwhash="h")
-    assert resolve_my_runs(account_id).runs == []
+    assert resolve_my_runs(account_id, "alice").runs == []
 
 
 def _raw_membership(account_id: int, slug: str, settled_at: str) -> None:
@@ -98,7 +100,7 @@ def test_naive_settled_at_recovered_as_utc(stores: Path) -> None:
     _fragment(stores, slug="legacy", name="Legacy", starts_at="2026-01-01T00:00:00Z")
     _raw_membership(account_id, "legacy", "2026-01-02T00:00:00")  # naive — no timezone
 
-    runs = resolve_my_runs(account_id).runs
+    runs = resolve_my_runs(account_id, "alice").runs
 
     assert [run.slug for run in runs] == ["legacy"]
     assert runs[0].settled_at.tzinfo is not None
@@ -112,4 +114,4 @@ def test_unparseable_settled_at_skipped_not_fatal(stores: Path) -> None:
     accounts.record_membership(account_id=account_id, slug="good", settled_at="2026-01-02T00:00:00+00:00")
     _raw_membership(account_id, "corrupt", "not-a-timestamp")
 
-    assert [run.slug for run in resolve_my_runs(account_id).runs] == ["good"]
+    assert [run.slug for run in resolve_my_runs(account_id, "alice").runs] == ["good"]


### PR DESCRIPTION
Closes #849.

## Problem

Changing your password in the lobby never prompted Apple Passwords (or other managers) to **update** the saved credential. Two causes:

1. The form submitted via `fetch` + `preventDefault()`. WebKit fires its save/update prompt on a real form-submit **navigation** — an intercepted `fetch` gives it nothing to detect.
2. There was no `autocomplete="username"` field, so a manager couldn't tell *which* stored credential the change applied to.

(The retired `SetNewPassword.tsx` had started down this path — a hidden username field + a native-POST `action` — but was never finished; this completes it properly.)

## Fix

- **Native form POST + Post/Redirect/Get.** The account form now submits natively to a new lobby endpoint `POST /auth/change-password-form`, which validates and 303-redirects back into the SPA at `/account?pw=changed | old-incorrect | too-short`. Every outcome is a redirect, so a native submit never renders raw JSON; the page turns `?pw=` into a banner. Client-side validation still runs and only `preventDefault()`s on failure.
- **`autocomplete="username"` field.** A read-only username row now identifies the credential. The username wasn't exposed client-side, so it's echoed back on the shared `my-runs` read (`MyRunsResponse.username` / `resolve_my_runs`), served identically by the lobby and every instance.
- **Cleanup.** Removed the now-dead JSON `change-password` endpoint, the `ChangePasswordRequest` schema, and the frontend hook/api/type that called it; regenerated `api.generated.ts`.

## Testing

- Rewrote the two change-password integration tests to post form data and assert the `303` + `Location`, plus a new too-short case; added `username` assertions to the my-runs unit + integration tests.
- Backend suite green (lobby / my-runs), frontend typecheck / lint / format clean.
- **Verified on production Safari** (deployed to `lobby.energetica-game.org`): the "update password" prompt now fires.

## Deploy note

Needs a **lobby** redeploy (`deploy-lobby.sh`). Instances share `resolve_my_runs` but aren't affected — nothing on the instance reads the new `username` field, so they can be redeployed on their normal cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the lobby password-change flow so password managers can detect updates.

- Adds a native form POST endpoint with redirect status handling.
- Adds the authenticated username to the my-runs response.
- Updates the account page to include a read-only username field.
- Removes the old JSON change-password client and schema surface.
- Updates backend and my-runs tests for the new response and redirect flow.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/routes-lobby/account.tsx | Changes the account password form to submit natively, show redirect banners, include the username field, and guard duplicate accepted submits. |
| lobby/routers.py | Adds the form-based password-change endpoint and redirects each outcome back to the account page. |
| energetica/my_runs.py | Returns the supplied username with the account run list. |

<sub>Reviews (2): Last reviewed commit: ["fix(lobby): guard change-password form a..."](https://github.com/felixvonsamson/energetica/commit/18c8b065f6a86858d8c6c4ad8f4b65fc5f2d5d47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43152609)</sub>

<!-- /greptile_comment -->