### PR TITLE
feat(recap): mint + publish hook at active→freeze (T5, #863)

### DIFF
--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -302,6 +302,27 @@ The landing fetches `/instances.json` and renders advertised entries. Apache ser
 
 Unadvertised instances that are public are reachable by direct URL — a user who knows the subdomain may sign up and play. Unadvertised + private instances are reachable only by URL *and* require allowlisted credentials.
 
+### Recap publication (lifecycle tombstone)
+
+At the `active → freeze` transition (the sim's own clock passing `freeze_at`), the instance mints a **recap** — a frozen JSON tombstone of its final leaderboard — and publishes it *beside* the fragment:
+
+```
+/var/www/energetica-landing/recaps/{slug}.json
+
+  { "slug": "autumn-2025", "name": "Autumn 2025",
+    "starts_at": "...", "freeze_at": "...", "ended_at": null,
+    "player_count": 42, "total_captured_co2": 1234.5, "total_net_emissions": -678.9,
+    "rows": [ { "rank": 1, "account_id": 20, "username_at_freeze": "bob",
+                "network_name": "Grid Co", "operating_income": 1500,
+                "xp": 99, "captured_co2": 250 }, ... ] }
+```
+
+- **Curated projection, not a live dump** — one income-ranked table plus a small totals header (see `energetica/schemas/recap.py`), sized for a single payload (~15 KB), so the lobby renders it with no live backend. Reads by attribute via a `RecapPlayer` protocol, so the schema stays free of the game ORM.
+- **Same atomic-write mechanism** as the fragment (`_atomic_write_json`: tmp-sibling → `chmod 0o640` → `os.replace`), but a **separate file** — the recap is **not** aggregated into `instances.json` (heavyweight-per-instance, read rarely; folding it in would bloat the manifest the picker downloads on every visit).
+- **Mint-once, re-runnable** — file-existence is the "already minted" flag (`instance_config.recap_exists`), so the repeated freeze-phase ticks and a process restart in freeze don't re-photograph it. **Admin regenerate is the manual delete/regenerate path**: an admin deletes `recaps/{slug}.json` and the next freeze tick re-mints it (scripts suffice for the baseline, as with force-freeze). `energetica.utils.recap.mint_recap` is the underlying unconditional force-overwrite primitive that a future admin control (the deferred admin dashboard, #279) can call directly. Re-minting is reproducible: ties break on the immutable `account_id`, so a regenerate yields the identical ranking.
+- **Visibility is phase-derived, not a flag** — reveal-at-freeze-start == publish-at-mint; the lobby offers "View recap" ⟺ the fragment's `freeze_at` has passed (no new discovery field).
+- **Survives teardown** — the artifact lives on the landing dir, not in the instance process, so it outlives the reap at `ended_at`. `teardown-instance.sh` deletes the *fragment* but **must leave the recap in place**.
+
 ### Operational notes
 
 - The landing's `instances/` subdirectory must be writable by every instance's systemd unit. Cleanest: create a shared group `energetica`, `chmod g+ws /var/www/energetica-landing/instances/`, and run each `energetica-{slug}.service` as a user in that group. Setgid ensures new fragment files inherit group ownership.

--- a/energetica/instance_config.py
+++ b/energetica/instance_config.py
@@ -27,9 +27,12 @@ import os
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 from pydantic import AwareDatetime, BaseModel, Field, model_validator
+
+if TYPE_CHECKING:
+    from energetica.schemas.recap import Recap
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +249,28 @@ def load_instance_config() -> InstanceConfig | None:
         raise InstanceConfigError(f"invalid instance.json at {path}: {exc}") from exc
 
 
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
+
+
+def _load_json_or_none(path: Path, model: type[_ModelT], *, what: str) -> _ModelT | None:
+    """Read a published static artifact into ``model``, tolerating absence or corruption.
+
+    The shared read policy for the landing dir's write-once JSON (fragments and recaps): an absent
+    file is ``None`` (nothing published / stale pointer), and a malformed one is ``None`` *with a
+    warning* rather than an exception — a single unreadable sibling must not poison a caller that
+    aggregates or lists many. ``what`` names the artifact in that warning ("instance fragment",
+    "recap"). Callers that must fail closed on corruption (the security-boundary config) parse
+    directly instead — see :func:`load_instance_config`.
+    """
+    if not path.exists():
+        return None
+    try:
+        return model.model_validate_json(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.warning("skipping unreadable %s %s", what, path)
+        return None
+
+
 def load_fragment(slug: str) -> InstanceFragment | None:
     """Read a single on-disk instance fragment by slug, or ``None`` if it is absent or unreadable.
 
@@ -256,13 +281,7 @@ def load_fragment(slug: str) -> InstanceFragment | None:
     the caller filters it out.
     """
     fragment_path = _landing_dir() / "instances" / f"{slug}.json"
-    if not fragment_path.exists():
-        return None
-    try:
-        return InstanceFragment.model_validate_json(fragment_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        logger.warning("skipping unreadable instance fragment %s", fragment_path)
-        return None
+    return _load_json_or_none(fragment_path, InstanceFragment, what="instance fragment")
 
 
 def is_access_allowed(config: InstanceConfig, username: str) -> bool:
@@ -322,12 +341,8 @@ def list_advertised_fragments() -> list[InstanceFragment]:
     fragments_dir = _landing_dir() / "instances"
     fragments: list[InstanceFragment] = []
     for fragment_path in fragments_dir.glob("*.json"):
-        try:
-            fragment = InstanceFragment.model_validate_json(fragment_path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            logger.warning("skipping unreadable instance fragment %s", fragment_path)
-            continue
-        if fragment.advertised:
+        fragment = _load_json_or_none(fragment_path, InstanceFragment, what="instance fragment")
+        if fragment is not None and fragment.advertised:
             fragments.append(fragment)
     fragments.sort(key=lambda fragment: fragment.starts_at, reverse=True)
     return fragments
@@ -376,3 +391,51 @@ def publish_on_startup() -> None:
         logger.warning("not publishing fragment on startup: %s", exc)
         return
     publish(config)
+
+
+# --- Recap (the frozen JSON tombstone, G1/T5) ------------------------------------------------
+#
+# The recap is a write-once snapshot published to the landing dir at ``active → freeze`` and read by
+# the lobby, so it lives *beside* the fragment (same dir, same atomic-write mechanism) but is a
+# separate file: it is **not** aggregated into ``instances.json`` (heavyweight-per-instance, read
+# rarely — folding it in would bloat the manifest the picker downloads on every visit). Discovery
+# rides the existing fragment pointer: the lobby offers "View recap" ⟺ the fragment's ``freeze_at``
+# has passed. These primitives stay free of the game domain (the module-boundary rule) — the mint
+# side that reads ``Player`` lives in ``energetica.utils.recap``.
+
+
+def recap_path(slug: str) -> Path:
+    """The on-disk location of a slug's published recap (``{landing}/recaps/{slug}.json``)."""
+    return _landing_dir() / "recaps" / f"{slug}.json"
+
+
+def recap_exists(slug: str) -> bool:
+    """Whether this slug's recap has already been published — the mint-once flag (T5).
+
+    File-existence *is* the "already minted" signal: idempotent across the repeated freeze-phase
+    ticks and across a process restart in freeze, and an admin deleting the file triggers a
+    re-mint on the next check (the manual delete/regenerate path).
+    """
+    return recap_path(slug).exists()
+
+
+def publish_recap(recap: Recap) -> None:
+    """Atomically write ``recap`` to the landing dir, overwriting any existing artifact.
+
+    Reuses :func:`_atomic_write_json` (tmp-sibling → chmod → ``os.replace``) so a concurrent lobby
+    reader never sees a partial file, and the group-readable mode lets Apache serve it. Overwriting is
+    intentional: a bare ``publish_recap`` is the admin *regenerate* path; the mint-once guard is
+    :func:`recap_exists`, applied by the caller.
+    """
+    _atomic_write_json(recap_path(recap.slug), recap.model_dump_json())
+
+
+def load_recap(slug: str) -> Recap | None:
+    """Read a published recap by slug, or ``None`` if it is absent or unreadable.
+
+    The read side used by the lobby (T6) and by teardown validation (T7) — the artifact is a plain
+    static file, so this needs neither the instance process nor the game domain.
+    """
+    from energetica.schemas.recap import Recap
+
+    return _load_json_or_none(recap_path(slug), Recap, what="recap")

--- a/energetica/schemas/recap.py
+++ b/energetica/schemas/recap.py
@@ -1,0 +1,130 @@
+"""The recap: a frozen JSON tombstone of an instance's final leaderboard (G1, #859).
+
+A recap is a **write-once, immutable snapshot** minted at the ``active → freeze`` transition and
+published to the lobby (``recaps/{slug}.json``), where it outlives the instance process (T7). It is a
+**curated projection** — a single income-ranked table plus a small instance-totals header — *not* the
+verbatim :class:`~energetica.schemas.leaderboards.PlayerDetailStats`: the extra columns are cheap as
+data but costly as render/parse surface, and they graduate from the fog as full-recap features later.
+
+**Frozen-photograph semantics:** every row captures the player's identity *as it was at freeze*
+(``username_at_freeze``, ``network_name``). The immutable ``account_id`` FK is retained so a future
+cross-instance indexer can resolve the row to a current identity without coupling this baseline to SQL.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Mapping, Protocol
+
+from pydantic import AwareDatetime, BaseModel, Field
+
+if TYPE_CHECKING:
+    from energetica.instance_config import InstanceConfig
+
+
+class _RecapUser(Protocol):
+    account_id: int
+
+
+class _RecapNetwork(Protocol):
+    name: str
+
+
+class RecapPlayer(Protocol):
+    """The narrow slice of a player the projection actually reads.
+
+    A structural view (any ``Player`` satisfies it), so :meth:`Recap.from_players` depends on this
+    shape rather than the ORM — the schema stays a game-domain-free leaf and is testable with plain
+    stand-ins.
+    """
+
+    @property
+    def username(self) -> str: ...
+
+    @property
+    def user(self) -> _RecapUser: ...
+
+    @property
+    def network(self) -> _RecapNetwork | None: ...
+
+    @property
+    def progression_metrics(self) -> Mapping[str, float]: ...
+
+    def calculate_net_emissions(self) -> float: ...
+
+
+class RecapRow(BaseModel):
+    """One player's final standing, one row of the income-ranked leaderboard."""
+
+    rank: int = Field(description="1-based placement by operating_income desc — the medal")
+    account_id: int = Field(description="Server-wide account FK, retained for future identity resolution")
+    username_at_freeze: str = Field(description="The player's name as it was at freeze (frozen photograph)")
+    network_name: str | None = Field(description="The player's network/team at freeze, or None if unaffiliated")
+    operating_income: float = Field(description="Lifetime cumulated operating income — the sort key, 'who won'")
+    xp: float = Field(description="Experience points — 'how far I got'")
+    captured_co2: float = Field(description="Total captured CO2 in kg — the on-theme brag stat")
+
+
+class Recap(BaseModel):
+    """The full published recap payload: an identity/totals header plus the income-ranked table.
+
+    Sized for a single payload (~100 players × 7 fields ≈ 15 KB), so the lobby fetches and renders it
+    with no live backend. Carries the same transition timestamps the fragment does, so the lobby can
+    render start/end dates without a second lookup.
+    """
+
+    slug: str
+    name: str
+    starts_at: AwareDatetime
+    # Both later boundaries mirror the fragment: nullable because ``ended_at`` in particular is often
+    # still unset at mint time (the run has only just frozen), and the phase ladder treats a None
+    # boundary as simply never crossed.
+    freeze_at: AwareDatetime | None = None
+    ended_at: AwareDatetime | None = None
+    player_count: int
+    total_captured_co2: float = Field(description="Sum of captured_co2 across all players, in kg")
+    total_net_emissions: float = Field(description="Sum of net CO2 emissions across all players, in kg")
+    rows: list[RecapRow]
+
+    @classmethod
+    def from_players(
+        cls,
+        *,
+        slug: str,
+        config: InstanceConfig,
+        players: Iterable[RecapPlayer],
+    ) -> Recap:
+        """Project the live final game state into the frozen recap payload.
+
+        Players are ranked by ``operating_income`` descending (rank 1 = the winner); the totals header
+        sums ``captured_co2`` and ``net_emissions`` across everyone. Ties break on the immutable
+        ``account_id`` (ascending), so the ranking — and every row's ``rank`` — is fully reproducible:
+        a re-mint (admin regenerate) yields the identical frozen photograph rather than reshuffling
+        equal-income players by enumeration order.
+        """
+        ranked = sorted(
+            players,
+            key=lambda player: (-player.progression_metrics.get("operating_income", 0), player.user.account_id),
+        )
+        rows = [
+            RecapRow(
+                rank=rank,
+                account_id=player.user.account_id,
+                username_at_freeze=player.username,
+                network_name=player.network.name if player.network else None,
+                operating_income=player.progression_metrics.get("operating_income", 0),
+                xp=player.progression_metrics.get("xp", 0),
+                captured_co2=player.progression_metrics.get("captured_co2", 0),
+            )
+            for rank, player in enumerate(ranked, start=1)
+        ]
+        return cls(
+            slug=slug,
+            name=config.name,
+            starts_at=config.starts_at,
+            freeze_at=config.freeze_at,
+            ended_at=config.ended_at,
+            player_count=len(rows),
+            total_captured_co2=sum(player.progression_metrics.get("captured_co2", 0) for player in ranked),
+            total_net_emissions=sum(player.calculate_net_emissions() for player in ranked),
+            rows=rows,
+        )

--- a/energetica/utils/recap.py
+++ b/energetica/utils/recap.py
@@ -1,0 +1,70 @@
+"""Mint + publish the recap at the ``active → freeze`` transition (T5, #863).
+
+This is the game-side half of the recap: it reads the live final state (``Player.all()`` + the
+instance config) and publishes the frozen tombstone via :mod:`energetica.instance_config`. It is kept
+out of ``instance_config`` itself so that leaf stays free of the game domain (the module-boundary
+rule) — the publish/load *primitives* live there, the ``Player``-reading *orchestration* lives here.
+
+The hook fires from ``tick_execution.state_update`` on every freeze/ended tick, but
+:func:`mint_recap_if_needed` mints only once (guarded by file existence), so the frozen photograph is
+taken at the first freeze tick and never overwritten by a later restart. Freeze is read-only and the
+sim is halted, so the state is final — mint-at-freeze *is* the final leaderboard.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from energetica import instance_config
+from energetica.database.player import Player
+from energetica.schemas.recap import Recap
+
+logger = logging.getLogger(__name__)
+
+
+def build_recap() -> Recap | None:
+    """Project this instance's live final state into a recap, or ``None`` when unconfigured.
+
+    Returns ``None`` (nothing to mint) for a dev/legacy instance with no slug or no on-disk config —
+    the same "unconfigured ⇒ no lifecycle" stance the phase read takes.
+    """
+    slug = instance_config.instance_slug()
+    if slug is None:
+        return None
+    config = instance_config.load_instance_config()
+    if config is None:
+        return None
+    return Recap.from_players(slug=slug, config=config, players=Player.all())
+
+
+def mint_recap() -> None:
+    """Build and publish the recap, **overwriting** any existing artifact — the force-overwrite primitive.
+
+    Unconditional on purpose: it regenerates the recap from current state regardless of what is already
+    on disk. The reachable baseline admin-regenerate path is manual delete + auto-remint (``rm`` the
+    file, the next freeze tick re-mints via :func:`mint_recap_if_needed`); this is the underlying
+    primitive a future admin control can call to force a regenerate without the delete step.
+    """
+    recap = build_recap()
+    if recap is None:
+        logger.info("skipping recap mint: instance is unconfigured (no slug / no instance.json)")
+        return
+    instance_config.publish_recap(recap)
+    logger.info("published recap for %s (%d players)", recap.slug, recap.player_count)
+
+
+def mint_recap_if_needed() -> None:
+    """Mint the recap once, at the ``active → freeze`` edge — the tick-loop hook.
+
+    Idempotent and re-runnable: file-existence is the mint-once flag, so this no-ops on every freeze
+    tick after the first and across a restart in freeze, while an admin deleting ``recaps/{slug}.json``
+    triggers a re-mint on the next tick. Best-effort — a mint failure is logged and swallowed so it can
+    never break the tick loop (the same stance ``instance_config.publish`` takes for the fragment).
+    """
+    slug = instance_config.instance_slug()
+    if slug is None or instance_config.recap_exists(slug):
+        return
+    try:
+        mint_recap()
+    except Exception:  # noqa: BLE001 — best-effort: minting must never break the tick loop
+        logger.exception("failed to mint recap for %s", slug)

--- a/energetica/utils/recap.py
+++ b/energetica/utils/recap.py
@@ -56,13 +56,17 @@ def mint_recap() -> None:
 def mint_recap_if_needed() -> None:
     """Mint the recap once, at the ``active → freeze`` edge — the tick-loop hook.
 
-    Idempotent and re-runnable: file-existence is the mint-once flag, so this no-ops on every freeze
-    tick after the first and across a restart in freeze, while an admin deleting ``recaps/{slug}.json``
-    triggers a re-mint on the next tick. Best-effort — a mint failure is logged and swallowed so it can
-    never break the tick loop (the same stance ``instance_config.publish`` takes for the fragment).
+    Idempotent and re-runnable: a *readable* recap on disk is the mint-once flag, so this no-ops on
+    every freeze tick after the first and across a restart in freeze. The guard is ``load_recap`` —
+    not bare file-existence — so it also **self-heals**: a malformed or unreadable recap reads back as
+    ``None`` and is re-minted on the next tick rather than stranding the lobby with a broken artifact
+    until an admin intervenes. An admin deleting ``recaps/{slug}.json`` re-mints the same way. The
+    re-parse per freeze tick is cheap (a ~15 KB file while the sim is halted). Best-effort — a mint
+    failure is logged and swallowed so it can never break the tick loop (the same stance
+    ``instance_config.publish`` takes for the fragment).
     """
     slug = instance_config.instance_slug()
-    if slug is None or instance_config.recap_exists(slug):
+    if slug is None or instance_config.load_recap(slug) is not None:
         return
     try:
         mint_recap()

--- a/energetica/utils/tick_execution.py
+++ b/energetica/utils/tick_execution.py
@@ -15,6 +15,7 @@ from energetica.enums import ProjectStatus, StorageFacilityType
 from energetica.globals import engine
 from energetica.schemas.simulate import TickAction
 from energetica.utils import projects
+from energetica.utils import recap
 from energetica.schemas.notifications import FacilityDecommissionedPayload
 from energetica.utils.facilities import dismantle_facility, remove_facility
 from energetica.utils.climate_helpers import check_climate_events
@@ -37,6 +38,10 @@ def state_update() -> None:
     # long post-downtime catch-up executes them a little after ``freeze_at`` in wall-clock. Re-checking
     # inside the loop would wrongly *drop* that valid pre-freeze catch-up.
     if instance_config.current_phase() in ("freeze", "ended"):
+        # Mint the recap on the way into freeze (T5, #863): the sim is now halted and the state is
+        # final, so this is where the frozen tombstone is taken. mint-once by file existence, so the
+        # repeated freeze-phase ticks (and a restart in freeze) don't re-photograph it.
+        recap.mint_recap_if_needed()
         return
     total_t = (time.time() - engine.start_date.timestamp()) / engine.clock_time
     while engine.total_t < total_t - 1 or engine.total_t == 0:

--- a/tests/unit/test_freeze_enforcement.py
+++ b/tests/unit/test_freeze_enforcement.py
@@ -11,6 +11,8 @@ config nor a running engine.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 from fastapi import HTTPException, status
 
@@ -52,4 +54,33 @@ def test_state_update_halts_sim_when_frozen(monkeypatch: pytest.MonkeyPatch, fro
         raise AssertionError("tick() must not run once the instance is frozen")
 
     monkeypatch.setattr(tick_execution, "tick", _fail_if_ticked)
+    monkeypatch.setattr(tick_execution.recap, "mint_recap_if_needed", lambda: None)
     tick_execution.state_update()  # returns cleanly; the AssertionError above would fire if it ticked
+
+
+@pytest.mark.parametrize("frozen_phase", ["freeze", "ended"])
+def test_state_update_mints_recap_when_frozen(monkeypatch: pytest.MonkeyPatch, frozen_phase: str) -> None:
+    """Entering freeze mints the recap (T5, #863) on the same halted-sim path that stops ticking."""
+    monkeypatch.setattr(tick_execution.instance_config, "current_phase", lambda: frozen_phase)
+    monkeypatch.setattr(tick_execution, "tick", lambda: None)
+
+    minted: list[bool] = []
+    monkeypatch.setattr(tick_execution.recap, "mint_recap_if_needed", lambda: minted.append(True))
+    tick_execution.state_update()
+
+    assert minted == [True]
+
+
+def test_state_update_does_not_mint_while_live(monkeypatch: pytest.MonkeyPatch) -> None:
+    """While the game is live (active), the recap hook never fires — nothing to snapshot yet."""
+    monkeypatch.setattr(tick_execution.instance_config, "current_phase", lambda: "active")
+    monkeypatch.setattr(tick_execution, "tick", lambda: None)
+    monkeypatch.setattr(tick_execution.engine, "start_date", datetime.now(timezone.utc))
+    monkeypatch.setattr(tick_execution.engine, "clock_time", 60)
+    monkeypatch.setattr(tick_execution.engine, "total_t", 100)
+
+    minted: list[bool] = []
+    monkeypatch.setattr(tick_execution.recap, "mint_recap_if_needed", lambda: minted.append(True))
+    tick_execution.state_update()
+
+    assert minted == []

--- a/tests/unit/test_recap.py
+++ b/tests/unit/test_recap.py
@@ -1,0 +1,290 @@
+"""Unit tests for the recap: schema projection (G1), publish/load primitives, and the mint hook (T5).
+
+The recap is a frozen JSON tombstone minted at ``active → freeze`` and published to the landing dir.
+These tests exercise it without a running engine: the schema projection takes plain player stand-ins
+(it reads by attribute), and the mint path is driven by monkeypatching ``Player.all`` + the config.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from energetica import instance_config
+from energetica.instance_config import InstanceConfig, PublicAccess
+from energetica.schemas.recap import Recap
+from energetica.utils import recap as recap_util
+
+SLUG = "autumn-2025"
+
+
+# --- lightweight player stand-ins (the schema reads by attribute, so it needs no real ORM) ----
+
+
+@dataclass
+class _FakeUser:
+    account_id: int
+
+
+@dataclass
+class _FakeNetwork:
+    name: str
+
+
+@dataclass
+class _FakePlayer:
+    account_id: int
+    _username: str
+    operating_income: float
+    xp: float
+    captured_co2: float
+    net_emissions: float
+    network_name: str | None = None
+
+    @property
+    def user(self) -> _FakeUser:
+        return _FakeUser(account_id=self.account_id)
+
+    @property
+    def username(self) -> str:
+        return self._username
+
+    @property
+    def network(self) -> _FakeNetwork | None:
+        return _FakeNetwork(name=self.network_name) if self.network_name is not None else None
+
+    @property
+    def progression_metrics(self) -> dict[str, float]:
+        return {"operating_income": self.operating_income, "xp": self.xp, "captured_co2": self.captured_co2}
+
+    def calculate_net_emissions(self) -> float:
+        return self.net_emissions
+
+
+def _config() -> InstanceConfig:
+    return InstanceConfig(
+        name="Autumn 2025",
+        advertised=True,
+        starts_at=datetime(2025, 9, 15, tzinfo=timezone.utc),
+        freeze_at=datetime(2025, 12, 1, tzinfo=timezone.utc),
+        access=PublicAccess(policy="public"),
+    )
+
+
+def _players() -> list[_FakePlayer]:
+    return [
+        _FakePlayer(account_id=10, _username="alice", operating_income=500, xp=42, captured_co2=100, net_emissions=-5),
+        _FakePlayer(
+            account_id=20,
+            _username="bob",
+            operating_income=1500,
+            xp=99,
+            captured_co2=250,
+            net_emissions=30,
+            network_name="Grid Co",
+        ),
+        _FakePlayer(account_id=30, _username="carol", operating_income=900, xp=70, captured_co2=0, net_emissions=12),
+    ]
+
+
+# --- Recap.from_players (schema projection, G1) ------------------------------------------------
+
+
+def test_from_players_ranks_by_operating_income_desc() -> None:
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+
+    assert [row.username_at_freeze for row in recap.rows] == ["bob", "carol", "alice"]
+    assert [row.rank for row in recap.rows] == [1, 2, 3]
+
+
+def test_from_players_ties_break_on_account_id_reproducibly() -> None:
+    """Equal-income players rank by ascending account_id, so a re-mint is a reproducible photograph
+    regardless of the order Player.all() enumerates them in.
+    """
+    tied = [
+        _FakePlayer(account_id=30, _username="carol", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
+        _FakePlayer(account_id=10, _username="alice", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
+        _FakePlayer(account_id=20, _username="bob", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
+    ]
+    forward = Recap.from_players(slug=SLUG, config=_config(), players=tied)
+    reshuffled = Recap.from_players(slug=SLUG, config=_config(), players=list(reversed(tied)))
+
+    assert [row.account_id for row in forward.rows] == [10, 20, 30]
+    assert forward.rows == reshuffled.rows  # identical frozen photograph across enumeration order
+
+
+def test_from_players_projects_the_curated_columns() -> None:
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+    winner = recap.rows[0]
+
+    assert winner.account_id == 20  # FK retained for future identity resolution
+    assert winner.username_at_freeze == "bob"
+    assert winner.network_name == "Grid Co"
+    assert winner.operating_income == 1500
+    assert winner.xp == 99
+    assert winner.captured_co2 == 250
+
+
+def test_from_players_network_is_none_when_unaffiliated() -> None:
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+
+    assert recap.rows[2].network_name is None  # alice, no network
+
+
+def test_from_players_totals_header() -> None:
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+
+    assert recap.player_count == 3
+    assert recap.total_captured_co2 == 350  # 100 + 250 + 0
+    assert recap.total_net_emissions == 37  # -5 + 30 + 12
+
+
+def test_from_players_carries_identity_header() -> None:
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+
+    assert recap.slug == SLUG
+    assert recap.name == "Autumn 2025"
+    assert recap.starts_at == datetime(2025, 9, 15, tzinfo=timezone.utc)
+    assert recap.freeze_at == datetime(2025, 12, 1, tzinfo=timezone.utc)
+    assert recap.ended_at is None
+
+
+def test_from_players_empty_instance() -> None:
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=[])
+
+    assert recap.player_count == 0
+    assert recap.rows == []
+    assert recap.total_captured_co2 == 0
+    assert recap.total_net_emissions == 0
+
+
+# --- publish / load / exists primitives (instance_config) --------------------------------------
+
+
+@pytest.fixture
+def landing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the module at a per-test landing dir and set the slug."""
+    landing_dir = tmp_path / "landing"
+    monkeypatch.setenv("ENERGETICA_INSTANCE_SLUG", SLUG)
+    monkeypatch.setenv("ENERGETICA_LANDING_DIR", str(landing_dir))
+    return landing_dir
+
+
+def test_publish_then_load_round_trips(landing: Path) -> None:
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+
+    assert instance_config.recap_exists(SLUG) is False
+    instance_config.publish_recap(recap)
+
+    assert instance_config.recap_exists(SLUG) is True
+    assert instance_config.recap_path(SLUG) == landing / "recaps" / f"{SLUG}.json"
+    loaded = instance_config.load_recap(SLUG)
+    assert loaded == recap
+
+
+def test_publish_is_not_world_readable(landing: Path) -> None:
+    """The atomic write mode is group-readable (0o640) but not world-readable — same as fragments."""
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+    instance_config.publish_recap(recap)
+
+    mode = instance_config.recap_path(SLUG).stat().st_mode & 0o777
+    assert mode == 0o640
+
+
+def test_recap_is_not_aggregated_into_the_manifest(landing: Path) -> None:
+    """A recap lives beside the fragment but is deliberately kept out of instances.json."""
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+    instance_config.publish_recap(recap)
+
+    assert not (landing / "instances.json").exists()  # publish_recap doesn't aggregate
+
+
+def test_load_recap_absent_is_none(landing: Path) -> None:
+    assert instance_config.load_recap(SLUG) is None
+
+
+def test_load_recap_corrupt_is_none(landing: Path) -> None:
+    path = instance_config.recap_path(SLUG)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ not valid json", encoding="utf-8")
+
+    assert instance_config.load_recap(SLUG) is None
+
+
+# --- mint orchestration (utils.recap) ----------------------------------------------------------
+
+
+@pytest.fixture
+def configured(landing: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """On-disk instance.json alongside the landing dir, plus a patched Player.all."""
+    config_dir = tmp_path / "etc"
+    target = config_dir / SLUG / "instance.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_config().model_dump_json(), encoding="utf-8")
+    monkeypatch.setenv("ENERGETICA_INSTANCE_CONFIG_DIR", str(config_dir))
+    monkeypatch.setattr(recap_util.Player, "all", classmethod(lambda cls: _players()))
+    return config_dir
+
+
+def test_mint_recap_publishes(configured: Path) -> None:
+    recap_util.mint_recap()
+
+    loaded = instance_config.load_recap(SLUG)
+    assert loaded is not None
+    assert loaded.player_count == 3
+    assert loaded.rows[0].username_at_freeze == "bob"
+
+
+def test_mint_recap_if_needed_is_mint_once(configured: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The frozen photograph is taken once — a second call after the file exists is a no-op."""
+    recap_util.mint_recap_if_needed()
+    first = instance_config.load_recap(SLUG)
+    assert first is not None
+
+    # The state changes, but the already-minted recap must not be re-photographed.
+    monkeypatch.setattr(
+        recap_util.Player,
+        "all",
+        classmethod(
+            lambda cls: [
+                _FakePlayer(
+                    account_id=99, _username="latecomer", operating_income=9999, xp=0, captured_co2=0, net_emissions=0
+                )
+            ]
+        ),
+    )
+    recap_util.mint_recap_if_needed()
+
+    assert instance_config.load_recap(SLUG) == first
+
+
+def test_mint_recap_regenerates_after_delete(configured: Path) -> None:
+    """Admin delete/regenerate: once the file is gone, the next mint-if-needed re-mints it."""
+    recap_util.mint_recap_if_needed()
+    instance_config.recap_path(SLUG).unlink()
+
+    recap_util.mint_recap_if_needed()
+
+    assert instance_config.recap_exists(SLUG) is True
+
+
+def test_mint_recap_noop_when_unconfigured(landing: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dev/legacy instance with no slug mints nothing (no lifecycle to snapshot)."""
+    monkeypatch.delenv("ENERGETICA_INSTANCE_SLUG", raising=False)
+
+    assert recap_util.build_recap() is None
+    recap_util.mint_recap_if_needed()  # must not raise
+
+
+def test_mint_recap_if_needed_swallows_errors(configured: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mint failure is best-effort — it is logged and swallowed, never breaking the tick loop."""
+
+    def _boom() -> Recap | None:
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(recap_util, "build_recap", _boom)
+
+    recap_util.mint_recap_if_needed()  # does not raise

--- a/tests/unit/test_recap.py
+++ b/tests/unit/test_recap.py
@@ -271,6 +271,21 @@ def test_mint_recap_regenerates_after_delete(configured: Path) -> None:
     assert instance_config.recap_exists(SLUG) is True
 
 
+def test_mint_recap_reheals_corrupt_file(configured: Path) -> None:
+    """A malformed recap on disk self-heals: the load-based guard re-mints it rather than treating
+    the corrupt file as 'already minted' and stranding the lobby with it.
+    """
+    path = instance_config.recap_path(SLUG)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ not valid json", encoding="utf-8")
+
+    recap_util.mint_recap_if_needed()
+
+    healed = instance_config.load_recap(SLUG)
+    assert healed is not None
+    assert healed.player_count == 3
+
+
 def test_mint_recap_noop_when_unconfigured(landing: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A dev/legacy instance with no slug mints nothing (no lifecycle to snapshot)."""
     monkeypatch.delenv("ENERGETICA_INSTANCE_SLUG", raising=False)


### PR DESCRIPTION
Implements **T5 · Recap mint + publish hook** (#863) per G1's resolved schema (#859), part of the server-lifecycle epic (#856).

## What it does

Mints the **recap** — a frozen JSON tombstone of the final leaderboard — once the instance's own clock crosses `freeze_at`, and publishes it to the lobby landing dir (`recaps/{slug}.json`) where it outlives instance teardown (T7).

## Changes

- **`energetica/schemas/recap.py`** — `Recap`/`RecapRow`, the curated income-ranked projection (per-row `rank`/`account_id`/`username_at_freeze`/`network_name`/`operating_income`/`xp`/`captured_co2` + totals header `player_count`/`total_captured_co2`/`total_net_emissions`). Reads players through a structural `RecapPlayer` protocol, so the schema stays game-ORM-free and testable with plain stand-ins. Ties break on the immutable `account_id`, so a re-mint is a reproducible frozen photograph.
- **`energetica/instance_config.py`** — `recap_path`/`recap_exists`/`publish_recap`/`load_recap`, reusing the atomic-write mechanism and writing beside the fragment — deliberately **not** aggregated into `instances.json`. Extracts a shared `_load_json_or_none` read-or-warn helper (fragments + recap).
- **`energetica/utils/recap.py`** — `build_recap` / `mint_recap` (force-overwrite primitive) / `mint_recap_if_needed` (mint-once by file existence).
- **`energetica/utils/tick_execution.py`** — fires `mint_recap_if_needed` on the halted-sim freeze path, best-effort so a mint failure never breaks the tick loop.

## How it satisfies the ticket

- **Mint once at active→freeze** — hangs off T3's (#861) freeze branch in `state_update`.
- **Idempotent / re-runnable** — file-existence is the mint-once flag; admin `rm` of the file auto-re-mints on the next freeze tick (Felix's "manual delete/regenerate").
- **Visibility** — phase-derived per G1 (reveal-at-freeze-start == publish-at-mint), no flag.
- **Survives teardown** — the artifact lives on the landing dir, not in the process.

**Deferred correctly** (out of T5 scope): lobby discovery/render is **T6** (#864); `teardown-instance.sh` recap-survival validation is **T7** (#865).

## Testing

New: 18 recap tests + 3 freeze-hook tests. Full suite green (286 passed). Two pre-existing failures remain unrelated to this change and fail identically on a clean tree — `test_daily_quiz_links` (live network requests) and `test_server_runs` (spawns a `python` binary absent from this sandbox's PATH).

Reviewed via `/code-review` (Standards + Spec axes); acted on the findings — extracted the shared read helper, added the deterministic tiebreak, and corrected a doc overclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds frozen leaderboard recaps when an instance reaches its freeze phase.

- Adds recap schema and player projection models.
- Publishes recap JSON beside instance fragments.
- Mints once during freeze or ended ticks.
- Adds recap and freeze-hook tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/schemas/recap.py | Adds the deterministic frozen recap projection and ranking model. |
| energetica/instance_config.py | Adds recap file persistence and tolerant static JSON loading. |
| energetica/utils/recap.py | Builds, publishes, and repairs missing or unreadable recaps during frozen ticks. |
| energetica/utils/tick_execution.py | Runs the recap mint hook before returning from freeze and ended phases. |
| tests/unit/test_recap.py | Covers recap projection, persistence, regeneration, and corrupt-file recovery. |

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/felixvonsamson/energetica/commit/826699a8a198c728360bdf25f477a6cfa6c6de8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45320448)</sub>

<!-- /greptile_comment -->