### PR TITLE
feat(lifecycle): announced phase — self-start at starts_at (T4, #862)

### DIFF
--- a/energetica/routers/game.py
+++ b/energetica/routers/game.py
@@ -22,6 +22,7 @@ def get_engine_config() -> GameEngineOut:
         start_date=engine.start_date,
         wall_clock_seconds_per_tick=engine.clock_time,
         game_seconds_per_tick=engine.in_game_seconds_per_tick,
+        starts_at=config.starts_at if config else None,
         freeze_at=config.freeze_at if config else None,
         ended_at=config.ended_at if config else None,
     )

--- a/energetica/schemas/game.py
+++ b/energetica/schemas/game.py
@@ -11,10 +11,14 @@ class GameEngineOut(BaseModel):
     start_date: datetime.datetime
     wall_clock_seconds_per_tick: int
     game_seconds_per_tick: int
-    # Lifecycle boundaries (#861), so the in-game app can derive its phase client-side (mirrored
-    # ``derivePhase``) instead of learning about freeze only from a rejected write. Absolute and
-    # tz-aware, sourced from this instance's ``instance.json``; ``null`` on an unconfigured/open-ended
-    # run (dev, or a run with no scheduled end). The in-game freeze UI that consumes these — banner,
-    # disabled controls, countdown — is built in T8 (#866).
+    # Lifecycle boundaries (#861 / #862), so the in-game app can derive its own phase client-side
+    # (mirrored ``derivePhase``) instead of learning about a transition only from a rejected write.
+    # Absolute and tz-aware, sourced from this instance's ``instance.json``; ``null`` on an
+    # unconfigured/open-ended run (dev, or a run with no scheduled end). ``start_date`` above is the
+    # *sim epoch* — during an announced window it is still process-start time and only re-anchors to
+    # the real start moment when play begins (see ``tick_execution.state_update``), so the client must
+    # derive phase from ``starts_at`` here, never from ``start_date``. The announced waiting screen
+    # (#862, T4) consumes ``starts_at``; the in-game freeze UI (#866, T8) consumes freeze/ended.
+    starts_at: AwareDatetime | None = None
     freeze_at: AwareDatetime | None = None
     ended_at: AwareDatetime | None = None

--- a/energetica/utils/tick_execution.py
+++ b/energetica/utils/tick_execution.py
@@ -1,5 +1,6 @@
 """Utility functions relating to the GameEngine class."""
 
+import math
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,7 +29,7 @@ def state_update() -> None:
     # sim halts — play is over. Checked here, around the catch-up loop, rather than inside ``tick()``:
     # a short-circuit *inside* ``tick()`` would never advance ``engine.total_t`` and spin the
     # ``while`` below forever. The named seam (tick_execution) is honoured; the loop is the correct
-    # spot within it. (``announced`` — sim paused before ``starts_at`` — is T4's concern, not gated here.)
+    # spot within it.
     #
     # One check before the loop (not inside it) is right: ``total_t`` is the wall-clock-now target
     # fixed at entry, and each ``tick()`` advances the sim counter *toward* it, so every tick
@@ -36,8 +37,35 @@ def state_update() -> None:
     # the loop runs is pre-``freeze_at`` in sim-time and legitimately belongs to the game — even if a
     # long post-downtime catch-up executes them a little after ``freeze_at`` in wall-clock. Re-checking
     # inside the loop would wrongly *drop* that valid pre-freeze catch-up.
-    if instance_config.current_phase() in ("freeze", "ended"):
+    phase = instance_config.current_phase()
+    if phase in ("freeze", "ended"):
         return
+    # announced → active self-start (#862, T4): before ``starts_at`` the sim is paused. The process
+    # runs from creation (fragment already advertised, whitelist editable) but must not tick. The
+    # scheduler re-reads the phase every fire, so the instant ``now`` crosses ``starts_at`` this guard
+    # clears and the loop below begins on its own — the exact mirror of the self-freeze above. The
+    # guard is load-bearing, not cosmetic: the ``engine.total_t == 0`` clause in the loop would
+    # otherwise fire tick 0 the moment the process comes up, starting the game during its announced
+    # window.
+    if phase == "announced":
+        return
+    # First-active re-anchor: fix the sim epoch (``start_date``) to the moment the game actually
+    # becomes active, once, keyed off ``total_t == 0`` (the "never ticked" signal). At construction
+    # ``start_date`` is process-start time — during an announced window that is well before
+    # ``starts_at``, so leaving it there would make the catch-up ``total_t`` below span the whole
+    # announced window and fast-forward the game across thousands of empty ticks the instant it
+    # starts. Re-anchoring at activation (rather than at construction) also means an admin editing
+    # ``starts_at`` during announced is honoured — the epoch is pinned only when play truly begins.
+    # A running game (``total_t > 0``) keeps its epoch, so post-downtime catch-up is untouched; and
+    # for an instance created already-active (``starts_at`` in the past, today's default) this simply
+    # re-pins to ~now, matching the previous construction-time behaviour. Floored to ``clock_time`` to
+    # preserve the alignment the daily-question schedule and tick math rely on (see GameEngine init).
+    if engine.total_t == 0:
+        with engine.lock:
+            aligned = math.floor(time.time() / engine.clock_time) * engine.clock_time
+            engine.start_date = datetime.fromtimestamp(aligned, tz=timezone.utc)
+            engine.first_tick_time = engine.start_date  # keep the "first tick not yet defined" sentinel
+            engine.save()
     total_t = (time.time() - engine.start_date.timestamp()) / engine.clock_time
     while engine.total_t < total_t - 1 or engine.total_t == 0:
         tick()

--- a/frontend/src/components/lifecycle/announced-screen.tsx
+++ b/frontend/src/components/lifecycle/announced-screen.tsx
@@ -1,0 +1,123 @@
+/**
+ * The announced-phase waiting screen (#862, T4).
+ *
+ * A run's process is up from creation — the fragment is advertised and (for a
+ * private run) the whitelist is being grown — but play does not begin until the
+ * instance's own clock crosses `starts_at`, at which point the backend
+ * self-starts the sim (`state_update`) and this screen's derived phase flips to
+ * `active`, dropping the player into the game. Until then there is nothing to
+ * play, so this is a full-screen takeover (no game chrome) rather than a
+ * banner: a countdown and the scheduled start, so a whitelisted player who
+ * arrives early knows they're in the right place and when to come back.
+ *
+ * The freeze/ended presentation is deliberately NOT here — that in-game
+ * read-only surface is T8 (#866).
+ */
+
+import { useEffect, useState } from "react";
+
+import { TypographyBrand } from "@/components/ui/typography";
+
+/** A wall-clock duration split into whole days/hours/minutes/seconds. */
+function splitDuration(ms: number): {
+    d: number;
+    h: number;
+    m: number;
+    s: number;
+} {
+    const total = Math.max(0, Math.floor(ms / 1000));
+    return {
+        d: Math.floor(total / 86400),
+        h: Math.floor((total % 86400) / 3600),
+        m: Math.floor((total % 3600) / 60),
+        s: total % 60,
+    };
+}
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * "Monday, 15 September 2025 at 09:00" in the viewer's locale, or null if
+ * unparseable.
+ */
+function formatStart(iso: string): string | null {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return null;
+    return new Intl.DateTimeFormat(undefined, {
+        weekday: "long",
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    }).format(date);
+}
+
+export function AnnouncedScreen({ startsAt }: { startsAt: string }) {
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, []);
+
+    const target = new Date(startsAt).getTime();
+    const remaining = Number.isNaN(target) ? 0 : target - now;
+    const { d, h, m, s } = splitDuration(remaining);
+    const startLabel = formatStart(startsAt);
+
+    return (
+        <div className="flex min-h-svh w-full flex-col items-center justify-center gap-8 p-6 text-center">
+            <TypographyBrand className="text-primary text-4xl">
+                Energetica
+            </TypographyBrand>
+
+            <div className="flex flex-col gap-2">
+                <h1 className="text-2xl font-semibold sm:text-3xl">
+                    The game hasn&apos;t started yet
+                </h1>
+                {startLabel && (
+                    <p className="text-muted-foreground">Starts {startLabel}</p>
+                )}
+            </div>
+
+            <div
+                className="flex items-start gap-3 sm:gap-4"
+                role="timer"
+                aria-label="Time until the game starts"
+            >
+                {d > 0 && (
+                    <CountdownUnit value={d} label={d === 1 ? "day" : "days"} />
+                )}
+                <CountdownUnit value={h} label="hours" pad />
+                <CountdownUnit value={m} label="minutes" pad />
+                <CountdownUnit value={s} label="seconds" pad />
+            </div>
+
+            <p className="text-muted-foreground max-w-md text-sm">
+                Keep this page open — it&apos;ll drop you into the game the
+                moment it begins. No need to refresh.
+            </p>
+        </div>
+    );
+}
+
+function CountdownUnit({
+    value,
+    label,
+    pad: shouldPad = false,
+}: {
+    value: number;
+    label: string;
+    pad?: boolean;
+}) {
+    return (
+        <div className="flex min-w-14 flex-col items-center gap-1 sm:min-w-20">
+            <span className="text-primary text-4xl font-bold tabular-nums sm:text-6xl">
+                {shouldPad ? pad(value) : value}
+            </span>
+            <span className="text-muted-foreground text-xs uppercase tracking-wide">
+                {label}
+            </span>
+        </div>
+    );
+}

--- a/frontend/src/components/lobby/run-cards.tsx
+++ b/frontend/src/components/lobby/run-cards.tsx
@@ -13,7 +13,7 @@ import { ChevronRight, Zap } from "lucide-react";
 
 import { TypographyMuted } from "@/components/ui/typography";
 import type { MyRun } from "@/lib/api/lobby";
-import type { InstanceFragment } from "@/lib/instances";
+import { derivePhase, type InstanceFragment } from "@/lib/instances";
 import { runAppHref } from "@/lib/lobby";
 
 /** "March 2026" from an ISO timestamp, or null when unparseable. */
@@ -81,7 +81,11 @@ export function OpenRunCard({
     instance: InstanceFragment;
     loggedIn: boolean;
 }) {
-    const since = formatMonthYear(instance.starts_at);
+    const when = formatMonthYear(instance.starts_at);
+    // An announced run advertises before it's playable (#862, T4): the fragment is published at
+    // creation with a future `starts_at`, so the card must say "Starts …", not "Running since …".
+    const label =
+        derivePhase(instance) === "announced" ? "Starts" : "Running since";
     const href = loggedIn
         ? runAppHref(instance.slug)
         : `/login?return=${encodeURIComponent(instance.slug)}`;
@@ -91,8 +95,10 @@ export function OpenRunCard({
                 <p className="text-lg font-semibold truncate">
                     {instance.name}
                 </p>
-                {since && (
-                    <TypographyMuted>Running since {since}</TypographyMuted>
+                {when && (
+                    <TypographyMuted>
+                        {label} {when}
+                    </TypographyMuted>
                 )}
             </div>
         </RunCardFrame>

--- a/frontend/src/hooks/use-phase.ts
+++ b/frontend/src/hooks/use-phase.ts
@@ -1,0 +1,50 @@
+/**
+ * Client-side derivation of this instance's lifecycle phase.
+ *
+ * The backend self-drives its transitions from its own clock (#861 freeze, #862
+ * announced) and exposes the three boundary timestamps on `/game/engine`; this
+ * hook is the frontend mirror, deriving the phase the same way (`derivePhase`,
+ * `lib/instances.ts`) so the UI can present "not started yet" / "read-only"
+ * without waiting to learn about a transition from a rejected request.
+ * Re-evaluated on a light wall-clock interval so a boundary crossed mid-session
+ * flips the UI on its own.
+ *
+ * `starts_at`/`freeze_at`/`ended_at` come from the engine config, NOT from
+ * `start_date` — `start_date` is the sim epoch, which during an announced
+ * window is still process-start time (see `state_update`).
+ */
+
+import { useEffect, useState } from "react";
+
+import { useGameEngine } from "@/hooks/use-game";
+import { derivePhase, type Phase } from "@/lib/instances";
+
+/**
+ * The instance's current lifecycle phase, or `undefined` while the engine
+ * config is still loading (or unavailable — an unconfigured/open-ended run,
+ * where the caller should fail open to the live game, mirroring the backend's
+ * fail-open-to-active phase read).
+ *
+ * @param intervalMs How often to re-derive against the wall clock. Default 1s —
+ *   fine-grained enough for an announced countdown; callers that only need the
+ *   coarse phase can pass a longer interval.
+ */
+export function usePhase(intervalMs = 1000): Phase | undefined {
+    const { data: engine } = useGameEngine();
+    const [now, setNow] = useState(() => new Date());
+
+    useEffect(() => {
+        const id = setInterval(() => setNow(new Date()), intervalMs);
+        return () => clearInterval(id);
+    }, [intervalMs]);
+
+    if (!engine?.starts_at) return undefined;
+    return derivePhase(
+        {
+            starts_at: engine.starts_at,
+            freeze_at: engine.freeze_at,
+            ended_at: engine.ended_at,
+        },
+        now,
+    );
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -7,9 +7,12 @@ import {
 } from "@tanstack/react-router";
 import { useEffect } from "react";
 
+import { AnnouncedScreen } from "@/components/lifecycle/announced-screen";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/hooks/use-auth";
 import { useCapabilities } from "@/hooks/use-capabilities";
+import { useGameEngine } from "@/hooks/use-game";
+import { usePhase } from "@/hooks/use-phase";
 import { lobbyLoginHref } from "@/lib/instances";
 import type { ApiSchema } from "@/types/api-helpers";
 import type { PlayerCapabilities } from "@/types/capabilities";
@@ -68,6 +71,8 @@ function RootComponent() {
     const navigate = useNavigate();
     const { user, isAuthenticated, isLoading } = useAuth();
     const capabilities = useCapabilities();
+    const phase = usePhase();
+    const { data: engine } = useGameEngine();
     const staticData = matches[matches.length - 1]?.staticData;
     const routeConfig = staticData?.routeConfig;
 
@@ -79,8 +84,20 @@ function RootComponent() {
     // page after the cutover, ADR-0002/0003).
     const mustLogIn =
         authResolved && routeNeedsAuth && (!isAuthenticated || !user);
+    // Announced-phase takeover (#862, T4): before `starts_at` the sim is paused and there is nothing
+    // to play, so an authenticated visitor sees the waiting screen on ANY app route. Gated at the
+    // root (not in GameLayout) so it also covers `/app/settle`, which renders outside GameLayout —
+    // this is what keeps "settle-during-announced" genuinely un-built (it stays fog, #856): a player
+    // can't reach the settle flow before the run starts. Fails open to the game — `usePhase` is
+    // `undefined` while the engine config loads or on an unconfigured/open-ended run — mirroring the
+    // backend's fail-open-to-active phase read (#861). Freeze/ended stay ungated here (that in-game
+    // read-only surface is T8, #866).
+    // `phase === "announced"` already implies `engine.starts_at` is set (usePhase returns undefined
+    // otherwise); the render branch below narrows it for the prop.
+    const announced =
+        authResolved && isAuthenticated && !!user && phase === "announced";
     const redirectTo =
-        authResolved && isAuthenticated && user
+        !announced && authResolved && isAuthenticated && user
             ? computeRedirect(routeConfig, user, capabilities)
             : null;
 
@@ -102,6 +119,12 @@ function RootComponent() {
         );
     }
     if (staticData === undefined) return "Unknown page";
+    // Before the run starts, an authenticated visitor waits here instead of entering the game or
+    // being routed to settle (#862, T4). Placed before the redirect gate so it preempts the
+    // settle/dashboard navigation the effect would otherwise fire.
+    if (announced && engine?.starts_at) {
+        return <AnnouncedScreen startsAt={engine.starts_at} />;
+    }
     // Block rendering until the redirect from the effect fires.
     if (mustLogIn || redirectTo) return null;
 

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2537,6 +2537,8 @@ export interface components {
             wall_clock_seconds_per_tick: number;
             /** Game Seconds Per Tick */
             game_seconds_per_tick: number;
+            /** Starts At */
+            starts_at?: string | null;
             /** Freeze At */
             freeze_at?: string | null;
             /** Ended At */

--- a/scripts/infra/whitelist-instance.sh
+++ b/scripts/infra/whitelist-instance.sh
@@ -37,6 +37,10 @@ command -v jq >/dev/null 2>&1 || { log_error "jq is required"; exit 1; }
 [ "$#" -ge 2 ] || usage
 
 INSTANCE="$1"; ACTION="$2"; shift 2
+[[ "$INSTANCE" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]] || {
+    log_error "Invalid instance slug: $INSTANCE"
+    exit 1
+}
 CONFIG="$CONFIG_ROOT/$INSTANCE/instance.json"
 
 [ -f "$CONFIG" ] || { log_error "No config at $CONFIG"; exit 1; }

--- a/scripts/infra/whitelist-instance.sh
+++ b/scripts/infra/whitelist-instance.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+# Energetica — grow (or trim) a private instance's access whitelist. Run as root on the server.
+#
+#   sudo bash scripts/infra/whitelist-instance.sh <instance> list
+#   sudo bash scripts/infra/whitelist-instance.sh <instance> add    <username> [<username> ...]
+#   sudo bash scripts/infra/whitelist-instance.sh <instance> remove <username> [<username> ...]
+#
+# Edits access.allowed_usernames in the admin-owned /etc/energetica/{instance}/instance.json.
+# The backend re-reads instance.json on every entry (no cache), so edits take effect on the
+# player's next load with NO restart and NO redeploy — this is exactly the "incremental whitelist
+# edits during the announced window" the lifecycle wants (#862, T4). The access block is stripped
+# from the public landing fragment, so the whitelist never leaks off-server.
+#
+# The instance must already be private (access.policy == "private"). Flipping public↔private is a
+# policy decision left to a hand-edit of instance.json (setup-instance.sh renders public by default).
+#
+# Requires jq. Writes atomically (temp file + mv) and preserves the file's root:energetica 0640.
+
+CONFIG_ROOT="${ENERGETICA_INSTANCE_CONFIG_DIR:-/etc/energetica}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+log_step()    { echo -e "${YELLOW}→ $1${NC}"; }
+log_success() { echo -e "${GREEN}✓ $1${NC}"; }
+log_error()   { echo -e "${RED}✗ $1${NC}"; }
+
+usage() {
+    echo "Usage: whitelist-instance.sh <instance> list"
+    echo "       whitelist-instance.sh <instance> add    <username> [<username> ...]"
+    echo "       whitelist-instance.sh <instance> remove <username> [<username> ...]"
+    exit 1
+}
+
+[ "$EUID" -eq 0 ] || { log_error "Must run as root (the config file is root-owned)"; exit 1; }
+command -v jq >/dev/null 2>&1 || { log_error "jq is required"; exit 1; }
+[ "$#" -ge 2 ] || usage
+
+INSTANCE="$1"; ACTION="$2"; shift 2
+CONFIG="$CONFIG_ROOT/$INSTANCE/instance.json"
+
+[ -f "$CONFIG" ] || { log_error "No config at $CONFIG"; exit 1; }
+
+POLICY="$(jq -r '.access.policy // "public"' "$CONFIG")"
+
+case "$ACTION" in
+    list)
+        [ "$#" -eq 0 ] || usage
+        if [ "$POLICY" != "private" ]; then
+            log_error "Instance '$INSTANCE' is $POLICY — no whitelist to list (edit access.policy to make it private)"
+            exit 1
+        fi
+        jq -r '.access.allowed_usernames[]?' "$CONFIG"
+        exit 0
+        ;;
+    add|remove) ;;
+    *) usage ;;
+esac
+
+[ "$#" -ge 1 ] || usage
+if [ "$POLICY" != "private" ]; then
+    log_error "Instance '$INSTANCE' is $POLICY — make it private first (set access.policy=private in $CONFIG)"
+    exit 1
+fi
+
+# Build the edit as a jq filter over the passed usernames. Add unions + dedupes + sorts; remove
+# subtracts. `--args` passes the usernames positionally so odd characters can't break the filter.
+if [ "$ACTION" = "add" ]; then
+    FILTER='.access.allowed_usernames = ((.access.allowed_usernames // []) + $ARGS.positional | unique)'
+else
+    FILTER='.access.allowed_usernames = ((.access.allowed_usernames // []) - $ARGS.positional)'
+fi
+
+TMP="$(mktemp "$(dirname "$CONFIG")/.instance.json.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+jq "$FILTER" "$CONFIG" --args "$@" > "$TMP"
+chown root:energetica "$TMP"
+chmod 0640 "$TMP"
+mv "$TMP" "$CONFIG"
+trap - EXIT
+
+log_success "$ACTION applied to '$INSTANCE'. Now allowed:"
+jq -r '.access.allowed_usernames[]?' "$CONFIG" | sed 's/^/  - /'
+log_step "No restart needed — the backend re-reads this on the next entry."

--- a/tests/unit/test_freeze_enforcement.py
+++ b/tests/unit/test_freeze_enforcement.py
@@ -1,15 +1,20 @@
-"""Unit tests for the active → freeze self-enforcement (#861, T3).
+"""Unit tests for the lifecycle self-enforcement seams (#861 T3 freeze, #862 T4 announced).
 
-Two seams, both keyed off ``instance_config.current_phase``:
+All keyed off ``instance_config.current_phase``:
 
 - ``reject_when_frozen`` — the game-action write-gate (409 once the instance is frozen/ended).
-- ``state_update`` — the sim tick halts once frozen (play is over).
+- ``state_update`` — the sim tick halts once frozen (play over) *and* stays paused while announced,
+  then self-starts once ``starts_at`` is crossed, re-anchoring the sim epoch to the start moment.
 
-Both are exercised here by monkeypatching the phase, so the tests need neither a real on-disk
-config nor a running engine.
+The phase is monkeypatched, so the freeze tests need neither a real on-disk config nor a running
+engine; the self-start test uses a small fake engine to observe the epoch re-anchor.
 """
 
 from __future__ import annotations
+
+from datetime import datetime, timezone
+from threading import RLock
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException, status
@@ -53,3 +58,72 @@ def test_state_update_halts_sim_when_frozen(monkeypatch: pytest.MonkeyPatch, fro
 
     monkeypatch.setattr(tick_execution, "tick", _fail_if_ticked)
     tick_execution.state_update()  # returns cleanly; the AssertionError above would fire if it ticked
+
+
+def test_state_update_pauses_sim_while_announced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Before ``starts_at`` the sim is paused: ``state_update`` returns without ticking (#862, T4).
+
+    This is the load-bearing half of self-start — without it the ``total_t == 0`` clause of the
+    catch-up loop would fire tick 0 the instant the announced process comes up.
+    """
+    monkeypatch.setattr(tick_execution.instance_config, "current_phase", lambda: "announced")
+
+    def _fail_if_ticked() -> None:
+        raise AssertionError("tick() must not run while the instance is announced")
+
+    monkeypatch.setattr(tick_execution, "tick", _fail_if_ticked)
+    tick_execution.state_update()  # returns cleanly; announced is a paused sim
+
+
+def test_state_update_self_starts_and_reanchors_epoch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Crossing ``starts_at`` self-starts the sim and re-anchors the epoch to the start moment (#862).
+
+    A fresh instance (``total_t == 0``) that has become ``active`` re-pins ``start_date`` to ~now
+    (clock-aligned) so the catch-up loop begins at tick 0 rather than fast-forwarding across the
+    whole announced window, then ticks. The re-anchor happens exactly once — a running game keeps
+    its epoch, covered by ``test_state_update_reanchor_skipped_for_running_game`` below.
+    """
+    monkeypatch.setattr(tick_execution.instance_config, "current_phase", lambda: "active")
+    # Epoch left over from the announced window: process-start, well before now.
+    stale_epoch = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    fake = SimpleNamespace(
+        total_t=0,
+        clock_time=60,
+        start_date=stale_epoch,
+        first_tick_time=stale_epoch,
+        lock=RLock(),
+        save=lambda: None,
+    )
+    monkeypatch.setattr(tick_execution, "engine", fake)
+    # A tick that just advances the counter, so the catch-up loop terminates after one iteration.
+    monkeypatch.setattr(tick_execution, "tick", lambda: setattr(fake, "total_t", fake.total_t + 1))
+
+    tick_execution.state_update()
+
+    assert fake.total_t == 1, "the sim should have self-started (ticked once)"
+    assert fake.start_date > stale_epoch, "the epoch must be re-anchored off the stale announced value"
+    assert fake.start_date.tzinfo is not None, "the re-anchored epoch stays tz-aware"
+    assert fake.start_date.timestamp() % fake.clock_time == 0, "the epoch stays clock-aligned"
+    assert fake.first_tick_time == fake.start_date, "the 'first tick not yet defined' sentinel is preserved"
+
+
+def test_state_update_reanchor_skipped_for_running_game(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A running game (``total_t > 0``) keeps its epoch — post-downtime catch-up is untouched (#862)."""
+    monkeypatch.setattr(tick_execution.instance_config, "current_phase", lambda: "active")
+    original_epoch = datetime(2020, 6, 1, tzinfo=timezone.utc)
+    fake = SimpleNamespace(
+        total_t=500,
+        clock_time=60,
+        start_date=original_epoch,
+        first_tick_time=datetime(2020, 6, 1, 0, 1, tzinfo=timezone.utc),
+        lock=RLock(),
+        save=lambda: None,
+    )
+    monkeypatch.setattr(tick_execution, "engine", fake)
+    # Stop the catch-up loop immediately: total_t is already past the wall-clock target for this old
+    # epoch only if we bump it high enough, so make tick a no-op-terminator by driving total_t up.
+    monkeypatch.setattr(tick_execution, "tick", lambda: setattr(fake, "total_t", 10**12))
+
+    tick_execution.state_update()
+
+    assert fake.start_date == original_epoch, "a running game must not re-anchor its epoch"


### PR DESCRIPTION
Builds the **announced** phase of the game-instance lifecycle (map #856, ticket #862): an instance's process runs from creation with the sim **paused**, and **self-starts** when its own clock passes `starts_at` — the mirror of the self-freeze at `freeze_at` (T3, #861), keyed off the same derived phase (T1, #857).

## What's here

- **Self-start.** `state_update` pauses the sim while `phase == announced` (returns before the catch-up loop, so the `total_t == 0` clause can't fire tick 0 during the announced window), then self-starts once the scheduler's next phase re-read crosses `starts_at`.
- **Epoch re-anchor.** On the first active tick (keyed off `total_t == 0`), `start_date` (the sim epoch) is re-anchored to the aligned start moment. At construction it's *process-start* time — during an announced window well before `starts_at` — so leaving it there would make the catch-up loop **fast-forward the whole announced window** at start. Re-anchoring at *activation* also honours an admin editing `starts_at` during announced; a running game (`total_t > 0`) keeps its epoch, so post-downtime catch-up is untouched.
- **Client-side phase.** `GameEngineOut` exposes `starts_at` (T3 added `freeze_at`/`ended_at`). The client keys off `starts_at`, **not** `start_date` (the re-anchoring epoch).
- **Player-facing view.** A full-screen waiting takeover (`AnnouncedScreen`) with a live countdown to `starts_at`, driven by `usePhase()` (the `derivePhase` mirror). Gated in the **app root** so it also covers `/app/settle`, which renders outside `GameLayout`. Fails **open** to the game when the engine config is loading/unavailable.
- **Incremental whitelist edits.** `scripts/infra/whitelist-instance.sh` (`add`/`remove`/`list` on `access.allowed_usernames`); re-read per entry, so edits during announced take effect with no restart. Lobby `OpenRunCard` now reads "Starts …" for an announced run.

## Scope calls

- **Settle-during-announced stays fog** — the root gate makes `/app/settle` unreachable before start rather than deciding the question.
- **No announced write-gate** — the existing `reject_when_frozen` contract treats `announced` as a live game (there's a test for it), and without settling there's no settled player to fire game actions.
- **In-game `active→freeze→ended` UI stays T8 (#866).**

## Verification

Backend: 9 lifecycle unit tests (pause-while-announced, self-start-and-reanchor, reanchor-skipped-for-running-game) + full unit suite green. Frontend: 65 tests, typecheck, lint all pass. Rebased onto `main` (T1/T3 already merged), no type drift.

Closes #862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the announced lifecycle phase for scheduled game instances. The main changes are:
- Pause simulation until `starts_at` and re-anchor its epoch on activation.
- Add an announced waiting screen and client-side phase handling.
- Expose `starts_at` through the game API and update lobby labels.
- Add a root-run whitelist management script with constrained instance slugs.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/utils/tick_execution.py | Adds announced-phase pausing and first-active-tick epoch re-anchoring. |
| frontend/src/routes/__root.tsx | Shows the announced waiting screen before authenticated users enter game routes. |
| scripts/infra/whitelist-instance.sh | Validates instance slugs before editing the selected private instance configuration. |

<sub>Reviews (2): Last reviewed commit: ["Update scripts/infra/whitelist-instance...."](https://github.com/felixvonsamson/energetica/commit/f197b51c988d904d1e8e176787dbd0f9effafe66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45318701)</sub>

<!-- /greptile_comment -->