### PR TITLE
feat(lifecycle): freeze self-enforcement at freeze_at (T3, #861)

### DIFF
--- a/energetica/game_error.py
+++ b/energetica/game_error.py
@@ -38,6 +38,8 @@ class GameExceptionType(StrEnum):
     SIGNUP_DISABLED = "SIGNUP_DISABLED"
     OLD_PASSWORD_INCORRECT = "OLD_PASSWORD_INCORRECT"
     INSTANCE_ACCESS_DENIED = "INSTANCE_ACCESS_DENIED"
+    # Lifecycle
+    INSTANCE_FROZEN = "Instance is frozen; the game is read-only."
     # Technology effects
     INVALID_MULTIPLIER = "InvalidMultiplier"
     # network prices

--- a/energetica/instance_config.py
+++ b/energetica/instance_config.py
@@ -179,6 +179,33 @@ class InstanceFragment(BaseModel):
         return derive_phase(now, starts_at=self.starts_at, freeze_at=self.freeze_at, ended_at=self.ended_at)
 
 
+def current_phase(now: datetime | None = None) -> Phase:
+    """This instance's own lifecycle phase right now, from its on-disk ``instance.json``.
+
+    The running backend self-drives its ``active → freeze → ended`` transitions from this — the sim
+    halt (``state_update``) and the read-only write-gate (``reject_when_frozen``) both key off it. The
+    config is re-read every call (no cache), exactly like the login/access path, so an admin editing
+    ``freeze_at`` (the manual force-freeze / adjustment override) takes effect on the next check with
+    no restart.
+
+    Fails **open** — returns ``active`` — when the instance is unconfigured (dev/legacy: no slug or no
+    file → open-ended run, no freeze boundary) or the config is present-but-broken. A config typo must
+    not silently freeze a live game; the login path already fails *closed* on a broken config, so
+    entry stops there, while the running game keeps serving until a *readable* ``freeze_at`` is
+    actually crossed. Freeze is entered only on a positive clock signal, never on an error.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    try:
+        config = load_instance_config()
+    except InstanceConfigError as exc:
+        logger.warning("treating instance as active; could not read config for phase: %s", exc)
+        return "active"
+    if config is None:
+        return "active"
+    return derive_phase(now, starts_at=config.starts_at, freeze_at=config.freeze_at, ended_at=config.ended_at)
+
+
 def instance_slug() -> str | None:
     """The instance's own slug, from the environment. ``None`` in dev / unconfigured deployments."""
     slug = os.environ.get(_SLUG_ENV_VAR)

--- a/energetica/routers/daily_quiz.py
+++ b/energetica/routers/daily_quiz.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends
 from energetica.database.player import Player
 from energetica.schemas.daily_quiz import DailyQuizBase, DailyQuizSubmitRequest
 from energetica.utils import misc
-from energetica.utils.auth import get_settled_player
+from energetica.utils.auth import get_settled_player, reject_when_frozen
 
 router = APIRouter(prefix="/daily-quiz", tags=["Daily Quiz"])
 
@@ -20,7 +20,7 @@ def get_quiz_question(
     return misc.get_quiz_question(player)
 
 
-@router.post("", response_model_exclude_unset=True)
+@router.post("", response_model_exclude_unset=True, dependencies=[Depends(reject_when_frozen)])
 def submit_quiz_answer(
     player: Annotated[Player, Depends(get_settled_player)],
     submission: DailyQuizSubmitRequest,

--- a/energetica/routers/electricity_markets.py
+++ b/energetica/routers/electricity_markets.py
@@ -14,7 +14,7 @@ from energetica.schemas.electricity_markets import (
     ElectricityMarketOut,
 )
 from energetica.utils import network_helpers
-from energetica.utils.auth import get_settled_player
+from energetica.utils.auth import get_settled_player, reject_when_frozen
 
 router = APIRouter(prefix="/electricity-markets", tags=["Electricity Markets"])
 
@@ -33,7 +33,7 @@ def get_electricity_market_list(
     )
 
 
-@router.post("/{network_id}:join")
+@router.post("/{network_id}:join", dependencies=[Depends(reject_when_frozen)])
 def join_electricity_market(
     player: Annotated[Player, Depends(get_settled_player)],
     network_id: int,
@@ -48,7 +48,7 @@ def join_electricity_market(
     return ElectricityMarketOut.from_network(network_helpers.join_network(player, network))
 
 
-@router.post("/{network_id}:leave")
+@router.post("/{network_id}:leave", dependencies=[Depends(reject_when_frozen)])
 def leave_electricity_market(
     player: Annotated[Player, Depends(get_settled_player)],
     network_id: int,
@@ -68,7 +68,7 @@ def leave_electricity_market(
     return ElectricityMarketOut.from_network(new_network)
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(reject_when_frozen)])
 def create_electricity_market(
     player: Annotated[Player, Depends(get_settled_player)], request_data: ElectricityMarketCreate
 ) -> ElectricityMarketOut:
@@ -79,7 +79,7 @@ def create_electricity_market(
     return ElectricityMarketOut.from_network(new_network)
 
 
-@router.patch("/prices", status_code=status.HTTP_204_NO_CONTENT)
+@router.patch("/prices", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(reject_when_frozen)])
 async def change_electricity_market_prices(
     player: Annotated[Player, Depends(get_settled_player)],
     prices_change_request: ChangeElectricityMarketPrices,

--- a/energetica/routers/facilities.py
+++ b/energetica/routers/facilities.py
@@ -14,7 +14,7 @@ from energetica.enums import (
 from energetica.schemas.facilities import FacilitiesListOut, FacilityStatuses
 from energetica.schemas.players import DismantleOut, MoneyOut
 from energetica.utils import facilities
-from energetica.utils.auth import get_settled_player
+from energetica.utils.auth import get_settled_player, reject_when_frozen
 
 router = APIRouter(prefix="/facilities", tags=["Facilities"])
 
@@ -27,7 +27,7 @@ def get_active_facilities(
     return FacilitiesListOut.from_player(player)
 
 
-@router.post("/{facility_id}:upgrade")
+@router.post("/{facility_id}:upgrade", dependencies=[Depends(reject_when_frozen)])
 def upgrade_facility(
     player: Annotated[Player, Depends(get_settled_player)],
     facility_id: int,
@@ -40,7 +40,7 @@ def upgrade_facility(
     return MoneyOut.from_player(player)
 
 
-@router.post(":upgrade-all")
+@router.post(":upgrade-all", dependencies=[Depends(reject_when_frozen)])
 async def upgrade_all_of_type(
     player: Annotated[Player, Depends(get_settled_player)],
     facility_type: PowerFacilityType | StorageFacilityType | ExtractionFacilityType,
@@ -50,7 +50,7 @@ async def upgrade_all_of_type(
     return MoneyOut.from_player(player)
 
 
-@router.post("/{facility_id}:dismantle")
+@router.post("/{facility_id}:dismantle", dependencies=[Depends(reject_when_frozen)])
 async def dismantle_facility(
     player: Annotated[Player, Depends(get_settled_player)],
     facility_id: int,
@@ -69,7 +69,7 @@ async def dismantle_facility(
     return DismantleOut(money=player.money, draining=draining)
 
 
-@router.post(":dismantle-all")
+@router.post(":dismantle-all", dependencies=[Depends(reject_when_frozen)])
 async def dismantle_all_of_type(
     player: Annotated[Player, Depends(get_settled_player)],
     facility_type: PowerFacilityType | StorageFacilityType | ExtractionFacilityType,

--- a/energetica/routers/game.py
+++ b/energetica/routers/game.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from energetica import instance_config
 from energetica.globals import engine
 from energetica.schemas.game import GameEngineOut
 
@@ -10,9 +11,17 @@ router = APIRouter(prefix="/game", tags=["Game"])
 
 @router.get("/engine")
 def get_engine_config() -> GameEngineOut:
-    """Get game engine configuration including clock time and simulation speed."""
+    """Get game engine configuration including clock time, simulation speed, and lifecycle boundaries."""
+    # None when unconfigured (dev) or unreadable — the in-game app then sees an open-ended run with no
+    # freeze, matching the fail-open phase read in instance_config.current_phase (#861).
+    try:
+        config = instance_config.load_instance_config()
+    except instance_config.InstanceConfigError:
+        config = None
     return GameEngineOut(
         start_date=engine.start_date,
         wall_clock_seconds_per_tick=engine.clock_time,
         game_seconds_per_tick=engine.in_game_seconds_per_tick,
+        freeze_at=config.freeze_at if config else None,
+        ended_at=config.ended_at if config else None,
     )

--- a/energetica/routers/map.py
+++ b/energetica/routers/map.py
@@ -8,7 +8,7 @@ from energetica.database.user import User
 from energetica.schemas.map import SettleRequest, SettleResponse
 from energetica.schemas.map import HexTileOut
 from energetica.utils import map_helpers
-from energetica.utils.auth import get_playing_user
+from energetica.utils.auth import get_playing_user, reject_when_frozen
 
 router = APIRouter(prefix="/map", tags=["Map"])
 
@@ -39,7 +39,7 @@ def get_map() -> list[HexTileOut]:
     return hex_list
 
 
-@router.post("/settle")
+@router.post("/settle", dependencies=[Depends(reject_when_frozen)])
 def settle_region(
     user: Annotated[User, Depends(get_playing_user)],
     request_data: SettleRequest,

--- a/energetica/routers/power_priorities.py
+++ b/energetica/routers/power_priorities.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from energetica.database.player import Player
 from energetica.schemas.electricity_markets import AskType, BidType
 from energetica.schemas.power_priorities import PowerPrioritiesListIn, PowerPrioritiesListOut
-from energetica.utils.auth import get_settled_player
+from energetica.utils.auth import get_settled_player, reject_when_frozen
 
 router = APIRouter(prefix="/power-priorities", tags=["Power Priorities"])
 
@@ -23,7 +23,7 @@ def get_power_priorities(
     return PowerPrioritiesListOut.from_player(player)
 
 
-@router.put("", status_code=status.HTTP_204_NO_CONTENT)
+@router.put("", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(reject_when_frozen)])
 def put_power_priorities(
     player: Annotated[Player, Depends(get_settled_player)],
     data: PowerPrioritiesListIn,
@@ -38,7 +38,7 @@ def put_power_priorities(
     )
 
 
-@router.post("/{side}/{item_type}:increase-priority")
+@router.post("/{side}/{item_type}:increase-priority", dependencies=[Depends(reject_when_frozen)])
 def increase_priority(
     player: Annotated[Player, Depends(get_settled_player)],
     side: Literal["ask", "bid"],
@@ -50,7 +50,7 @@ def increase_priority(
     return PowerPrioritiesListOut.from_player(player)
 
 
-@router.post("/{side}/{item_type}:decrease-priority")
+@router.post("/{side}/{item_type}:decrease-priority", dependencies=[Depends(reject_when_frozen)])
 def decrease_priority(
     player: Annotated[Player, Depends(get_settled_player)],
     side: Literal["ask", "bid"],

--- a/energetica/routers/projects.py
+++ b/energetica/routers/projects.py
@@ -15,7 +15,7 @@ from energetica.schemas.projects import (
     StorageFacilityCatalogListOut,
     TechnologyCatalogListOut,
 )
-from energetica.utils.auth import get_settled_player
+from energetica.utils.auth import get_settled_player, reject_when_frozen
 from energetica.utils import projects
 
 router = APIRouter(prefix="/projects", tags=["Projects"])
@@ -29,7 +29,7 @@ def get_projects(
     return ProjectListOut.from_player(player)
 
 
-@router.post("", status_code=status.HTTP_200_OK)
+@router.post("", status_code=status.HTTP_200_OK, dependencies=[Depends(reject_when_frozen)])
 def queue_project(
     player: Annotated[Player, Depends(get_settled_player)],
     project: ProjectIn,
@@ -43,7 +43,7 @@ def queue_project(
     return get_projects(player)
 
 
-@router.post("/{project_id}:cancel")
+@router.post("/{project_id}:cancel", dependencies=[Depends(reject_when_frozen)])
 def cancel_project(
     player: Annotated[Player, Depends(get_settled_player)],
     project_id: int,
@@ -60,7 +60,7 @@ def cancel_project(
     return get_projects(player)
 
 
-@router.post("/{project_id}:pause")
+@router.post("/{project_id}:pause", dependencies=[Depends(reject_when_frozen)])
 def request_pause_project(
     player: Annotated[Player, Depends(get_settled_player)],
     project_id: int,
@@ -77,7 +77,7 @@ def request_pause_project(
     return get_projects(player)
 
 
-@router.post("/{project_id}:resume")
+@router.post("/{project_id}:resume", dependencies=[Depends(reject_when_frozen)])
 def request_resume_project(
     player: Annotated[Player, Depends(get_settled_player)],
     project_id: int,
@@ -94,7 +94,7 @@ def request_resume_project(
     return get_projects(player)
 
 
-@router.post("/{project_id}:decrease-priority")
+@router.post("/{project_id}:decrease-priority", dependencies=[Depends(reject_when_frozen)])
 async def decrease_project_priority(
     player: Annotated[Player, Depends(get_settled_player)],
     project_id: int,
@@ -111,7 +111,7 @@ async def decrease_project_priority(
     return get_projects(player)
 
 
-@router.post("/{project_id}:increase-priority")
+@router.post("/{project_id}:increase-priority", dependencies=[Depends(reject_when_frozen)])
 async def increase_project_priority(
     player: Annotated[Player, Depends(get_settled_player)],
     project_id: int,

--- a/energetica/routers/resource_market.py
+++ b/energetica/routers/resource_market.py
@@ -14,7 +14,7 @@ from energetica.schemas.resource_market import (
     DeliveryCalculationResponse,
     PurchaseOrderCreate,
 )
-from energetica.utils.auth import get_settled_player
+from energetica.utils.auth import get_settled_player, reject_when_frozen
 from energetica.utils.resource_market import (
     calculate_shipment_duration,
     create_ask,
@@ -34,7 +34,7 @@ def get_resource_market_asks() -> AskListOut:
     )
 
 
-@router.post("/asks", status_code=201)
+@router.post("/asks", status_code=201, dependencies=[Depends(reject_when_frozen)])
 def post_resource_market_ask(
     player: Annotated[Player, Depends(get_settled_player)],
     request_data: AskCreate,
@@ -50,7 +50,7 @@ def post_resource_market_ask(
     )
 
 
-@router.post("/asks/{ask_id}:purchase")
+@router.post("/asks/{ask_id}:purchase", dependencies=[Depends(reject_when_frozen)])
 def post_resource_market_purchase(
     player: Annotated[Player, Depends(get_settled_player)],
     ask_id: int,
@@ -75,7 +75,7 @@ def post_resource_market_purchase(
     return AskOut.from_resource_on_sale(new_sale)
 
 
-@router.patch("/asks/{ask_id}")
+@router.patch("/asks/{ask_id}", dependencies=[Depends(reject_when_frozen)])
 def patch_resource_market_ask(
     player: Annotated[Player, Depends(get_settled_player)],
     ask_id: int,
@@ -90,7 +90,7 @@ def patch_resource_market_ask(
     )
 
 
-@router.delete("/asks/{ask_id}", status_code=204)
+@router.delete("/asks/{ask_id}", status_code=204, dependencies=[Depends(reject_when_frozen)])
 def delete_resource_market_ask(
     player: Annotated[Player, Depends(get_settled_player)],
     ask_id: int,

--- a/energetica/schemas/game.py
+++ b/energetica/schemas/game.py
@@ -2,7 +2,7 @@
 
 import datetime
 
-from pydantic import BaseModel
+from pydantic import AwareDatetime, BaseModel
 
 
 class GameEngineOut(BaseModel):
@@ -11,3 +11,10 @@ class GameEngineOut(BaseModel):
     start_date: datetime.datetime
     wall_clock_seconds_per_tick: int
     game_seconds_per_tick: int
+    # Lifecycle boundaries (#861), so the in-game app can derive its phase client-side (mirrored
+    # ``derivePhase``) instead of learning about freeze only from a rejected write. Absolute and
+    # tz-aware, sourced from this instance's ``instance.json``; ``null`` on an unconfigured/open-ended
+    # run (dev, or a run with no scheduled end). The in-game freeze UI that consumes these — banner,
+    # disabled controls, countdown — is built in T8 (#866).
+    freeze_at: AwareDatetime | None = None
+    ended_at: AwareDatetime | None = None

--- a/energetica/utils/auth.py
+++ b/energetica/utils/auth.py
@@ -66,6 +66,15 @@ def reject_when_frozen() -> None:
     ``403``s that mean auth failures). This is a **backstop**: a normal client derives its phase
     locally and never fires a frozen write, so the 409 only catches a client whose clock lags the
     freeze boundary, or a stale/scripted one.
+
+    The check is at request entry, not atomic with the mutation, so a request that passes here can
+    have ``freeze_at`` cross before its handler commits — a single in-flight write landing
+    milliseconds into freeze, once, at the exact boundary instant. Accepted by design: freeze is a
+    coarse wall-clock boundary (client-side derivation is the primary gate, this the backstop), an
+    already-submitted action completing at the deadline is the expected behaviour of any deadline,
+    and the recap is a freeze-instant photograph a late write simply isn't part of. Making it
+    airtight would mean re-checking inside each mutation's engine-lock section, which G2 (#860)
+    deliberately rejected in favour of this entry guard.
     """
     if instance_config.current_phase() in ("freeze", "ended"):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=GameExceptionType.INSTANCE_FROZEN)

--- a/energetica/utils/auth.py
+++ b/energetica/utils/auth.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 
 from fastapi import HTTPException, Request, status
 
+from energetica import instance_config
 from energetica.database.player import Player
 from energetica.database.user import User
 from energetica.game_error import GameExceptionType
@@ -47,7 +48,27 @@ __all__ = [
     "get_user",
     "get_playing_user",
     "get_settled_player",
+    "reject_when_frozen",
 ]
+
+
+def reject_when_frozen() -> None:
+    """Path-operation guard: reject game-state mutations once this instance has entered ``freeze``
+    (or ``ended``).
+
+    Attached via ``dependencies=[Depends(reject_when_frozen)]`` on exactly the game-action **write**
+    endpoints (facilities/projects/power-priorities/resource-market/electricity-markets/map-settle/
+    daily-quiz). Reads, and the meta-writes that survive freeze (chat, ``/players/me/settings``,
+    notifications), keep their plain ``get_settled_player`` dependency — the frozen write-set is
+    game-state mutation + the sim tick, nothing else (see G2, #860).
+
+    Fails with ``409 Conflict`` (state, not authorization, forbids the write — distinct from the
+    ``403``s that mean auth failures). This is a **backstop**: a normal client derives its phase
+    locally and never fires a frozen write, so the 409 only catches a client whose clock lags the
+    freeze boundary, or a stale/scripted one.
+    """
+    if instance_config.current_phase() in ("freeze", "ended"):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=GameExceptionType.INSTANCE_FROZEN)
 
 
 def get_user_from_token(token: str) -> User | None:

--- a/energetica/utils/tick_execution.py
+++ b/energetica/utils/tick_execution.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from energetica import instance_config
 from energetica import production_update
 from energetica.database.active_facility import ActiveFacility
 from energetica.database.climate_event_recovery import ClimateEventRecovery
@@ -23,6 +24,13 @@ from energetica.utils.resource_market import store_import
 
 def state_update() -> None:
     """Update the game state on every tick."""
+    # active → freeze self-transition (#861): once this instance's own clock passes ``freeze_at`` the
+    # sim halts — play is over. Checked here, around the catch-up loop, rather than inside ``tick()``:
+    # a short-circuit *inside* ``tick()`` would never advance ``engine.total_t`` and spin the
+    # ``while`` below forever. The named seam (tick_execution) is honoured; the loop is the correct
+    # spot within it. (``announced`` — sim paused before ``starts_at`` — is T4's concern, not gated here.)
+    if instance_config.current_phase() in ("freeze", "ended"):
+        return
     total_t = (time.time() - engine.start_date.timestamp()) / engine.clock_time
     while engine.total_t < total_t - 1 or engine.total_t == 0:
         tick()

--- a/energetica/utils/tick_execution.py
+++ b/energetica/utils/tick_execution.py
@@ -29,6 +29,13 @@ def state_update() -> None:
     # a short-circuit *inside* ``tick()`` would never advance ``engine.total_t`` and spin the
     # ``while`` below forever. The named seam (tick_execution) is honoured; the loop is the correct
     # spot within it. (``announced`` — sim paused before ``starts_at`` — is T4's concern, not gated here.)
+    #
+    # One check before the loop (not inside it) is right: ``total_t`` is the wall-clock-now target
+    # fixed at entry, and each ``tick()`` advances the sim counter *toward* it, so every tick
+    # processed has simulated time ≤ now. If ``freeze_at ≤ now`` we return here; otherwise every tick
+    # the loop runs is pre-``freeze_at`` in sim-time and legitimately belongs to the game — even if a
+    # long post-downtime catch-up executes them a little after ``freeze_at`` in wall-clock. Re-checking
+    # inside the loop would wrongly *drop* that valid pre-freeze catch-up.
     if instance_config.current_phase() in ("freeze", "ended"):
         return
     total_t = (time.time() - engine.start_date.timestamp()) / engine.clock_time

--- a/frontend/src/components/layout/run-switcher.tsx
+++ b/frontend/src/components/layout/run-switcher.tsx
@@ -31,9 +31,15 @@ import {
     lobbyHref,
     runAppHref,
 } from "@/lib/instances";
+import { isSingleOriginHost } from "@/lib/single-origin";
 
 export function RunSwitcher() {
     const { data: runs } = useMyRuns();
+    // On a single-origin proxy host (e.g. energetica.ethz.ch) exactly one run is
+    // reachable and the lobby is the same origin, so every entry this control
+    // offers — lateral run-hops and "Open lobby" — is a no-op that lands back on
+    // this same app. Hide it entirely. See lib/single-origin.ts + ADR-0002.
+    if (isSingleOriginHost()) return null;
     // In a live-backend dev server the hostname is `localhost`, so there is no run in the URL —
     // fall back to the injected slug the proxy is pinned to. When that is set, hopping to any other
     // run would leave the local dev app for a prod origin, so those entries are disabled.

--- a/frontend/src/lib/game-messages.ts
+++ b/frontend/src/lib/game-messages.ts
@@ -39,6 +39,13 @@ export const GAME_ERROR_MESSAGES: Record<GameExceptionType, string> = {
     OLD_PASSWORD_INCORRECT: "The current password you entered is incorrect.",
     INSTANCE_ACCESS_DENIED: "Your account is not allowed on this instance.",
 
+    // --- Lifecycle ---
+    // 409 backstop when a write reaches a frozen instance (#861). Normally unseen: the client
+    // derives its phase locally and stops firing game actions before this fires. The in-game
+    // read-only banner/disabled-controls UI lives in T8 (#866).
+    "Instance is frozen; the game is read-only.":
+        "This game has ended — it's now read-only.",
+
     // --- Location / tile ---
     locationOccupied: "This location is already occupied by another player.",
     choiceUnmodifiable: "Your location choice cannot be changed.",

--- a/frontend/src/lib/instances.ts
+++ b/frontend/src/lib/instances.ts
@@ -10,6 +10,8 @@
  * Visibility & Access.
  */
 
+import { isSingleOriginHost } from "./single-origin";
+
 /**
  * Public projection of an instance. Mirrors the backend `InstanceFragment`
  * model.
@@ -74,7 +76,24 @@ export function derivePhase(run: Lifecycle, now: Date = new Date()): Phase {
  * at build time. Empty during the interim, when the landing is still served
  * same-origin by FastAPI.
  */
-const APEX_DOMAIN = import.meta.env.VITE_APEX_DOMAIN;
+const BUILD_APEX = import.meta.env.VITE_APEX_DOMAIN;
+
+/**
+ * The apex used to build cross-origin links, or `undefined` to force a
+ * same-origin fallback.
+ *
+ * Normally the build-time {@link BUILD_APEX}. Suppressed to `undefined` on a
+ * single-origin proxy host (`lib/single-origin.ts`, ADR-0002 amendment): there,
+ * the lobby and the one reachable instance share ONE origin, so `lobby.{apex}`
+ * and `{slug}.{apex}` do not resolve and every helper below must emit a
+ * same-origin path instead. Routing all apex reads through this one gate means
+ * the existing no-apex fallbacks (`return path` / `"/app"`) cover
+ * `runAppHref`, `lobbyHref`, `currentRunSlug`, and `landingHref` with no
+ * per-helper special-casing.
+ */
+function apexDomain(): string | undefined {
+    return isSingleOriginHost() ? undefined : BUILD_APEX;
+}
 
 const LOBBY_SUBDOMAIN = "lobby.";
 
@@ -112,8 +131,9 @@ export function isValidRunSlug(slug: string): boolean {
  * link beats a cross-origin URL pointing at a host we did not intend.
  */
 export function runAppHref(slug: string): string {
-    if (!APEX_DOMAIN || !isValidRunSlug(slug)) return "/app";
-    return `https://${slug}.${APEX_DOMAIN}/app`;
+    const apex = apexDomain();
+    if (!apex || !isValidRunSlug(slug)) return "/app";
+    return `https://${slug}.${apex}/app`;
 }
 
 /**
@@ -157,7 +177,7 @@ export function resolveLobbyBaseUrl(opts: {
 function lobbyBaseUrl(): string | null {
     return resolveLobbyBaseUrl({
         dev: import.meta.env.DEV,
-        apex: APEX_DOMAIN,
+        apex: apexDomain(),
         lobbyDevUrl: LOBBY_DEV_URL,
     });
 }
@@ -200,8 +220,9 @@ export function devInstanceSlug(): string | null {
  * apex.
  */
 export function currentRunSlug(): string | null {
-    if (!APEX_DOMAIN) return null;
-    const suffix = `.${APEX_DOMAIN}`;
+    const apex = apexDomain();
+    if (!apex) return null;
+    const suffix = `.${apex}`;
     const { hostname } = window.location;
     if (!hostname.endsWith(suffix)) return null;
     const label = hostname.slice(0, -suffix.length);
@@ -240,8 +261,9 @@ export function lobbyLoginHref(): string {
  * @param path Absolute landing path, e.g. `/landing-page`.
  */
 export function landingHref(path: string): string {
-    if (!APEX_DOMAIN) return path;
-    return `https://${APEX_DOMAIN}${path}`;
+    const apex = apexDomain();
+    if (!apex) return path;
+    return `https://${apex}${path}`;
 }
 
 /**

--- a/frontend/src/lib/single-origin.ts
+++ b/frontend/src/lib/single-origin.ts
@@ -1,0 +1,45 @@
+/**
+ * Single-origin proxy hosts.
+ *
+ * Some players sit behind a VPN that cannot reach `*.energetica-game.org` but
+ * can reach a foreign host — `energetica.ethz.ch` — that reverse-proxies the
+ * game. That host fronts the lobby AND a single game instance on **one origin**
+ * (see the ADR-0002 amendment and `scripts/infra/apache-ethz-proxy.conf`),
+ * because the ETHZ domain is not ours to carve subdomains from.
+ *
+ * On such a host the per-subdomain URL scheme (`lobby.{apex}`, `{slug}.{apex}`)
+ * does not resolve, so the frontend must (a) build **same-origin** links instead
+ * of cross-subdomain ones (see `apexDomain()` in `lib/instances.ts`) and
+ * (b) collapse the multi-run chooser — there is exactly one reachable run, so
+ * the picker bounces straight into it and the in-run switcher hides its lateral
+ * hops.
+ *
+ * This is an explicit allowlist, deliberately **not** a heuristic ("hostname
+ * isn't my build-time apex"): it drives auth-adjacent behaviour, so a reviewer
+ * should see exactly which hosts flip it, and adding one is a one-line, reviewed
+ * change. It ships in every bundle and is inert unless the current host is
+ * listed.
+ */
+export const SINGLE_ORIGIN_HOSTS: ReadonlySet<string> = new Set([
+    "energetica.ethz.ch",
+]);
+
+/**
+ * Pure core of {@link isSingleOriginHost}: whether `hostname` is a single-origin
+ * proxy host. Host injected so the rule is unit-testable without stubbing
+ * `window.location`.
+ */
+export function isSingleOrigin(hostname: string): boolean {
+    return SINGLE_ORIGIN_HOSTS.has(hostname);
+}
+
+/**
+ * Whether this bundle is being served from a single-origin proxy host. `false`
+ * outside a browser (SSR / tests) and for every normal deployment origin.
+ */
+export function isSingleOriginHost(): boolean {
+    return (
+        typeof window !== "undefined" &&
+        isSingleOrigin(window.location.hostname)
+    );
+}

--- a/frontend/src/routes-lobby/index.tsx
+++ b/frontend/src/routes-lobby/index.tsx
@@ -17,6 +17,7 @@ import { useInstancesManifest, useMyRuns } from "@/hooks/use-lobby";
 import type { MyRun } from "@/lib/api/lobby";
 import type { InstanceFragment } from "@/lib/instances";
 import { runAppHref, validateReturnSearch } from "@/lib/lobby";
+import { isSingleOriginHost } from "@/lib/single-origin";
 
 export const Route = createFileRoute("/")({
     validateSearch: validateReturnSearch,
@@ -29,21 +30,31 @@ function PickerPage() {
     const myRuns = useMyRuns();
     const instances = useInstancesManifest();
 
-    // `?return=` bounce (client-side by design): once logged in and both run
-    // lists are known, forward a *validated* slug to its run. The URL is
-    // constructed against the fixed apex (runAppHref), never taken from the
-    // parameter — no open redirect. Unknown slugs fall through to the picker.
-    // The target is derived in render (so the spinner below holds while the
-    // cross-origin navigation is in flight, instead of flashing the picker);
-    // the ref keeps the assign one-shot across query refetches.
+    // Where an authenticated player is forwarded, if anywhere. Derived in render
+    // (so the spinner below holds while the navigation is in flight, instead of
+    // flashing the picker); the ref keeps the assign one-shot across refetches.
     let bounceHref: string | null = null;
-    if (returnSlug && myRuns.data && instances.data !== undefined) {
-        const knownSlugs = new Set([
-            ...myRuns.data.runs.map((run) => run.slug),
-            ...instances.data.map((instance) => instance.slug),
-        ]);
-        if (knownSlugs.has(returnSlug)) {
-            bounceHref = runAppHref(returnSlug);
+    if (myRuns.data) {
+        if (isSingleOriginHost()) {
+            // Single-origin proxy host (e.g. energetica.ethz.ch): exactly one
+            // run is reachable through this origin, so the picker's choice is
+            // moot. Send the player straight into the app — the instance's
+            // entry gate provisions/authorises them per its access policy. The
+            // multi-run UI below is never rendered here. See lib/single-origin.ts
+            // and the ADR-0002 amendment.
+            bounceHref = "/app";
+        } else if (returnSlug && instances.data !== undefined) {
+            // `?return=` bounce (client-side by design): once both run lists are
+            // known, forward a *validated* slug to its run. The URL is built
+            // against the fixed apex (runAppHref), never taken from the
+            // parameter — no open redirect. Unknown slugs fall through.
+            const knownSlugs = new Set([
+                ...myRuns.data.runs.map((run) => run.slug),
+                ...instances.data.map((instance) => instance.slug),
+            ]);
+            if (knownSlugs.has(returnSlug)) {
+                bounceHref = runAppHref(returnSlug);
+            }
         }
     }
     const bouncedRef = useRef(false);

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -951,7 +951,7 @@ export interface paths {
         };
         /**
          * Get Engine Config
-         * @description Get game engine configuration including clock time and simulation speed.
+         * @description Get game engine configuration including clock time, simulation speed, and lifecycle boundaries.
          */
         get: operations["get_engine_config_api_v1_game_engine_get"];
         put?: never;
@@ -2537,6 +2537,10 @@ export interface components {
             wall_clock_seconds_per_tick: number;
             /** Game Seconds Per Tick */
             game_seconds_per_tick: number;
+            /** Freeze At */
+            freeze_at?: string | null;
+            /** Ended At */
+            ended_at?: string | null;
         };
         /**
          * GameStateOut
@@ -4223,7 +4227,7 @@ export interface components {
          * GameExceptionType
          * @enum {string}
          */
-        GameExceptionType: "Not enough money" | "TileNotFound" | "noTile" | "noLocation" | "Player has no tile" | "locationOccupied" | "choiceUnmodifiable" | "USERNAME_TAKEN" | "USER_NOT_FOUND" | "INVALID_PASSWORD" | "NOT_AUTHENTICATED" | "USER_IS_NOT_A_PLAYER" | "PLAYER_NOT_SET_UP" | "SIGNUP_DISABLED" | "OLD_PASSWORD_INCORRECT" | "INSTANCE_ACCESS_DENIED" | "InvalidMultiplier" | "malformedRequest" | "storagePriceInversion" | "Project not found" | "CannotDecreasePriorityOfLastProject" | "CannotIncreasePriorityOfFirstProject" | "requirementsPreventReorder" | "cannotPause" | "cannotResume" | "CannotSwapPausedProject" | "PausedPrerequisitePreventUnpause" | "Requirements not satisfied" | "HasDependents" | "Facility not upgradable" | "FacilityIsDecommissioning" | "Facility not found" | "Cannot remove technologies or functional facilities" | "wrongTitleLength" | "chatAlreadyExist" | "notInChat" | "noMessage" | "messageTooLong" | "quizAlreadyAnswered" | "networkNotUnlocked" | "noSuchNetwork" | "playerAlreadyInNetwork" | "nameAlreadyUsed" | "notInNetwork" | "networkFull" | "notEnoughResource" | "invalidQuantity";
+        GameExceptionType: "Not enough money" | "TileNotFound" | "noTile" | "noLocation" | "Player has no tile" | "locationOccupied" | "choiceUnmodifiable" | "USERNAME_TAKEN" | "USER_NOT_FOUND" | "INVALID_PASSWORD" | "NOT_AUTHENTICATED" | "USER_IS_NOT_A_PLAYER" | "PLAYER_NOT_SET_UP" | "SIGNUP_DISABLED" | "OLD_PASSWORD_INCORRECT" | "INSTANCE_ACCESS_DENIED" | "Instance is frozen; the game is read-only." | "InvalidMultiplier" | "malformedRequest" | "storagePriceInversion" | "Project not found" | "CannotDecreasePriorityOfLastProject" | "CannotIncreasePriorityOfFirstProject" | "requirementsPreventReorder" | "cannotPause" | "cannotResume" | "CannotSwapPausedProject" | "PausedPrerequisitePreventUnpause" | "Requirements not satisfied" | "HasDependents" | "Facility not upgradable" | "FacilityIsDecommissioning" | "Facility not found" | "Cannot remove technologies or functional facilities" | "wrongTitleLength" | "chatAlreadyExist" | "notInChat" | "noMessage" | "messageTooLong" | "quizAlreadyAnswered" | "networkNotUnlocked" | "noSuchNetwork" | "playerAlreadyInNetwork" | "nameAlreadyUsed" | "notInNetwork" | "networkFull" | "notEnoughResource" | "invalidQuantity";
     };
     responses: never;
     parameters: never;

--- a/tests/unit/test_freeze_enforcement.py
+++ b/tests/unit/test_freeze_enforcement.py
@@ -1,0 +1,55 @@
+"""Unit tests for the active → freeze self-enforcement (#861, T3).
+
+Two seams, both keyed off ``instance_config.current_phase``:
+
+- ``reject_when_frozen`` — the game-action write-gate (409 once the instance is frozen/ended).
+- ``state_update`` — the sim tick halts once frozen (play is over).
+
+Both are exercised here by monkeypatching the phase, so the tests need neither a real on-disk
+config nor a running engine.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException, status
+
+from energetica import instance_config
+from energetica.game_error import GameExceptionType
+from energetica.utils import auth, tick_execution
+
+
+@pytest.mark.parametrize("frozen_phase", ["freeze", "ended"])
+def test_reject_when_frozen_raises_409(monkeypatch: pytest.MonkeyPatch, frozen_phase: str) -> None:
+    """A game-action write is rejected with a 409 once the instance is frozen/ended.
+
+    The detail is the honest read-only signal — distinct from the 403s that mean auth failures.
+    """
+    monkeypatch.setattr(instance_config, "current_phase", lambda: frozen_phase)
+    with pytest.raises(HTTPException) as excinfo:
+        auth.reject_when_frozen()
+    assert excinfo.value.status_code == status.HTTP_409_CONFLICT
+    assert excinfo.value.detail == GameExceptionType.INSTANCE_FROZEN
+
+
+@pytest.mark.parametrize("live_phase", ["announced", "active"])
+def test_reject_when_frozen_allows_live_game(monkeypatch: pytest.MonkeyPatch, live_phase: str) -> None:
+    """While the game is live (announced/active), the write-gate is a no-op — writes pass through."""
+    monkeypatch.setattr(instance_config, "current_phase", lambda: live_phase)
+    assert auth.reject_when_frozen() is None
+
+
+@pytest.mark.parametrize("frozen_phase", ["freeze", "ended"])
+def test_state_update_halts_sim_when_frozen(monkeypatch: pytest.MonkeyPatch, frozen_phase: str) -> None:
+    """The sim tick stops once the instance's own clock passes freeze_at.
+
+    state_update returns without ticking. (Checked around the catch-up loop, not inside tick(), which
+    would otherwise spin forever since a short-circuited tick never advances total_t.)
+    """
+    monkeypatch.setattr(tick_execution.instance_config, "current_phase", lambda: frozen_phase)
+
+    def _fail_if_ticked() -> None:
+        raise AssertionError("tick() must not run once the instance is frozen")
+
+    monkeypatch.setattr(tick_execution, "tick", _fail_if_ticked)
+    tick_execution.state_update()  # returns cleanly; the AssertionError above would fire if it ticked

--- a/tests/unit/test_instance_config.py
+++ b/tests/unit/test_instance_config.py
@@ -445,3 +445,28 @@ def test_equal_timestamps_allowed() -> None:
         {**LIFECYCLE_JSON, "freeze_at": "2026-02-01T00:00:00Z", "ended_at": "2026-02-01T00:00:00Z"}
     )
     assert config.freeze_at == config.ended_at
+
+
+def test_current_phase_reads_own_config(configured: Path) -> None:
+    """current_phase derives this instance's live phase from its on-disk config (#861) — the source
+    both the sim halt and the write-gate key off.
+    """
+    _write_instance_json(configured, LIFECYCLE_JSON)
+    assert instance_config.current_phase(datetime(2026, 1, 15, tzinfo=timezone.utc)) == "active"
+    assert instance_config.current_phase(datetime(2026, 2, 15, tzinfo=timezone.utc)) == "freeze"
+    assert instance_config.current_phase(datetime(2026, 4, 1, tzinfo=timezone.utc)) == "ended"
+
+
+def test_current_phase_unconfigured_is_active(configured: Path) -> None:
+    """No instance.json (dev/legacy, open-ended run) → active: an unconfigured instance never freezes."""
+    assert instance_config.current_phase(datetime(2026, 4, 1, tzinfo=timezone.utc)) == "active"
+
+
+def test_current_phase_broken_config_fails_open_to_active(configured: Path) -> None:
+    """A present-but-broken config fails **open** to active.
+
+    A config typo must not silently freeze a live game. (The login path fails *closed* on the same
+    file; freeze is entered only on a positive clock signal, never on an error.)
+    """
+    _write_instance_json(configured, "{ not valid json")
+    assert instance_config.current_phase(datetime(2026, 4, 1, tzinfo=timezone.utc)) == "active"


### PR DESCRIPTION
Resolves **T3 · Freeze self-enforcement at freeze_at** (#861) of the [Server lifecycle map (#856)](https://github.com/felixvonsamson/Energetica/issues/856).

Once an instance's own clock passes `freeze_at`, it self-transitions `active → freeze`: the **sim tick halts** and **game-state writes fail closed** with a `409`, while **all reads** and the meta-writes that survive freeze (**chat, settings, notifications**) stay live. This is the read-only surface decided in **G2 (#860)**, keyed off the derived phase from **T1 (#857)**.

## What's here (backend enforcement + data exposure)
- **`instance_config.current_phase()`** — the instance's live phase from its own `instance.json`, re-read each call so an admin editing `freeze_at` force-freezes with **no restart**. Fails **open** to `active` when unconfigured (dev/open-ended) or the config is broken — a typo must not silently freeze a live game; freeze is entered only on a positive clock signal.
- **Sim halt** — `state_update` returns early when phase is `freeze`/`ended`. Checked around the catch-up loop, not inside `tick()` (which would spin forever, since a short-circuited tick never advances `total_t`).
- **Write-gate** — `reject_when_frozen` dependency raises `409 Conflict` / `GameExceptionType.INSTANCE_FROZEN` on exactly the **23 game-action write endpoints** (facilities, projects, power-priorities, resource-market asks/purchase/patch/delete, electricity-markets, map-settle, daily-quiz). Reads, chat, `/players/me/settings`, notifications, and the read-like `:calculate-delivery` stay open. A **backstop** — a normal client derives its phase locally and never fires a frozen write.
- **`GameEngineOut`** now carries `freeze_at`/`ended_at` so the in-game app can derive its phase client-side.

## Scope boundary (T3 vs T8)
T3 is the **backend** self-enforcement + the lifecycle data exposure. The in-game **UI** consuming it — freeze banner, disabled-in-place controls, countdown, soft self-heal on the 409 — lives in **T8 (#866)**, which already owns in-game lifecycle UI and must coordinate the banner. `game-messages.ts` gets the 409's fallback copy so the toast map stays complete.

## Verification
- `bun run typecheck` / `lint` / `format` and `ruff` green; `bun run generate-types` applied.
- New unit tests (`tests/unit/test_freeze_enforcement.py`, additions to `test_instance_config.py`): `current_phase` across phases/unconfigured/broken, `reject_when_frozen` 409-vs-passthrough, `state_update` halt. 49 passing.
- Route introspection confirms exactly the 23 intended writes guarded, **0 reads/chat/settings/notifications guarded**.
- The 5 pre-existing suite failures (`test_server_runs`, `test_daily_quiz_links`) are environmental (missing `python` on PATH, external URLs) and identical on the base branch.

**Stacked on the T1 branch** (`feat/856-t1-lifecycle-timestamps`, #867) — this PR targets it, not `main`; rebase onto `main` once T1 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds backend lifecycle freeze enforcement and exposes lifecycle data to clients.

- Derives the live instance phase from `instance.json`.
- Rejects selected game-action writes after freeze.
- Stops scheduled simulation updates when frozen.
- Adds lifecycle timestamps to the game engine response.
- Adds single-origin proxy link handling in the frontend.

<h3>Confidence Score: 5/5</h3>

No additional blocking issue was identified in the updated code.

- The lifecycle enforcement paths match the intended freeze behavior.
- The client-facing lifecycle fields and generated API types are aligned.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/instance_config.py | Adds a live phase lookup based on the instance lifecycle configuration. |
| energetica/utils/auth.py | Adds a dependency that rejects selected game-state writes in frozen and ended phases. |
| energetica/utils/tick_execution.py | Adds lifecycle gating before scheduled simulation updates. |
| frontend/src/lib/instances.ts | Routes instance and lobby links through single-origin-aware URL generation. |

<sub>Reviews (2): Last reviewed commit: ["docs(lifecycle): note the accepted freez..."](https://github.com/felixvonsamson/energetica/commit/2d5a67ec60f2fef50c474c61dc818553592191a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44307918)</sub>

<!-- /greptile_comment -->