### PR TITLE
docs: plain-writing guidance for reader-facing prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 Web game for energy systems with a focus on electricity.
 
+## Writing for people (GitHub, docs, code comments, commits)
+
+Prose others read should be plain and direct. Lead with the point. Write complete,
+ordinary sentences that stay concise while remaining easy to read. Prefer literal
+phrasing and common words. Explain programming jargon on first use (project and domain
+terms are fine). In-session conversational style is exempt.
+
 ## Stack
 
 Backend(`energetica/`): Python + FastAPI backend


### PR DESCRIPTION
Adds a CLAUDE.md section asking for plain, direct writing in prose that others read: GitHub issues, PRs, and comments above all, but also docs, code comments, and commit messages.

Recent GitHub content had drifted two opposite ways, both hard to read — padding without reaching the point, and over-compressed, telegraphic phrasing. The new guidance asks for the point up front, complete and concise sentences, literal phrasing, common words, and an explanation of programming jargon on first use (project and domain terms stay as-is). In-session conversational style is exempt and left to each contributor's personal settings.

The guidance is written in positive framing (what to aim for) and kept to five lines, so it models the advice it gives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds guidance for clear reader-facing prose. The main changes are:

- Adds plain-writing guidance to `CLAUDE.md`.
- Covers GitHub content, docs, comments, and commits.
- Exempts in-session conversational style.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Adds concise guidance for plain, direct prose in reader-facing project content. |

<sub>Reviews (1): Last reviewed commit: ["docs: add plain-writing guidance for rea..."](https://github.com/felixvonsamson/energetica/commit/19cd0f370d7dd992b0c7959c27d4e6c524b3c064) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45360269)</sub>

<!-- /greptile_comment -->