### PR TITLE
refactor(market): extract pure player-agnostic clearing seam (S1)

### DIFF
--- a/energetica/market.py
+++ b/energetica/market.py
@@ -10,9 +10,9 @@ Because clearing never reads ``MarketEntry.player_id``, a caller can inject a
 demand bid backed by no player at all (e.g. a Workshop-mode demand block) and
 still get a well-defined clearing out.
 
-NOTE: the historical naming is inverted vs. finance — :func:`place_bid` adds
-*supply* (an offer), :func:`place_ask` adds *demand*. Left as-is to keep this a
-behaviour-preserving extraction; flipping to ask/bid is a candidate follow-up.
+Naming follows finance convention: :func:`place_ask` adds *supply* (a seller's
+offer, into ``capacities``); :func:`place_bid` adds *demand* (a buyer's bid, into
+``demands``).
 """
 
 from __future__ import annotations
@@ -40,15 +40,15 @@ def init_market() -> dict:
     }
 
 
-def place_bid(market: dict, player_id: int, capacity: float, price: float, facility: str) -> dict:
-    """Make a bid (offer, supply) on the market."""
+def place_ask(market: dict, player_id: int, capacity: float, price: float, facility: str) -> dict:
+    """Make an ask (offer, supply) on the market."""
     if capacity > 0:
         market["capacities"].append(MarketEntry(player_id, capacity, price, facility))
     return market
 
 
-def place_ask(market: dict, player_id: int, demand: float, price: float, facility: str) -> dict:
-    """Make an ask (demand) on the market."""
+def place_bid(market: dict, player_id: int, demand: float, price: float, facility: str) -> dict:
+    """Make a bid (demand) on the market."""
     if demand > 0:
         market["demands"].append(MarketEntry(player_id, demand, price, facility))
     return market

--- a/energetica/market.py
+++ b/energetica/market.py
@@ -61,6 +61,24 @@ class Fill:
     entry: MarketEntry
     cleared: float  # MW sold (offer) or bought (demand), clamped to [0, entry.capacity]
 
+    @classmethod
+    def from_entry(cls, entry: MarketEntry, quantity: float) -> Fill:
+        """Build the fill for ``entry`` given the market cleared ``quantity`` MW.
+
+        Entries whose cumulative capacity sits at or below ``quantity`` clear in full;
+        the marginal (price-setting) entry clears partially; entries past it clear nothing.
+        """
+        if entry.cumul_capacities > quantity:
+            cleared = max(0.0, min(entry.capacity, entry.capacity - entry.cumul_capacities + quantity))
+        else:
+            cleared = entry.capacity
+        return cls(entry, cleared)
+
+    @property
+    def unmet(self) -> float:
+        """MW that was offered (supply) or bid (demand) but did not clear."""
+        return self.entry.capacity - self.cleared
+
 
 @dataclass(frozen=True, slots=True)
 class MarketClearing:
@@ -71,17 +89,6 @@ class MarketClearing:
     offers: list[Fill]  # sorted ascending by price; each entry's cumul_capacities is set
     demands: list[Fill]  # sorted descending by price; each entry's cumul_capacities is set
     unserved: float  # market-level MW of demand that was bid but did not clear (total demand - cleared demand)
-
-
-def _cleared_mw(entry: MarketEntry, quantity: float) -> float:
-    """MW of ``entry`` that clears at the intersection, clamped to ``[0, capacity]``.
-
-    Entries whose cumulative capacity sits at or below ``quantity`` clear in full;
-    the marginal (price-setting) entry clears partially; entries past it clear nothing.
-    """
-    if entry.cumul_capacities > quantity:
-        return max(0.0, min(entry.capacity, entry.capacity - entry.cumul_capacities + quantity))
-    return entry.capacity
 
 
 def clear_market(offers: list[MarketEntry], demands: list[MarketEntry]) -> MarketClearing:
@@ -109,9 +116,9 @@ def clear_market(offers: list[MarketEntry], demands: list[MarketEntry]) -> Marke
 
     price, quantity = market_optimum(sorted_offers, sorted_demands)
 
-    offer_fills = [Fill(entry, _cleared_mw(entry, quantity)) for entry in sorted_offers]
-    demand_fills = [Fill(entry, _cleared_mw(entry, quantity)) for entry in sorted_demands]
-    unserved = sum(fill.entry.capacity - fill.cleared for fill in demand_fills)
+    offer_fills = [Fill.from_entry(entry, quantity) for entry in sorted_offers]
+    demand_fills = [Fill.from_entry(entry, quantity) for entry in sorted_demands]
+    unserved = sum(fill.unmet for fill in demand_fills)
 
     return MarketClearing(price, quantity, offer_fills, demand_fills, unserved)
 

--- a/energetica/market.py
+++ b/energetica/market.py
@@ -1,0 +1,150 @@
+"""Electricity market construction and uniform-price clearing.
+
+Pure and player-agnostic: nothing in this module reads ``Player``, engine state,
+``new_values``, or touches I/O. Given supply offers and demand bids it finds the
+uniform clearing price and quantity and reports, per entry, how much cleared —
+plus the market-level unserved demand. *Settlement* (money, generation,
+curtailment, chart data) is the caller's job and lives in ``production_update``.
+
+Because clearing never reads ``MarketEntry.player_id``, a caller can inject a
+demand bid backed by no player at all (e.g. a Workshop-mode demand block) and
+still get a well-defined clearing out.
+
+NOTE: the historical naming is inverted vs. finance — :func:`place_bid` adds
+*supply* (an offer), :func:`place_ask` adds *demand*. Left as-is to keep this a
+behaviour-preserving extraction; flipping to ask/bid is a candidate follow-up.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+class MarketEntry:
+    __slots__ = ("player_id", "capacity", "price", "facility", "cumul_capacities")
+
+    def __init__(self, player_id: int, capacity: float, price: float, facility: str) -> None:
+        self.player_id = player_id
+        self.capacity = capacity
+        self.price = price
+        self.facility = facility
+        self.cumul_capacities = 0.0
+
+
+def init_market() -> dict:
+    """Initialize an empty market."""
+    return {
+        "capacities": [],
+        "demands": [],
+    }
+
+
+def place_bid(market: dict, player_id: int, capacity: float, price: float, facility: str) -> dict:
+    """Make a bid (offer, supply) on the market."""
+    if capacity > 0:
+        market["capacities"].append(MarketEntry(player_id, capacity, price, facility))
+    return market
+
+
+def place_ask(market: dict, player_id: int, demand: float, price: float, facility: str) -> dict:
+    """Make an ask (demand) on the market."""
+    if demand > 0:
+        market["demands"].append(MarketEntry(player_id, demand, price, facility))
+    return market
+
+
+@dataclass(frozen=True, slots=True)
+class Fill:
+    """One market entry paired with how much of it cleared at the market price."""
+
+    entry: MarketEntry
+    cleared: float  # MW sold (offer) or bought (demand), clamped to [0, entry.capacity]
+
+
+@dataclass(frozen=True, slots=True)
+class MarketClearing:
+    """Result of a uniform-price clearing. Pure data — carries no Player references."""
+
+    price: float  # uniform clearing price
+    quantity: float  # total cleared MW at the supply/demand intersection
+    offers: list[Fill]  # sorted ascending by price; each entry's cumul_capacities is set
+    demands: list[Fill]  # sorted descending by price; each entry's cumul_capacities is set
+    unserved: float  # market-level MW of demand that was bid but did not clear (total demand - cleared demand)
+
+
+def _cleared_mw(entry: MarketEntry, quantity: float) -> float:
+    """MW of ``entry`` that clears at the intersection, clamped to ``[0, capacity]``.
+
+    Entries whose cumulative capacity sits at or below ``quantity`` clear in full;
+    the marginal (price-setting) entry clears partially; entries past it clear nothing.
+    """
+    if entry.cumul_capacities > quantity:
+        return max(0.0, min(entry.capacity, entry.capacity - entry.cumul_capacities + quantity))
+    return entry.capacity
+
+
+def clear_market(offers: list[MarketEntry], demands: list[MarketEntry]) -> MarketClearing:
+    """Clear a uniform-price market.
+
+    Sorts offers ascending and demands descending by price, sets each entry's
+    ``cumul_capacities``, finds the clearing price and quantity via
+    :func:`market_optimum`, then reports per-entry cleared MW and the
+    market-level unserved demand.
+
+    Mutates the passed entries' ``cumul_capacities`` in place — the caller's
+    chart serialization relies on the merit-order position being recorded there.
+    """
+    sorted_offers = sorted(offers, key=lambda e: e.price)
+    cumul = 0.0
+    for entry in sorted_offers:
+        cumul += entry.capacity
+        entry.cumul_capacities = cumul
+
+    sorted_demands = sorted(demands, key=lambda e: e.price, reverse=True)
+    cumul = 0.0
+    for entry in sorted_demands:
+        cumul += entry.capacity
+        entry.cumul_capacities = cumul
+
+    price, quantity = market_optimum(sorted_offers, sorted_demands)
+
+    offer_fills = [Fill(entry, _cleared_mw(entry, quantity)) for entry in sorted_offers]
+    demand_fills = [Fill(entry, _cleared_mw(entry, quantity)) for entry in sorted_demands]
+    unserved = sum(fill.entry.capacity - fill.cleared for fill in demand_fills)
+
+    return MarketClearing(price, quantity, offer_fills, demand_fills, unserved)
+
+
+def market_optimum(offers: list[MarketEntry], demands: list[MarketEntry]) -> tuple[float, float]:
+    """Find market price and quantity by finding the intersection of demand and supply."""
+    if not demands or not offers:
+        return 0, 0
+
+    price_d = demands[0].price
+    price_o = offers[0].price
+
+    if price_o > price_d:
+        return price_d, 0
+
+    # Build merged event list: (cumul_capacity, is_offer, next_step_price)
+    # For offers (sorted ascending): next step price is the price of the next row (or +inf for last)
+    # For demands (sorted descending): next step price is the price of the next row (or -6 for last)
+    events: list[tuple[float, bool, float]] = []
+    for i, entry in enumerate(offers):
+        next_price = offers[i + 1].price if i + 1 < len(offers) else math.inf
+        events.append((entry.cumul_capacities, True, next_price))
+    for i, entry in enumerate(demands):
+        next_price = demands[i + 1].price if i + 1 < len(demands) else -6.0
+        events.append((entry.cumul_capacities, False, next_price))
+
+    events.sort(key=lambda e: e[0])
+
+    for cumul, is_offer, next_price in events:
+        if is_offer:
+            price_o = next_price
+        else:
+            price_d = next_price
+        if price_d < price_o:
+            return (price_d if is_offer else price_o), cumul
+    raise ValueError("No market optimum found.")

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -31,6 +31,7 @@ from energetica.enums import (
     power_facility_types,
 )
 from energetica.globals import engine
+from energetica.market import clear_market, init_market, place_ask, place_bid
 from energetica.schemas.electricity_markets import AskType
 from energetica.schemas.notifications import NetworkExpelledPayload, NetworkOverdraftWarningPayload
 from energetica.utils import network_helpers
@@ -216,26 +217,6 @@ def update_player_progress_values(player: Player, new_values: dict) -> None:
     )
 
     player.check_continuous_achievements()
-
-
-class _MarketEntry:
-    __slots__ = ("player_id", "capacity", "price", "facility", "cumul_capacities")
-
-    def __init__(self, player_id: int, capacity: float, price: float, facility: str) -> None:
-        self.player_id = player_id
-        self.capacity = capacity
-        self.price = price
-        self.facility = facility
-        self.cumul_capacities = 0.0
-
-
-def init_market() -> dict:
-    # TODO (Felix): should be moved somewhere else, e.g. create a Market class in market.py (new) ?
-    """Initialize an empty market."""
-    return {
-        "capacities": [],
-        "demands": [],
-    }
 
 
 def update_storage_lvls(new_values: dict, player: Player) -> None:
@@ -572,26 +553,22 @@ def market_logic(new_values: dict, market: dict) -> None:
     market["generation"] = {}
     market["consumption"] = {}
 
-    offers = sorted(market["capacities"], key=lambda e: e.price)
-    cumul = 0.0
-    for entry in offers:
-        cumul += entry.capacity
-        entry.cumul_capacities = cumul
+    # Pure clearing: find the price/quantity and per-entry cleared MW. Settling the
+    # consequences onto players (money, generation, curtailment, chart data) is what
+    # the loops below do — that half stays here because it is Player-coupled.
+    clearing = clear_market(market["capacities"], market["demands"])
+    market_price = clearing.price
+    market_quantity = clearing.quantity
+    # Write the sorted, cumul-populated entries back so the chart serialization
+    # further up in update_electricity() dumps them in merit order.
+    market["capacities"] = [fill.entry for fill in clearing.offers]
+    market["demands"] = [fill.entry for fill in clearing.demands]
 
-    demands = sorted(market["demands"], key=lambda e: e.price, reverse=True)
-    cumul = 0.0
-    for entry in demands:
-        cumul += entry.capacity
-        entry.cumul_capacities = cumul
-
-    market["capacities"] = offers
-    market["demands"] = demands
-
-    market_price, market_quantity = market_optimum(offers, demands)
     # sell all capacities under market price
-    for row in offers:
+    for fill in clearing.offers:
+        row = fill.entry
         if row.cumul_capacities > market_quantity:
-            sold_cap = row.capacity - row.cumul_capacities + market_quantity
+            sold_cap = fill.cleared
             if sold_cap > 0.1:
                 sell(row, market_price, quantity=sold_cap)
             # dumping electricity that is offered at the minimal price and not sold
@@ -610,9 +587,10 @@ def market_logic(new_values: dict, market: dict) -> None:
             break
         sell(row, market_price)
     # buy all demands over market price
-    for row in demands:
+    for fill in clearing.demands:
+        row = fill.entry
         if row.cumul_capacities > market_quantity:
-            bought_cap = row.capacity - row.cumul_capacities + market_quantity
+            bought_cap = fill.cleared
             if bought_cap > 0.1:
                 buy(row, market_price, quantity=bought_cap)
             # measures a taken to reduce demand
@@ -626,41 +604,6 @@ def market_logic(new_values: dict, market: dict) -> None:
             buy(row, market_price)
     market["market_price"] = market_price
     market["market_quantity"] = market_quantity
-
-
-def market_optimum(offers: list[_MarketEntry], demands: list[_MarketEntry]) -> tuple[float, float]:
-    # TODO (Felix) : Move to market.py (new)
-    """Find market price and quantity by finding the intersection of demand and supply."""
-    if not demands or not offers:
-        return 0, 0
-
-    price_d = demands[0].price
-    price_o = offers[0].price
-
-    if price_o > price_d:
-        return price_d, 0
-
-    # Build merged event list: (cumul_capacity, is_offer, next_step_price)
-    # For offers (sorted ascending): next step price is the price of the next row (or +inf for last)
-    # For demands (sorted descending): next step price is the price of the next row (or -6 for last)
-    events: list[tuple[float, bool, float]] = []
-    for i, entry in enumerate(offers):
-        next_price = offers[i + 1].price if i + 1 < len(offers) else math.inf
-        events.append((entry.cumul_capacities, True, next_price))
-    for i, entry in enumerate(demands):
-        next_price = demands[i + 1].price if i + 1 < len(demands) else -6.0
-        events.append((entry.cumul_capacities, False, next_price))
-
-    events.sort(key=lambda e: e[0])
-
-    for cumul, is_offer, next_price in events:
-        if is_offer:
-            price_o = next_price
-        else:
-            price_d = next_price
-        if price_d < price_o:
-            return (price_d if is_offer else price_o), cumul
-    raise ValueError("No market optimum found.")
 
 
 def renewables_generation(player: Player, generation: dict) -> None:
@@ -835,22 +778,6 @@ def minimal_generation(player: Player, generation: dict, resource_reservations: 
             )
 
 
-def place_bid(market: dict, player_id: int, capacity: float, price: float, facility: str) -> dict:
-    # TODO (Felix): should be moved somewhere else, e.g. market.py (new) ?
-    """Make an bid (offer, supply) on the market."""
-    if capacity > 0:
-        market["capacities"].append(_MarketEntry(player_id, capacity, price, facility))
-    return market
-
-
-def place_ask(market: dict, player_id: int, demand: float, price: float, facility: str) -> dict:
-    # TODO (Felix): should be moved somewhere else, e.g. market.py (new) ?
-    """Make an ask (demand) on the market."""
-    if demand > 0:
-        market["demands"].append(_MarketEntry(player_id, demand, price, facility))
-    return market
-
-
 def resources_and_pollution(new_values: dict, player: Player) -> None:
     """Calculate resource use and production, O&M costs and emissions."""
     assert player is not None
@@ -867,9 +794,7 @@ def resources_and_pollution(new_values: dict, player: Player) -> None:
                     fuel = Fuel(fuel)
                     quantity = amount * generation[facility] / power
                     player.resources[fuel] -= quantity
-                facility_emissions = (
-                    player.capacities[facility]["pollution"] * generation[facility] / power
-                )
+                facility_emissions = player.capacities[facility]["pollution"] * generation[facility] / power
                 add_emissions(new_values, player, facility, facility_emissions)
 
     if player.functional_facility_lvl[FunctionalFacilityType.WAREHOUSE] > 0:

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -412,7 +412,7 @@ def calculate_generation_without_market(new_values: dict, player: Player) -> flo
     # Obligatory generation is put on the internal market at a price of -5
     for facility in (*StorageFacilityType, *power_facility_types):
         if facility in player.capacities:
-            internal_market = place_bid(
+            internal_market = place_ask(
                 internal_market,
                 player.id,
                 generation[facility],
@@ -424,7 +424,7 @@ def calculate_generation_without_market(new_values: dict, player: Player) -> flo
     for bid_type in player.network_prices.bid_prices.keys():
         if bid_type in demand:
             price = player.network_prices.bid_prices[bid_type]
-            internal_market = place_ask(
+            internal_market = place_bid(
                 internal_market,
                 player.id,
                 demand[bid_type],
@@ -444,7 +444,7 @@ def calculate_generation_without_market(new_values: dict, player: Player) -> flo
             )
             price = player.network_prices.ask_prices[facility]
             capacity = max_prod - generation[facility]
-            internal_market = place_bid(internal_market, player.id, capacity, price, facility)
+            internal_market = place_ask(internal_market, player.id, capacity, price, facility)
 
     market_logic(new_values, internal_market)
     return internal_market["market_price"]  # type: ignore[return-value]
@@ -461,7 +461,7 @@ def calculate_generation_with_market(new_values: dict, market: dict, player: Pla
     # offer minimal generation capacities of facilities on the market at a negative price
     for facility in (*StorageFacilityType, *power_facility_types):
         if player.capacities.get(facility) is not None:
-            market = place_bid(market, player.id, generation[facility], -5, facility)
+            market = place_ask(market, player.id, generation[facility], -5, facility)
 
     # ask demand on the market at the set prices
     # TODO (Felix): Ideally, we would want to get rid of calls of network prices as iterators everywhere where they
@@ -470,7 +470,7 @@ def calculate_generation_with_market(new_values: dict, market: dict, player: Pla
         if demand_type in demand:
             bid_q = demand[demand_type]
             price = player.network_prices.bid_prices[demand_type]
-            market = place_ask(market, player.id, bid_q, price, demand_type)
+            market = place_bid(market, player.id, bid_q, price, demand_type)
 
     resource_reservations = reset_resource_reservations()
     # offer capacities of remaining facilities on the market
@@ -487,7 +487,7 @@ def calculate_generation_with_market(new_values: dict, market: dict, player: Pla
             )
             price = player.network_prices.ask_prices[facility]  # type: ignore
             capacity = max_prod - generation[facility]
-            market = place_bid(market, player.id, capacity, price, facility)
+            market = place_ask(market, player.id, capacity, price, facility)
 
     return market
 

--- a/energetica/production_update.py
+++ b/energetica/production_update.py
@@ -493,7 +493,6 @@ def calculate_generation_with_market(new_values: dict, market: dict, player: Pla
 
 
 def market_logic(new_values: dict, market: dict) -> None:
-    # TODO (Felix): should be moved somewhere else, e.g. market.py (new)
     """
     Perform the market logic for a network.
 
@@ -878,7 +877,6 @@ def construction_emissions(new_values: dict, player: Player) -> None:
 
 
 def reduce_demand(new_values: dict, demand_type: str, player_id: int, satisfaction: float) -> None:
-    # TODO (Felix): should be moved somewhere else, e.g. market.py (new) ?
     """
     Take measures to reduce power demand.
 

--- a/tests/unit/test_market_clearing.py
+++ b/tests/unit/test_market_clearing.py
@@ -62,8 +62,12 @@ def test_unserved_is_all_demand_that_did_not_clear() -> None:
     total_demand = 150 + 100
     assert clearing.unserved == total_demand - clearing.quantity
     assert clearing.unserved == 100
-    # the sub-clearing-price demand is the unmet one; each fill's shortfall sums to `unserved`
-    assert sum(f.entry.capacity - f.cleared for f in clearing.demands) == clearing.unserved
+    # demands come back sorted descending by price: the €80 bid is served, the €30 bid is not
+    served, curtailed = clearing.demands
+    assert served.entry.price == 80
+    assert served.unmet == 0
+    assert curtailed.entry.price == 30
+    assert curtailed.unmet == 100
 
 
 def test_cleared_is_clamped_to_capacity_beyond_the_margin() -> None:

--- a/tests/unit/test_market_clearing.py
+++ b/tests/unit/test_market_clearing.py
@@ -1,0 +1,128 @@
+"""Unit tests for the extracted uniform-price market clearing (issue #873, S1).
+
+The point of the extraction is that ``clear_market`` is *pure and player-agnostic*:
+it finds the price/quantity and per-entry cleared MW without ever reading
+``MarketEntry.player_id`` — so it can be exercised here with no ``Player``, no DB,
+and no engine, and a future caller can inject a demand bid backed by no player at all.
+"""
+
+from __future__ import annotations
+
+from energetica.market import MarketEntry, clear_market, market_optimum, place_ask, place_bid
+
+
+def _offer(capacity: float, price: float, player_id: int = 0) -> MarketEntry:
+    return MarketEntry(player_id, capacity, price, "facility")
+
+
+def _demand(capacity: float, price: float, player_id: int = 0) -> MarketEntry:
+    return MarketEntry(player_id, capacity, price, "demand")
+
+
+def test_clears_without_any_player() -> None:
+    """The whole seam: clear a market whose entries reference no real player.
+
+    ``player_id`` here is a sentinel that ``Player.get`` would fail on — the fact
+    that clearing returns cleanly proves it never touches the player layer.
+    """
+    offers = [_offer(100, 10, player_id=-1), _offer(100, 50, player_id=-1)]
+    demands = [_demand(150, 80, player_id=-999), _demand(100, 30, player_id=-999)]
+
+    clearing = clear_market(offers, demands)
+
+    assert clearing.price == 50
+    assert clearing.quantity == 150
+
+
+def test_marginal_offer_is_partially_cleared() -> None:
+    """The price-setting offer clears only up to the intersection quantity."""
+    offers = [_offer(100, 10), _offer(100, 50)]
+    demands = [_demand(150, 80), _demand(100, 30)]
+
+    clearing = clear_market(offers, demands)
+
+    # offers come back sorted ascending by price
+    cheap, marginal = clearing.offers
+    assert cheap.entry.price == 10
+    assert cheap.cleared == 100  # fully in-merit
+    assert marginal.entry.price == 50
+    assert marginal.cleared == 50  # 100 - cumul(200) + quantity(150)
+    assert sum(f.cleared for f in clearing.offers) == clearing.quantity
+
+
+def test_unserved_is_all_demand_that_did_not_clear() -> None:
+    """Unserved = total demand bid minus demand cleared — the quantity today's
+    ``reduce_demand`` consumes silently, now reported additively.
+    """
+    offers = [_offer(100, 10), _offer(100, 50)]
+    demands = [_demand(150, 80), _demand(100, 30)]
+
+    clearing = clear_market(offers, demands)
+
+    total_demand = 150 + 100
+    assert clearing.unserved == total_demand - clearing.quantity
+    assert clearing.unserved == 100
+    # the sub-clearing-price demand is the unmet one; each fill's shortfall sums to `unserved`
+    assert sum(f.entry.capacity - f.cleared for f in clearing.demands) == clearing.unserved
+
+
+def test_cleared_is_clamped_to_capacity_beyond_the_margin() -> None:
+    """Offers past the marginal one clear nothing — never a negative fill."""
+    offers = [_offer(50, 10), _offer(50, 20), _offer(50, 90)]
+    demands = [_demand(60, 100)]
+
+    clearing = clear_market(offers, demands)
+
+    assert clearing.quantity == 60
+    assert all(0.0 <= f.cleared <= f.entry.capacity for f in clearing.offers)
+    # third offer (price 90) sits entirely past the intersection
+    assert clearing.offers[2].entry.price == 90
+    assert clearing.offers[2].cleared == 0.0
+
+
+def test_empty_market_clears_to_zero() -> None:
+    clearing = clear_market([], [])
+    assert clearing.price == 0
+    assert clearing.quantity == 0
+    assert clearing.offers == []
+    assert clearing.demands == []
+    assert clearing.unserved == 0
+
+
+def test_no_cross_serves_nothing() -> None:
+    """When the cheapest offer is dearer than the priciest bid, nothing clears and
+    all demand is unserved.
+    """
+    offers = [_offer(100, 90)]
+    demands = [_demand(80, 40)]
+
+    clearing = clear_market(offers, demands)
+
+    assert clearing.quantity == 0
+    assert clearing.offers[0].cleared == 0.0
+    assert clearing.unserved == 80
+
+
+def test_place_helpers_skip_nonpositive_quantities() -> None:
+    """place_bid/place_ask append only positive-quantity entries."""
+    market = {"capacities": [], "demands": []}
+    place_bid(market, 1, 50, 10, "coal")
+    place_bid(market, 1, 0, 10, "coal")  # skipped
+    place_ask(market, 2, 30, 80, "industry")
+    place_ask(market, 2, -5, 80, "industry")  # skipped
+
+    assert len(market["capacities"]) == 1
+    assert len(market["demands"]) == 1
+
+
+def test_market_optimum_matches_clear_market_price_quantity() -> None:
+    """clear_market delegates price/quantity to market_optimum unchanged."""
+    offers = [_offer(100, 10), _offer(100, 50)]
+    demands = [_demand(150, 80), _demand(100, 30)]
+    clearing = clear_market(offers, demands)
+
+    # market_optimum needs cumul_capacities populated, which clear_market has now done
+    assert market_optimum([f.entry for f in clearing.offers], [f.entry for f in clearing.demands]) == (
+        clearing.price,
+        clearing.quantity,
+    )

--- a/tests/unit/test_market_clearing.py
+++ b/tests/unit/test_market_clearing.py
@@ -104,12 +104,12 @@ def test_no_cross_serves_nothing() -> None:
 
 
 def test_place_helpers_skip_nonpositive_quantities() -> None:
-    """place_bid/place_ask append only positive-quantity entries."""
+    """place_ask/place_bid append only positive-quantity entries."""
     market = {"capacities": [], "demands": []}
-    place_bid(market, 1, 50, 10, "coal")
-    place_bid(market, 1, 0, 10, "coal")  # skipped
-    place_ask(market, 2, 30, 80, "industry")
-    place_ask(market, 2, -5, 80, "industry")  # skipped
+    place_ask(market, 1, 50, 10, "coal")
+    place_ask(market, 1, 0, 10, "coal")  # skipped
+    place_bid(market, 2, 30, 80, "industry")
+    place_bid(market, 2, -5, 80, "industry")  # skipped
 
     assert len(market["capacities"]) == 1
     assert len(market["demands"]) == 1


### PR DESCRIPTION
Resolves the **S1** seam of the Workshop Mode map (#873): extract the uniform-price electricity clearing so it is pure and player-agnostic, shipped as a standalone refactor of the persistent world on its own merits.

## What changed

- **New `energetica/market.py`** — `clear_market(offers, demands) → MarketClearing`. It does the sort → cumulative → `market_optimum` and reports per-`Fill` cleared MW plus a new market-level `unserved` (the quantity `reduce_demand` consumes silently today, now surfaced additively). No `Player.get` anywhere in the clearing path.
- **Settlement stays in `production_update.py`** — money, generation, `reduce_demand`, the €5 dumping penalty and the `player_id`-keyed chart dicts. `market_logic` now calls `clear_market` and loops the fills; the settlement loops' control flow is unchanged.
- Moved verbatim into the module: `MarketEntry`, `init_market`, `market_optimum`, and the two market-building helpers.
- **Naming fix (2nd commit):** flipped `place_bid`/`place_ask` to finance convention — an *ask* is a seller's offer (supply → `capacities`), a *bid* is a buyer's demand (→ `demands`). Pure rename, no behaviour change.

## Behaviour preservation

The settlement loops are byte-for-byte identical — only the inline `sold_cap`/`bought_cap` locals were replaced by `fill.cleared`, which equals the old value for every row the loops reach (the marginal row's raw value is always in `[0, capacity]`, so the clamp is an identity; beyond-margin rows are touched only via the dumping `continue`, where old and new both yield `dump_cap == capacity`). Both the network and the `network is None` solo path funnel through `market_logic`, so both are covered.

## Why

Clearing is now player-free, so a future Workshop-mode demand-block engine can inject an exogenous demand bid backed by no `Player` and read `unserved` out — the injection point falls out of the seam for free. Building that engine is out of scope here.

## Tests

New `tests/unit/test_market_clearing.py` (8 tests), including clearing a market whose entries carry a non-existent `player_id` to prove the seam holds with no player layer. `pyright` clean, `ruff` clean, `test_module_boundary` still green (`energetica.market` is a pure leaf — only `math` + `dataclasses`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the electricity-market clearing seam into a pure module. The main changes are:

- Adds player-agnostic market construction and clearing.
- Keeps settlement and player updates in `production_update`.
- Renames bid and ask helpers to match finance convention.
- Adds unit coverage for clearing outcomes and empty markets.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/market.py | Adds the pure market-entry, order-building, clearing, fill, and unserved-demand types. |
| energetica/production_update.py | Uses the extracted market helpers while retaining player-coupled settlement and market updates. |
| tests/unit/test_market_clearing.py | Covers player-independent clearing, partial fills, empty markets, no-cross cases, and order helpers. |

<sub>Reviews (2): Last reviewed commit: ["refactor(market): address review — Fill...."](https://github.com/felixvonsamson/energetica/commit/a35d5fbcfe83477662bd063028f3268c6db80476) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44649065)</sub>

<!-- /greptile_comment -->