### PR TITLE
ci(security): forbid raw-HTML rendering of UGC (ADR-0002, #843)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Lint
         run: bun run lint
         working-directory: frontend
+      - name: Guard — no raw-HTML rendering of UGC (ADR-0002, #843)
+        run: bun run guard:no-raw-html
+        working-directory: frontend
 
   type-check:
     runs-on: ubuntu-latest

--- a/docs/adr/0002-server-wide-sso-shared-cookie.md
+++ b/docs/adr/0002-server-wide-sso-shared-cookie.md
@@ -63,7 +63,9 @@ with the shared secret and auto-provisions a local `User` on first authenticated
   `components/chat/`. New raw-HTML renders are denied by default; adding one requires
   amending the allowlist, which forces a reviewer to confirm the input is not
   user-controlled. The day any UGC surface renders raw HTML, the cross-instance leak goes
-  live.
+  live. *Implemented (#843) as `scripts/guard-no-raw-html.ts`, run in CI via the frontend
+  `guard:no-raw-html` script; the allowlist pins each permitted sink to its file and the
+  exact `__html` expression.*
 - **A2 is the committed hardening path** (#813), to land before any UGC surface gains a
   rich-content renderer (backstop re-evaluation: 2026-12). Reversing A1 later means a
   cookie/secret migration across every instance — hence recording it here.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
         "format:check": "prettier --check \"./**/*.{ts,tsx}\"",
         "typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.landing.json && tsc --noEmit --project tsconfig.lobby.json && tsc --noEmit --project tsconfig.sw.json",
         "typecheck:watch": "tsc --noEmit --watch",
+        "guard:no-raw-html": "bun ../scripts/guard-no-raw-html.ts",
         "test": "vitest run",
         "test:watch": "vitest"
     },

--- a/scripts/guard-no-raw-html.ts
+++ b/scripts/guard-no-raw-html.ts
@@ -1,35 +1,53 @@
 /**
- * CI guard: forbid raw-HTML rendering of user-generated content (ADR-0002, #843).
+ * CI guard: forbid raw-HTML rendering of user-generated content (ADR-0002,
+ * #843).
  *
  * With the shared parent-domain SSO cookie live in production, the sole live
  * defence against a cross-instance session-ride is that every user-controlled
  * string renders as React-escaped text. This guard fails CI if any frontend
- * source introduces a raw-HTML sink — `dangerouslySetInnerHTML` or `rehype-raw`
- * — outside the explicit allowlist below.
+ * source introduces a raw-HTML sink outside the explicit allowlist below.
  *
- * The allowlist is intentionally tiny and granular: it pins each permitted sink
- * to both its file AND the exact expression fed to `__html`. Adding a new UGC
- * surface, or changing an allowlisted site to render a different (possibly
- * user-controlled) field, therefore requires a visible, security-reviewable
- * edit to this file — it can never slip in silently.
+ * Two sinks are covered:
  *
- * Run: `bun run guard:no-raw-html` (from frontend/) or `bun scripts/guard-no-raw-html.ts`.
+ * 1. `dangerouslySetInnerHTML` — a JSX-level sink, so it is only scanned in
+ *    `frontend/src`. Each occurrence is pinned to a (file, __html-expression)
+ *    allowlist entry, consumed 1:1: a second sink — even one that reuses the
+ *    same expression text in a different scope — needs its own reviewable
+ *    entry, so a refactor cannot silently ride an existing approval.
+ * 2. `rehype-raw` — re-enables raw HTML inside our build-time MDX pipeline. MDX
+ *    plugins are wired in `frontend/vite.config*.ts` (never in `src`), so a
+ *    `src`-only scan would miss it entirely. It is forbidden outright at two
+ *    layers that together defeat aliasing / wrapper indirection: (a) it must
+ *    not be a declared dependency (or npm-aliased dependency) in
+ *    `frontend/package.json` — no package present, nothing to import; (b) its
+ *    module specifier must not be imported anywhere in `frontend/src` or the
+ *    build configs.
+ *
+ * The allowlist is intentionally tiny and granular. Adding a new UGC surface,
+ * or changing an allowlisted site to render a different (possibly
+ * user-controlled) field, requires a visible, security-reviewable edit to this
+ * file — it can never slip in silently.
+ *
+ * Run: `bun run guard:no-raw-html` (from frontend/) or `bun
+ * scripts/guard-no-raw-html.ts`.
  */
 
-import { readdirSync, readFileSync, statSync } from "fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const SCAN_ROOT = join(REPO_ROOT, "frontend", "src");
+const FRONTEND_ROOT = join(REPO_ROOT, "frontend");
+const SCAN_ROOT = join(FRONTEND_ROOT, "src");
 
 /**
  * Every currently-permitted `dangerouslySetInnerHTML` sink.
  *
  * `file` is repo-relative; `html` is the exact expression passed to `__html`.
- * Both must match for a usage to be allowed. All current entries render
- * developer-authored game content (technology / facility descriptions), never
- * user-generated content.
+ * Both must match for a usage to be allowed, and entries are consumed one per
+ * physical sink: two sinks in the same file need two entries. All current
+ * entries render developer-authored game content (technology / facility
+ * descriptions), never user-generated content.
  *
  * DO NOT extend this list to cover any user-controlled string (chat, player /
  * team / tile names, or any future rich field). See ADR-0002.
@@ -57,6 +75,9 @@ const ALLOWLIST: { file: string; html: string }[] = [
     },
 ];
 
+/** The forbidden raw-HTML MDX plugin. */
+const RAW_MD_PACKAGE = "rehype-raw";
+
 interface Finding {
     file: string; // repo-relative
     line: number;
@@ -76,6 +97,14 @@ function collectSources(dir: string): string[] {
         }
     }
     return out;
+}
+
+/** Non-recursive .ts/.tsx files directly under `dir` (e.g. build configs). */
+function collectTopLevel(dir: string): string[] {
+    return readdirSync(dir)
+        .filter((e) => /\.tsx?$/.test(e))
+        .map((e) => join(dir, e))
+        .filter((f) => statSync(f).isFile());
 }
 
 function lineOf(source: string, index: number): number {
@@ -98,6 +127,7 @@ function extractHtmlExpr(source: string, from: number): string | undefined {
 
 const findings: Finding[] = [];
 
+// `dangerouslySetInnerHTML` is a JSX sink: scan application sources only.
 for (const absFile of collectSources(SCAN_ROOT)) {
     const file = relative(REPO_ROOT, absFile);
     const source = readFileSync(absFile, "utf8");
@@ -114,12 +144,25 @@ for (const absFile of collectSources(SCAN_ROOT)) {
             html: extractHtmlExpr(source, idx),
         });
     }
+}
 
-    // rehype-raw re-enables raw HTML inside react-markdown; forbidden outright,
-    // matched on the package name (import) and the conventional identifier.
-    const rawRe = /rehype-raw|rehypeRaw/g;
+// `rehype-raw` re-enables raw HTML inside react-markdown / MDX. Match only an
+// actual quoted module specifier (`"rehype-raw"` / `'rehype-raw'`), so prose or
+// a comment that merely names the package cannot trip CI. Scan both the app
+// sources and the build configs, where MDX `rehypePlugins` are actually wired.
+const rawSpecifierRe = new RegExp(
+    `["']${RAW_MD_PACKAGE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["']`,
+    "g",
+);
+const rawScanFiles = [
+    ...collectSources(SCAN_ROOT),
+    ...collectTopLevel(FRONTEND_ROOT),
+];
+for (const absFile of rawScanFiles) {
+    const file = relative(REPO_ROOT, absFile);
+    const source = readFileSync(absFile, "utf8");
     let m: RegExpExecArray | null;
-    while ((m = rawRe.exec(source)) !== null) {
+    while ((m = rawSpecifierRe.exec(source)) !== null) {
         findings.push({
             file,
             line: lineOf(source, m.index),
@@ -128,16 +171,52 @@ for (const absFile of collectSources(SCAN_ROOT)) {
     }
 }
 
-// Match findings against the allowlist. An allowlist entry is "used" only when
-// a real finding matches it, so stale entries surface as errors and the list
-// stays truthful and minimal.
-const used = new Set<number>();
+// Dependency-level block: an aliased or wrapped import still needs `rehype-raw`
+// present as a (possibly npm-aliased) dependency. Scan the manifest's keys AND
+// values so `"anything": "npm:rehype-raw@^7"` is caught too.
+const depViolations: string[] = [];
+const pkgPath = join(FRONTEND_ROOT, "package.json");
+if (existsSync(pkgPath)) {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as Record<
+        string,
+        unknown
+    >;
+    const depSections = [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ];
+    for (const section of depSections) {
+        const deps = pkg[section];
+        if (!deps || typeof deps !== "object") continue;
+        for (const [name, version] of Object.entries(
+            deps as Record<string, string>,
+        )) {
+            if (
+                name === RAW_MD_PACKAGE ||
+                String(version).includes(RAW_MD_PACKAGE)
+            ) {
+                depViolations.push(
+                    `frontend/package.json  ${section}["${name}"] pulls in ${RAW_MD_PACKAGE}`,
+                );
+            }
+        }
+    }
+}
+
+// Match findings against the allowlist. Entries are consumed one-per-sink: a
+// finding claims the first *unconsumed* matching entry, so a duplicate sink
+// with no dedicated entry (even same file + same expression, different scope)
+// surfaces as a violation. Unconsumed entries are stale, keeping the list
+// truthful and minimal.
+const consumed = new Array<boolean>(ALLOWLIST.length).fill(false);
 const violations: string[] = [];
 
 for (const f of findings) {
     if (f.kind === "rehype-raw") {
         violations.push(
-            `${f.file}:${f.line}  raw-HTML markdown (rehype-raw) is forbidden`,
+            `${f.file}:${f.line}  raw-HTML markdown (${RAW_MD_PACKAGE}) is forbidden`,
         );
         continue;
     }
@@ -149,20 +228,24 @@ for (const f of findings) {
         continue;
     }
     const allowIdx = ALLOWLIST.findIndex(
-        (a) => a.file === f.file && a.html === f.html,
+        (a, i) => !consumed[i] && a.file === f.file && a.html === f.html,
     );
     if (allowIdx === -1) {
         violations.push(
             `${f.file}:${f.line}  dangerouslySetInnerHTML={{ __html: ${f.html} }} is not allowlisted`,
         );
     } else {
-        used.add(allowIdx);
+        consumed[allowIdx] = true;
     }
 }
 
-const stale = ALLOWLIST.filter((_, i) => !used.has(i));
+const stale = ALLOWLIST.filter((_, i) => !consumed[i]);
 
-if (violations.length === 0 && stale.length === 0) {
+if (
+    violations.length === 0 &&
+    depViolations.length === 0 &&
+    stale.length === 0
+) {
     console.log(
         `✓ raw-HTML UGC guard: ${ALLOWLIST.length} allowlisted sink(s), no violations.`,
     );
@@ -184,6 +267,15 @@ if (violations.length > 0) {
             "content, add an explicit { file, html } entry to ALLOWLIST in\n" +
             "scripts/guard-no-raw-html.ts — that edit gets security review.",
     );
+}
+
+if (depViolations.length > 0) {
+    console.error(
+        `\n${RAW_MD_PACKAGE} must not be a dependency — its presence lets any\n` +
+            "module re-enable raw HTML in the MDX pipeline, defeating this guard.\n\n" +
+            "Offending manifest entries:",
+    );
+    for (const v of depViolations) console.error(`  - ${v}`);
 }
 
 if (stale.length > 0) {

--- a/scripts/guard-no-raw-html.ts
+++ b/scripts/guard-no-raw-html.ts
@@ -1,0 +1,197 @@
+/**
+ * CI guard: forbid raw-HTML rendering of user-generated content (ADR-0002, #843).
+ *
+ * With the shared parent-domain SSO cookie live in production, the sole live
+ * defence against a cross-instance session-ride is that every user-controlled
+ * string renders as React-escaped text. This guard fails CI if any frontend
+ * source introduces a raw-HTML sink — `dangerouslySetInnerHTML` or `rehype-raw`
+ * — outside the explicit allowlist below.
+ *
+ * The allowlist is intentionally tiny and granular: it pins each permitted sink
+ * to both its file AND the exact expression fed to `__html`. Adding a new UGC
+ * surface, or changing an allowlisted site to render a different (possibly
+ * user-controlled) field, therefore requires a visible, security-reviewable
+ * edit to this file — it can never slip in silently.
+ *
+ * Run: `bun run guard:no-raw-html` (from frontend/) or `bun scripts/guard-no-raw-html.ts`.
+ */
+
+import { readdirSync, readFileSync, statSync } from "fs";
+import { dirname, join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCAN_ROOT = join(REPO_ROOT, "frontend", "src");
+
+/**
+ * Every currently-permitted `dangerouslySetInnerHTML` sink.
+ *
+ * `file` is repo-relative; `html` is the exact expression passed to `__html`.
+ * Both must match for a usage to be allowed. All current entries render
+ * developer-authored game content (technology / facility descriptions), never
+ * user-generated content.
+ *
+ * DO NOT extend this list to cover any user-controlled string (chat, player /
+ * team / tile names, or any future rich field). See ADR-0002.
+ */
+const ALLOWLIST: { file: string; html: string }[] = [
+    {
+        file: "frontend/src/components/technologies/technology-detail-dialog.tsx",
+        html: "displayedTechnology.description",
+    },
+    {
+        file: "frontend/src/components/facilities/facility-detail-dialog.tsx",
+        html: "facility.description",
+    },
+    {
+        file: "frontend/src/routes/app/facilities/extraction.tsx",
+        html: "facility.description",
+    },
+    {
+        file: "frontend/src/routes/app/facilities/functional.tsx",
+        html: "facility.description",
+    },
+    {
+        file: "frontend/src/routes/app/facilities/power.tsx",
+        html: "facility.description",
+    },
+];
+
+interface Finding {
+    file: string; // repo-relative
+    line: number;
+    kind: "dangerouslySetInnerHTML" | "rehype-raw";
+    html?: string; // expression passed to __html, when parseable
+}
+
+/** Recursively collect .ts/.tsx source files under `dir`. */
+function collectSources(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+            out.push(...collectSources(full));
+        } else if (/\.tsx?$/.test(entry)) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+function lineOf(source: string, index: number): number {
+    let line = 1;
+    for (let i = 0; i < index; i++) if (source[i] === "\n") line++;
+    return line;
+}
+
+/**
+ * Extract the `__html` expression that follows a `dangerouslySetInnerHTML`
+ * occurrence at `from`. Returns the trimmed expression, or undefined if the
+ * usage does not match the expected `{{ __html: <expr> }}` shape — an
+ * unparseable sink is treated as a violation, never waved through.
+ */
+function extractHtmlExpr(source: string, from: number): string | undefined {
+    const rest = source.slice(from, from + 400);
+    const m = rest.match(/__html\s*:\s*([\s\S]+?)\s*[,}]/);
+    return m ? m[1].trim() : undefined;
+}
+
+const findings: Finding[] = [];
+
+for (const absFile of collectSources(SCAN_ROOT)) {
+    const file = relative(REPO_ROOT, absFile);
+    const source = readFileSync(absFile, "utf8");
+
+    for (
+        let idx = source.indexOf("dangerouslySetInnerHTML");
+        idx !== -1;
+        idx = source.indexOf("dangerouslySetInnerHTML", idx + 1)
+    ) {
+        findings.push({
+            file,
+            line: lineOf(source, idx),
+            kind: "dangerouslySetInnerHTML",
+            html: extractHtmlExpr(source, idx),
+        });
+    }
+
+    // rehype-raw re-enables raw HTML inside react-markdown; forbidden outright,
+    // matched on the package name (import) and the conventional identifier.
+    const rawRe = /rehype-raw|rehypeRaw/g;
+    let m: RegExpExecArray | null;
+    while ((m = rawRe.exec(source)) !== null) {
+        findings.push({
+            file,
+            line: lineOf(source, m.index),
+            kind: "rehype-raw",
+        });
+    }
+}
+
+// Match findings against the allowlist. An allowlist entry is "used" only when
+// a real finding matches it, so stale entries surface as errors and the list
+// stays truthful and minimal.
+const used = new Set<number>();
+const violations: string[] = [];
+
+for (const f of findings) {
+    if (f.kind === "rehype-raw") {
+        violations.push(
+            `${f.file}:${f.line}  raw-HTML markdown (rehype-raw) is forbidden`,
+        );
+        continue;
+    }
+    if (f.html === undefined) {
+        violations.push(
+            `${f.file}:${f.line}  dangerouslySetInnerHTML with an unrecognised shape — ` +
+                `cannot verify the rendered value is not user-controlled`,
+        );
+        continue;
+    }
+    const allowIdx = ALLOWLIST.findIndex(
+        (a) => a.file === f.file && a.html === f.html,
+    );
+    if (allowIdx === -1) {
+        violations.push(
+            `${f.file}:${f.line}  dangerouslySetInnerHTML={{ __html: ${f.html} }} is not allowlisted`,
+        );
+    } else {
+        used.add(allowIdx);
+    }
+}
+
+const stale = ALLOWLIST.filter((_, i) => !used.has(i));
+
+if (violations.length === 0 && stale.length === 0) {
+    console.log(
+        `✓ raw-HTML UGC guard: ${ALLOWLIST.length} allowlisted sink(s), no violations.`,
+    );
+    process.exit(0);
+}
+
+console.error("✗ raw-HTML UGC guard failed (ADR-0002, #843).\n");
+
+if (violations.length > 0) {
+    console.error(
+        "Raw-HTML sinks render their input as unescaped markup. On any\n" +
+            "user-controlled string this is a stored-XSS / cross-instance\n" +
+            "session-ride vector. Render UGC as React-escaped text instead.\n\n" +
+            "Disallowed sinks:",
+    );
+    for (const v of violations) console.error(`  - ${v}`);
+    console.error(
+        "\nIf (and only if) the rendered value is developer-authored game\n" +
+            "content, add an explicit { file, html } entry to ALLOWLIST in\n" +
+            "scripts/guard-no-raw-html.ts — that edit gets security review.",
+    );
+}
+
+if (stale.length > 0) {
+    console.error("\nStale ALLOWLIST entries (no matching sink found):");
+    for (const s of stale) console.error(`  - ${s.file}  __html: ${s.html}`);
+    console.error(
+        "\nRemove them from scripts/guard-no-raw-html.ts so the allowlist stays minimal.",
+    );
+}
+
+process.exit(1);

--- a/scripts/guard-no-raw-html.ts
+++ b/scripts/guard-no-raw-html.ts
@@ -17,11 +17,18 @@
  * 2. `rehype-raw` — re-enables raw HTML inside our build-time MDX pipeline. MDX
  *    plugins are wired in `frontend/vite.config*.ts` (never in `src`), so a
  *    `src`-only scan would miss it entirely. It is forbidden outright at two
- *    layers that together defeat aliasing / wrapper indirection: (a) it must
- *    not be a declared dependency (or npm-aliased dependency) in
- *    `frontend/package.json` — no package present, nothing to import; (b) its
- *    module specifier must not be imported anywhere in `frontend/src` or the
- *    build configs.
+ *    layers: (a) it must not be a declared dependency (or npm-aliased
+ *    dependency) in `frontend/package.json` — no package present, nothing to
+ *    import; (b) it must not be imported as a module specifier anywhere in
+ *    `frontend/src` or the build configs.
+ *
+ * Known boundary: this is a text-and-manifest guard, one defence-in-depth layer
+ * — not a hermetic sandbox. It does not resolve the dependency graph, so a
+ * wrapper package that transitively pulls `rehype-raw` and re-exports it under
+ * its own name would not be caught. That is an accepted residual risk: adding
+ * such a wrapper is a conspicuous, reviewable new dependency, not the silent
+ * slip this guard exists to stop. Graph resolution was considered and rejected
+ * as disproportionately brittle and false-positive-prone.
  *
  * The allowlist is intentionally tiny and granular. Adding a new UGC surface,
  * or changing an allowlisted site to render a different (possibly
@@ -146,12 +153,15 @@ for (const absFile of collectSources(SCAN_ROOT)) {
     }
 }
 
-// `rehype-raw` re-enables raw HTML inside react-markdown / MDX. Match only an
-// actual quoted module specifier (`"rehype-raw"` / `'rehype-raw'`), so prose or
-// a comment that merely names the package cannot trip CI. Scan both the app
+// `rehype-raw` re-enables raw HTML inside react-markdown / MDX. Match the
+// package name ONLY where it is an actual module specifier — the target of an
+// `import` / `export … from`, a side-effect `import`, or a `require(...)` /
+// dynamic `import(...)`. A bare quoted `"rehype-raw"` in prose, a data literal,
+// or a test fixture is therefore not a false positive. Scan both the app
 // sources and the build configs, where MDX `rehypePlugins` are actually wired.
+const pkgEsc = RAW_MD_PACKAGE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const rawSpecifierRe = new RegExp(
-    `["']${RAW_MD_PACKAGE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["']`,
+    `(?:\\bfrom\\s*|\\bimport\\s*\\(?\\s*|\\brequire\\s*\\(\\s*)(["'])${pkgEsc}\\1`,
     "g",
 );
 const rawScanFiles = [


### PR DESCRIPTION
Closes #843.

With the shared parent-domain SSO cookie live in production (ADR-0002), the *sole* live defence against a cross-instance session-ride is that every user-controlled string renders as React-escaped text. This adds the CI guard that ADR-0002 requires before any UGC surface can gain a rich-content renderer.

## What

`scripts/guard-no-raw-html.ts` scans `frontend/src/**/*.{ts,tsx}` and fails CI on any raw-HTML sink outside an explicit allowlist:

- **`dangerouslySetInnerHTML`** — each occurrence is matched against a `(file, __html-expression)` pair.
- **`rehype-raw` / `rehypeRaw`** — forbidden outright, no allowlist.

Wired as the frontend `guard:no-raw-html` script and a step in the CI `frontend-checks` job (after lint). ADR-0002's consequences section is updated to link the implementation.

## Why a dedicated script over `react/no-danger`

The security property that matters is that a *new* UGC surface can't silently gain raw HTML. `react/no-danger` with per-site `// eslint-disable` comments fails that — a dev adds the render plus a disable and CI stays green, the exact leak ADR-0002 warns about. This guard uses a **centralized, granular allowlist**: adding a sink requires editing a checked-in file (a visible, security-reviewable diff), and it pins the *expression*, so swapping `facility.description` → a user-controlled field at an allowlisted site still trips it. Stale entries also fail, keeping the list minimal.

## Allowlist

The current 5 entries are exactly the existing developer-authored technology/facility `description` renders. No UGC surface (chat, player/team/tile names) renders raw HTML today.

## Verified locally

- Clean tree: passes (`✓ 5 allowlisted sink(s), no violations`).
- Fails on: a new non-allowlisted sink; `rehype-raw`; a user-controlled field swapped into an allowlisted site; a stale allowlist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a CI guard for raw HTML rendering in the frontend. The main changes are:

- Adds `scripts/guard-no-raw-html.ts` with an allowlist for existing raw HTML sinks.
- Blocks `rehype-raw` usage through source and manifest checks.
- Wires the guard into the frontend package script and CI workflow.
- Updates ADR-0002 to point to the guard implementation.

<h3>Confidence Score: 4/5</h3>

This is close, but the guard still has two changed-path failures to fix before merging.

- Import-shaped comments or fixture strings can still block CI without adding a renderer.
- A wrapper dependency can still expose `rehype-raw` while avoiding the current manifest and source checks.

scripts/guard-no-raw-html.ts

<details open><summary><h3>Security Review</h3></summary>

The wrapper dependency path can still re-enable raw HTML in the MDX pipeline while the guard passes, leaving the ADR-0002 raw-HTML boundary incomplete.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/guard-no-raw-html.ts | Adds the raw HTML guard, allowlist matching, source scan, and dependency checks. |
| frontend/package.json | Adds the frontend script that runs the raw HTML guard. |
| .github/workflows/ci.yml | Runs the raw HTML guard during frontend CI checks. |
| docs/adr/0002-server-wide-sso-shared-cookie.md | Documents the guard as the ADR-0002 implementation. |

<sub>Reviews (3): Last reviewed commit: ["ci(security): anchor rehype-raw scan to ..."](https://github.com/felixvonsamson/energetica/commit/50413f81efcabff822b27f5acf37a4e22b5ca34a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43156417)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->