### PR TITLE
feat(deploy): report the deployed version of each component via /healthz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ admin_accounts.txt
 .env
 frontend/.env
 .claude
+
+# Deploy-time backend version stamp — written on the server by scripts/deploy-*.sh, and
+# never committed (would be stale the moment it lands). See scripts/lib/version-stamp.sh.
+DEPLOYED_VERSION.json

--- a/energetica/__init__.py
+++ b/energetica/__init__.py
@@ -11,7 +11,6 @@ import platform
 import secrets
 import shutil
 import socket
-import subprocess
 import tarfile
 import uuid
 from contextlib import asynccontextmanager
@@ -90,13 +89,6 @@ def create_app(
         app = FastAPI()
         setup_routes(app)
         return app
-
-    try:
-        engine.git_sha = (
-            subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        engine.git_sha = None
 
     print(f"Server is running in {env} mode")
     if simulate_checkpoint_ticks is None:

--- a/energetica/game_engine.py
+++ b/energetica/game_engine.py
@@ -75,7 +75,6 @@ class GameEngine(object):
         self.resim_start_tick: int | None = None
         self.resim_target_tick: int | None = None
         self.scheduler_exception_count: int = 0
-        self.git_sha: str | None = None
 
         with open(_DATA_DIR / "industry_demand.pck", "rb") as file:
             # array of length 1440 of normalized daily industry demand variations

--- a/energetica/routers/health.py
+++ b/energetica/routers/health.py
@@ -21,10 +21,13 @@ from fastapi import APIRouter
 from energetica.database.player import Player
 from energetica.database.network import Network
 from energetica.globals import engine
+from energetica.utils.version import backend_version, frontend_version
 
 router = APIRouter(prefix="", tags=["Health"])
 
 STATIC_INDEX_PATH = "energetica/static/app/index.html"
+# Where the built app bundle (and its build-info.json stamp) lives, relative to the repo root.
+APP_BUNDLE_SUBPATH = "energetica/static/app"
 PICKLE_PATH = "instance/engine_data.pck"
 
 Status = Literal["loading_actions", "resimulating", "ok", "degraded"]
@@ -90,9 +93,13 @@ def healthz() -> dict:
 
     uptime_s = int((datetime.datetime.now(datetime.timezone.utc) - engine.server_start_time).total_seconds())
 
+    backend = backend_version()
+
     body: dict = {
         "status": status,
-        "git_sha": engine.git_sha,
+        # Kept for backward compatibility with older probes; the full picture is under "version".
+        "git_sha": backend["commit"] if backend else None,
+        "version": {"backend": backend, "frontend": frontend_version(APP_BUNDLE_SUBPATH)},
         "uptime_s": uptime_s,
         "engine": {
             "loaded": engine.clock_time is not None,

--- a/energetica/utils/version.py
+++ b/energetica/utils/version.py
@@ -1,0 +1,76 @@
+"""Report the deployed version of each half of the app for ``/healthz``.
+
+The backend and the frontend are shipped by different deploy steps and can drift apart
+(a frontend-only redeploy from a dirty tree against an unchanged backend is routine), so
+each half is stamped separately:
+
+- **backend** — ``scripts/deploy-*.sh`` write ``DEPLOYED_VERSION.json`` at the repo root on
+  the server at rsync time. The deploy machine has a git checkout; the server does not
+  (deploys rsync with ``--exclude='.git'``), so the commit must be captured before shipping.
+- **frontend** — the vite build writes ``build-info.json`` into the bundle it emits
+  (``energetica/static/app`` for an instance, ``dist-lobby`` for the lobby), and it rsyncs
+  to the server with the rest of the bundle.
+
+In local dev neither file exists, so the backend half falls back to reading git directly.
+Everything here fails soft: an unreadable or absent stamp yields ``None``, never an
+exception — ``/healthz`` must answer even when the version is unknown.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+# energetica/utils/version.py -> energetica/utils -> energetica -> repo root. On the server the
+# "repo root" is the instance dir (e.g. /var/www/energetica-hertz), which is where the deploy
+# script writes DEPLOYED_VERSION.json and under which the frontend bundles live.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_BACKEND_STAMP = REPO_ROOT / "DEPLOYED_VERSION.json"
+
+
+def _read_json(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _git(*args: str) -> str | None:
+    try:
+        out = subprocess.check_output(["git", *args], cwd=REPO_ROOT, stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    return out.decode().strip()
+
+
+def _git_fallback() -> dict | None:
+    """Read the version straight from git — the local-dev path, where a checkout exists."""
+    commit = _git("rev-parse", "HEAD")
+    if commit is None:
+        return None
+    porcelain = _git("status", "--porcelain")
+    return {
+        "commit": commit,
+        "commit_short": commit[:9],
+        "branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+        # None (not False) when git could not be queried, so "clean" and "unknown" stay distinct.
+        "dirty": None if porcelain is None else bool(porcelain),
+        "source": "git",
+    }
+
+
+def backend_version() -> dict | None:
+    """The deployed backend version: the deploy stamp if present, else git (local dev)."""
+    return _read_json(_BACKEND_STAMP) or _git_fallback()
+
+
+def frontend_version(bundle_subpath: str) -> dict | None:
+    """The built frontend version stamped into ``{bundle_subpath}/build-info.json``.
+
+    ``bundle_subpath`` is relative to the repo/instance root (e.g. ``energetica/static/app``
+    or ``dist-lobby``). Returns ``None`` when the bundle has no stamp — an old bundle built
+    before this stamping existed, or a dev server that serves the app from vite instead.
+    """
+    return _read_json(REPO_ROOT / bundle_subpath / "build-info.json")

--- a/frontend/vite.config.lobby.ts
+++ b/frontend/vite.config.lobby.ts
@@ -5,6 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
 import {
+    buildInfoPlugin,
     DEV_PORTS,
     loadDeploymentEnv,
     resolveLobbyProxyTarget,
@@ -52,6 +53,7 @@ export default defineConfig(({ mode }) => {
     return {
         plugins: [
             lobbyHtmlFallback,
+            buildInfoPlugin(),
             // Please make sure that '@tanstack/router-plugin' is passed before '@vitejs/plugin-react'
             tanstackRouter({
                 target: "react",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,7 @@ import svgr from "vite-plugin-svgr";
 import path from "path";
 
 import {
+    buildInfoPlugin,
     DEV_PORTS,
     explicitBackendUrl,
     instanceSlugFromBackend,
@@ -120,6 +121,7 @@ export default defineConfig(async ({ mode, command }) => {
     return {
         plugins: [
             devRootRedirect,
+            buildInfoPlugin(),
             // Please make sure that '@tanstack/router-plugin' is passed before '@vitejs/plugin-react'
             tanstackRouter({
                 target: "react",

--- a/frontend/vite.shared.ts
+++ b/frontend/vite.shared.ts
@@ -1,7 +1,8 @@
+import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
 
-import { loadEnv, type ProxyOptions } from "vite";
+import { loadEnv, type Plugin, type ProxyOptions } from "vite";
 
 /**
  * Fixed dev-server ports, one per surface, so the app and lobby (and landing)
@@ -142,3 +143,68 @@ export const rewriteSetCookieForLocalhost: NonNullable<
         }
     });
 };
+
+/**
+ * Run a git command from the frontend dir, returning trimmed stdout or `null`
+ * on any failure.
+ */
+function git(args: string[]): string | null {
+    try {
+        return execSync(`git ${args.join(" ")}`, {
+            stdio: ["ignore", "pipe", "ignore"],
+        })
+            .toString()
+            .trim();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * The git state at build time, written verbatim into each bundle's
+ * build-info.json. `dirty` reflects the whole tree (git cannot cheaply
+ * attribute uncommitted changes to the frontend alone), so it means "the tree
+ * had uncommitted changes when this bundle was built" — the signal that the
+ * `commit` below may not be the whole truth. `null` fields mean git could not
+ * be queried (e.g. a source tarball with no .git); the frontend and backend are
+ * stamped independently precisely because they can be built from different
+ * states.
+ */
+export function gitBuildInfo(): Record<string, string | boolean | null> {
+    const commit = git(["rev-parse", "HEAD"]);
+    const porcelain = git(["status", "--porcelain"]);
+    return {
+        commit,
+        commit_short: commit ? commit.slice(0, 9) : null,
+        branch: git(["rev-parse", "--abbrev-ref", "HEAD"]),
+        // null (not false) when git could not be queried, so "clean" and "unknown" stay distinct.
+        dirty: porcelain === null ? null : porcelain.length > 0,
+        built_at: new Date().toISOString(),
+        source: "build",
+    };
+}
+
+/**
+ * Write build-info.json into the build output dir so the backend's /healthz can
+ * report the deployed frontend version. Build-only (`apply: "build"`): a dev
+ * server serves the app from vite, not from a bundle, so there is nothing to
+ * stamp. Runs at closeBundle — after Vite has emitted (and, with emptyOutDir,
+ * cleared then repopulated) the dir — so the stamp survives.
+ */
+export function buildInfoPlugin(): Plugin {
+    let outDir = "";
+    return {
+        name: "energetica-build-info",
+        apply: "build",
+        configResolved(config) {
+            outDir = config.build.outDir;
+        },
+        closeBundle() {
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(outDir, "build-info.json"),
+                JSON.stringify(gitBuildInfo(), null, 2) + "\n",
+            );
+        },
+    };
+}

--- a/lobby/app.py
+++ b/lobby/app.py
@@ -13,7 +13,12 @@ from fastapi.responses import JSONResponse
 
 from energetica.game_error import GameError
 from energetica.schemas.common import GameErrorOut
+from energetica.utils.version import backend_version, frontend_version
 from lobby.routers import auth_router, lobby_router
+
+# The lobby serves its SPA from dist-lobby (see scripts/deploy-lobby.sh), so that is where its
+# frontend build stamp lives — relative to the repo/instance root that version.py resolves against.
+LOBBY_BUNDLE_SUBPATH = "dist-lobby"
 
 
 def create_lobby_app(*, schema_only: bool = False) -> FastAPI:
@@ -38,6 +43,22 @@ def create_lobby_app(*, schema_only: bool = False) -> FastAPI:
         """Mirror the game's 400 GameError envelope so the frontend decodes lobby errors identically."""
         content = GameErrorOut.from_game_error(exc)
         return JSONResponse(content=content.model_dump(by_alias=True), status_code=status.HTTP_400_BAD_REQUEST)
+
+    @app.get("/healthz", include_in_schema=False)
+    def healthz() -> dict:
+        """Deployed-version probe for the lobby.
+
+        The lobby is engine-free, so this reports only liveness and the deployed version of
+        each half — no tick counters or game state (unlike the instance ``/healthz``). The
+        deploy script and drift-check tooling read the same "version" shape from both.
+        """
+        return {
+            "status": "ok",
+            "version": {
+                "backend": backend_version(),
+                "frontend": frontend_version(LOBBY_BUNDLE_SUBPATH),
+            },
+        }
 
     app.include_router(auth_router, prefix="/api/v1")
     app.include_router(lobby_router, prefix="/api/v1")

--- a/scripts/DEPLOYMENT.md
+++ b/scripts/DEPLOYMENT.md
@@ -143,6 +143,37 @@ ssh energetica-game 'sudo systemctl restart energetica-autumn-2025'
 curl https://autumn-2025.energetica-game.org/healthz
 ```
 
+## Checking what is deployed
+
+The server has no git checkout (deploys rsync with `--exclude='.git'`), so a component cannot
+read its own commit from git. Instead each half is stamped, and both are reported by `/healthz`:
+
+- **Backend** — `deploy-instance.sh` / `deploy-lobby.sh` write `DEPLOYED_VERSION.json` to the
+  deploy root at rsync time, capturing the commit, branch, dirty flag, deployer, and timestamp.
+- **Frontend** — the vite build writes `build-info.json` into the bundle it emits.
+
+`/healthz` reads both and returns a `version` block:
+
+```json
+{ "status": "ok",
+  "version": {
+    "backend":  { "commit_short": "abc123def", "dirty": false, "deployed_by": "you", "source": "deploy" },
+    "frontend": { "commit_short": "abc123def", "dirty": false, "source": "build" } } }
+```
+
+The lobby now serves `/healthz` too (it previously had none). To see every component on a server
+and how each compares to `origin/main` in one table:
+
+```bash
+git fetch origin main
+./scripts/deployed-versions.sh --server energetica-game --domain energetica-game.org
+```
+
+A `*` next to a commit means it was built or deployed from a tree with uncommitted changes, so
+the commit alone does not fully describe what is running. Backend and frontend are stamped
+independently because they can be shipped from different states (a frontend-only redeploy is
+routine).
+
 ## Rollback
 
 (Not yet implemented. Re-deploy a previous local checkout with `deploy-instance.sh`.)

--- a/scripts/deploy-instance.sh
+++ b/scripts/deploy-instance.sh
@@ -120,13 +120,6 @@ rsync -az --delete \
     ./ "$SSH:$REMOTE_PATH/" >/dev/null
 log_success "Backend synced"
 
-# --- 3b. Stamp the deployed backend version -------------------------------------
-# The server has no .git (rsync excludes it), so /healthz cannot read the commit itself.
-# Capture it here — on the deploy machine, which does have git — and write it to the
-# instance root as DEPLOYED_VERSION.json. It is excluded from the rsync above so --delete
-# never prunes it, and it is rewritten on every deploy. Read by energetica/utils/version.py.
-stamp_deployed_version "$SSH" "$REMOTE_PATH"
-
 # --- 4. rsync app bundle (hashed assets need pruning → --delete) ---------------
 log_step "Syncing app bundle..."
 rsync -az --delete ./energetica/static/app/ "$SSH:$REMOTE_PATH/energetica/static/app/" >/dev/null
@@ -176,6 +169,14 @@ while [ "$(date +%s)" -lt "$HEALTH_DEADLINE" ]; do
 done
 [ "$HEALTH_OK" = true ] || { log_error "/healthz did not reach status=ok within 600s"; echo "Logs: ssh $SSH 'sudo journalctl -u energetica-$INSTANCE -f'"; exit 1; }
 log_success "/healthz status=ok"
+
+# --- 8. Stamp the deployed backend version -------------------------------------
+# Written only now — after the new process is confirmed serving — so /healthz never reports a
+# commit that failed to activate. The server has no .git (rsync excludes it), so the commit is
+# captured here on the deploy machine and written to the instance root as DEPLOYED_VERSION.json.
+# It is excluded from the rsync --delete above, so between restart and this write /healthz keeps
+# reporting the *previous* commit rather than a wrong one. Read by energetica/utils/version.py.
+stamp_deployed_version "$SSH" "$REMOTE_PATH"
 
 echo
 log_success "Deployed $INSTANCE → https://$FQDN"

--- a/scripts/deploy-instance.sh
+++ b/scripts/deploy-instance.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# shellcheck source=lib/version-stamp.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/version-stamp.sh"
+
 # Energetica — deploy a single instance (Option A: no git on the server, rsync only).
 #
 #   ./scripts/deploy-instance.sh --server <ssh-host> --instance <instance> --domain <apex> \
@@ -113,8 +116,16 @@ rsync -az --delete \
     --exclude='__pycache__' \
     --exclude='*.pyc' \
     --exclude='energetica/static/app' \
+    --exclude='DEPLOYED_VERSION.json' \
     ./ "$SSH:$REMOTE_PATH/" >/dev/null
 log_success "Backend synced"
+
+# --- 3b. Stamp the deployed backend version -------------------------------------
+# The server has no .git (rsync excludes it), so /healthz cannot read the commit itself.
+# Capture it here — on the deploy machine, which does have git — and write it to the
+# instance root as DEPLOYED_VERSION.json. It is excluded from the rsync above so --delete
+# never prunes it, and it is rewritten on every deploy. Read by energetica/utils/version.py.
+stamp_deployed_version "$SSH" "$REMOTE_PATH"
 
 # --- 4. rsync app bundle (hashed assets need pruning → --delete) ---------------
 log_step "Syncing app bundle..."

--- a/scripts/deploy-lobby.sh
+++ b/scripts/deploy-lobby.sh
@@ -130,11 +130,6 @@ rsync -az --delete \
     ./ "$SSH:$REMOTE_PATH/" >/dev/null
 log_success "Backend synced"
 
-# Stamp the deployed backend version (the server has no .git; the deploy machine does). Excluded
-# from the rsync above so --delete never prunes it. Read by energetica/utils/version.py for
-# the lobby's /healthz. See scripts/lib/version-stamp.sh.
-stamp_deployed_version "$SSH" "$REMOTE_PATH"
-
 # --- 5. rsync lobby bundle (hashed assets need pruning → --delete) ------------------
 log_step "Syncing lobby bundle..."
 # Apache reads the bundle via the energetica group (the tree is 2750 deploy:energetica), and
@@ -209,6 +204,13 @@ if [ "$HEALTH_OK" != true ]; then
     exit 1
 fi
 log_success "Lobby healthy (SPA 200, my-runs 401, manifest 200, accounts.db reachable)"
+
+# Stamp the deployed backend version — only now, after the new lobby is confirmed serving, so
+# /healthz never reports a commit that failed to activate. The server has no .git (rsync excludes
+# it), so the commit is captured here on the deploy machine. Excluded from the rsync --delete
+# above, so between restart and this write /healthz keeps reporting the previous commit rather
+# than a wrong one. Read by energetica/utils/version.py. See scripts/lib/version-stamp.sh.
+stamp_deployed_version "$SSH" "$REMOTE_PATH"
 
 echo
 log_success "Deployed lobby → https://$FQDN"

--- a/scripts/deploy-lobby.sh
+++ b/scripts/deploy-lobby.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# shellcheck source=lib/version-stamp.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/version-stamp.sh"
+
 # Energetica — deploy the lobby service (backend + SPA bundle, rsync only, no git).
 #
 #   ./scripts/deploy-lobby.sh --server <ssh-host> --domain <apex> \
@@ -123,8 +126,14 @@ rsync -az --delete \
     --exclude='*.pyc' \
     --exclude='energetica/static/app' \
     --exclude='dist-lobby/' \
+    --exclude='DEPLOYED_VERSION.json' \
     ./ "$SSH:$REMOTE_PATH/" >/dev/null
 log_success "Backend synced"
+
+# Stamp the deployed backend version (the server has no .git; the deploy machine does). Excluded
+# from the rsync above so --delete never prunes it. Read by energetica/utils/version.py for
+# the lobby's /healthz. See scripts/lib/version-stamp.sh.
+stamp_deployed_version "$SSH" "$REMOTE_PATH"
 
 # --- 5. rsync lobby bundle (hashed assets need pruning → --delete) ------------------
 log_step "Syncing lobby bundle..."

--- a/scripts/deployed-versions.sh
+++ b/scripts/deployed-versions.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+
+# Energetica — show the deployed version of every instance + the lobby on a server, and how
+# each compares to a reference commit (default: origin/main).
+#
+#   ./scripts/deployed-versions.sh --server <ssh-host> --domain <apex> \
+#        [--user <ssh-user>] [--ref <git-ref>]
+#
+# Reads each component's public /healthz (added for the lobby in the same change that added
+# this script) and prints its stamped backend commit, frontend commit, dirty flags, and a
+# BEHIND / up-to-date / dirty verdict against the reference. Instances are enumerated from
+# systemd, the same source of truth as list-instances.sh.
+#
+# This is a read-only diagnostic — it deploys nothing. Requires git (locally) and jq.
+
+REMOTE_HOST="${DEPLOY_HOST:-}"
+REMOTE_USER="${DEPLOY_USER:-deploy}"
+DOMAIN="${DEPLOY_DOMAIN:-}"
+REF="origin/main"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server) REMOTE_HOST="$2"; shift 2 ;;
+        --domain) DOMAIN="$2"; shift 2 ;;
+        --user) REMOTE_USER="$2"; shift 2 ;;
+        --ref) REF="$2"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+[ -n "$REMOTE_HOST" ] || { echo "--server is required (or set DEPLOY_HOST)" >&2; exit 1; }
+[ -n "$DOMAIN" ]      || { echo "--domain is required (or set DEPLOY_DOMAIN)" >&2; exit 1; }
+command -v jq  >/dev/null || { echo "jq is required (used to parse /healthz)." >&2; exit 1; }
+command -v git >/dev/null || { echo "git is required (used to resolve the reference commit)." >&2; exit 1; }
+
+SSH="${REMOTE_USER}@${REMOTE_HOST}"
+
+# Reference commit to compare against. Short to 9 chars to match the stamp (git --short=9 /
+# version.py's commit[:9]). A missing ref (e.g. origin/main not fetched) is fatal: comparing
+# against nothing would silently call every deploy "unknown".
+REF_FULL=$(git rev-parse "$REF" 2>/dev/null) || { echo "Cannot resolve git ref '$REF' — fetch it first (e.g. 'git fetch origin main')." >&2; exit 1; }
+REF_SHORT=${REF_FULL:0:9}
+echo "Reference: $REF = $REF_SHORT"
+echo
+
+# Enumerate instance slugs from systemd (same source of truth as list-instances.sh), then
+# probe the lobby too. The landing site is pure static with no /healthz, so it is not listed.
+SLUGS=$(ssh "$SSH" 'systemctl list-unit-files --no-legend "energetica-*.service" 2>/dev/null | awk "{print \$1}" | grep "^energetica-.*\.service$" | sed -E "s/^energetica-(.*)\.service$/\1/" | grep -v "^lobby$"' || true)
+
+# One /healthz probe → one table row. Verdict precedence: unreachable > no stamp > dirty >
+# behind > up-to-date. "dirty" (either half) wins over "behind" because a dirty deploy's commit
+# is not fully trustworthy in the first place — flag that before comparing SHAs.
+probe() {
+    local label="$1" url="$2"
+    local body be fe be_dirty fe_dirty verdict
+    body=$(curl -fsS --max-time 8 "$url/healthz" 2>/dev/null || true)
+    if [ -z "$body" ]; then
+        echo "$label|$url|unreachable|-|UNREACHABLE"; return
+    fi
+    be=$(echo "$body" | jq -r '.version.backend.commit_short // "?"' 2>/dev/null || echo "?")
+    fe=$(echo "$body" | jq -r '.version.frontend.commit_short // "?"' 2>/dev/null || echo "?")
+    be_dirty=$(echo "$body" | jq -r '.version.backend.dirty // false' 2>/dev/null || echo false)
+    fe_dirty=$(echo "$body" | jq -r '.version.frontend.dirty // false' 2>/dev/null || echo false)
+    [ "$be_dirty" = "true" ] && be="$be*"
+    [ "$fe_dirty" = "true" ] && fe="$fe*"
+
+    if [ "$be" = "?" ]; then
+        verdict="no-stamp"
+    elif [ "$be_dirty" = "true" ] || [ "$fe_dirty" = "true" ]; then
+        verdict="DIRTY"
+    elif [ "${be%\*}" = "$REF_SHORT" ]; then
+        verdict="up-to-date"
+    else
+        verdict="BEHIND"
+    fi
+    echo "$label|$url|$be|$fe|$verdict"
+}
+
+{
+    echo "COMPONENT|URL|BACKEND|FRONTEND|VS-REF"
+    probe "lobby" "https://lobby.$DOMAIN"
+    for slug in $SLUGS; do
+        probe "$slug" "https://$slug.$DOMAIN"
+    done
+} | column -t -s '|'
+
+echo
+echo "* = built/deployed from a tree with uncommitted changes (commit is not the whole truth)."

--- a/scripts/deployed-versions.sh
+++ b/scripts/deployed-versions.sh
@@ -48,16 +48,30 @@ echo
 # probe the lobby too. The landing site is pure static with no /healthz, so it is not listed.
 SLUGS=$(ssh "$SSH" 'systemctl list-unit-files --no-legend "energetica-*.service" 2>/dev/null | awk "{print \$1}" | grep "^energetica-.*\.service$" | sed -E "s/^energetica-(.*)\.service$/\1/" | grep -v "^lobby$"' || true)
 
+# Classify a deployed backend commit against the reference by git ancestry, so a deploy that is
+# ahead of or diverged from the reference is not mislabelled "behind". Needs the commit object
+# present locally; a deploy built from an unfetched commit is reported "differs?" rather than
+# guessed. Callers handle the unknown/dirty cases before this runs.
+classify() {
+    local commit="$1"
+    [ "$commit" = "$REF_FULL" ] && { echo "up-to-date"; return; }
+    git cat-file -e "${commit}^{commit}" 2>/dev/null || { echo "differs?"; return; }
+    git merge-base --is-ancestor "$commit" "$REF_FULL" 2>/dev/null && { echo "BEHIND"; return; }
+    git merge-base --is-ancestor "$REF_FULL" "$commit" 2>/dev/null && { echo "ahead"; return; }
+    echo "DIVERGED"
+}
+
 # One /healthz probe → one table row. Verdict precedence: unreachable > no stamp > dirty >
-# behind > up-to-date. "dirty" (either half) wins over "behind" because a dirty deploy's commit
-# is not fully trustworthy in the first place — flag that before comparing SHAs.
+# ancestry (behind / ahead / diverged / up-to-date). "dirty" (either half) wins over the ancestry
+# verdict because a dirty deploy's commit is not fully trustworthy in the first place.
 probe() {
     local label="$1" url="$2"
-    local body be fe be_dirty fe_dirty verdict
+    local body be_full be fe be_dirty fe_dirty verdict
     body=$(curl -fsS --max-time 8 "$url/healthz" 2>/dev/null || true)
     if [ -z "$body" ]; then
         echo "$label|$url|unreachable|-|UNREACHABLE"; return
     fi
+    be_full=$(echo "$body" | jq -r '.version.backend.commit // ""' 2>/dev/null || echo "")
     be=$(echo "$body" | jq -r '.version.backend.commit_short // "?"' 2>/dev/null || echo "?")
     fe=$(echo "$body" | jq -r '.version.frontend.commit_short // "?"' 2>/dev/null || echo "?")
     be_dirty=$(echo "$body" | jq -r '.version.backend.dirty // false' 2>/dev/null || echo false)
@@ -65,14 +79,12 @@ probe() {
     [ "$be_dirty" = "true" ] && be="$be*"
     [ "$fe_dirty" = "true" ] && fe="$fe*"
 
-    if [ "$be" = "?" ]; then
+    if [ -z "$be_full" ]; then
         verdict="no-stamp"
     elif [ "$be_dirty" = "true" ] || [ "$fe_dirty" = "true" ]; then
         verdict="DIRTY"
-    elif [ "${be%\*}" = "$REF_SHORT" ]; then
-        verdict="up-to-date"
     else
-        verdict="BEHIND"
+        verdict=$(classify "$be_full")
     fi
     echo "$label|$url|$be|$fe|$verdict"
 }
@@ -87,3 +99,4 @@ probe() {
 
 echo
 echo "* = built/deployed from a tree with uncommitted changes (commit is not the whole truth)."
+echo "VS-REF: up-to-date | BEHIND | ahead | DIVERGED (vs $REF); differs? = commit not fetched locally."

--- a/scripts/lib/version-stamp.sh
+++ b/scripts/lib/version-stamp.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Shared by deploy-instance.sh and deploy-lobby.sh: stamp the deployed backend version.
+#
+# The server carries no git checkout (deploys rsync with --exclude='.git'), so the running
+# backend cannot report its own commit. The deploy machine does have git, so we capture the
+# state here and write it to the deploy root as DEPLOYED_VERSION.json, which
+# energetica/utils/version.py reads for /healthz. Both callers exclude this file from their
+# rsync --delete so it survives between deploys and is simply overwritten each time.
+#
+#   stamp_deployed_version <ssh-target> <remote-path>
+
+stamp_deployed_version() {
+    local ssh_target="$1" remote_path="$2"
+    local commit commit_short branch dirty deployed_by deployed_at
+
+    commit=$(git rev-parse HEAD 2>/dev/null || echo "")
+    commit_short=$(git rev-parse --short=9 HEAD 2>/dev/null || echo "")
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    # dirty means the deploy machine had uncommitted changes — the commit above may not be the
+    # whole truth (a routine case: shipping a WIP frontend). It is repo-wide; git cannot cheaply
+    # split it into backend vs frontend, and the frontend is stamped separately at build anyway.
+    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then dirty=true; else dirty=false; fi
+    deployed_by=$(whoami)
+    deployed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    log_step "Stamping deployed version ($commit_short, dirty=$dirty)..."
+    # Heredoc piped over ssh so no version file is written locally. Default umask makes it
+    # world-readable, which the service user (energetica) needs to read it for /healthz.
+    ssh "$ssh_target" "cat > $remote_path/DEPLOYED_VERSION.json" <<EOF
+{
+  "commit": "$commit",
+  "commit_short": "$commit_short",
+  "branch": "$branch",
+  "dirty": $dirty,
+  "deployed_by": "$deployed_by",
+  "deployed_at": "$deployed_at",
+  "source": "deploy"
+}
+EOF
+    log_success "Stamped deployed version"
+}

--- a/scripts/lib/version-stamp.sh
+++ b/scripts/lib/version-stamp.sh
@@ -24,18 +24,31 @@ stamp_deployed_version() {
     deployed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
     log_step "Stamping deployed version ($commit_short, dirty=$dirty)..."
-    # Heredoc piped over ssh so no version file is written locally. Default umask makes it
-    # world-readable, which the service user (energetica) needs to read it for /healthz.
-    ssh "$ssh_target" "cat > $remote_path/DEPLOYED_VERSION.json" <<EOF
-{
-  "commit": "$commit",
-  "commit_short": "$commit_short",
-  "branch": "$branch",
-  "dirty": $dirty,
-  "deployed_by": "$deployed_by",
-  "deployed_at": "$deployed_at",
-  "source": "deploy"
-}
-EOF
+    # Build the JSON with a real encoder rather than interpolating shell values into a template:
+    # git allows a branch name (and, in principle, a username) to contain a double quote or
+    # backslash, which would produce invalid JSON that version.py rejects — leaving the host with
+    # no reported version at all. Values are passed via the environment so the encoder, not the
+    # shell, does the escaping. python3 is used (present wherever this repo builds); dirty is a
+    # real JSON bool, the rest are strings.
+    local json
+    json=$(
+        DV_COMMIT="$commit" DV_COMMIT_SHORT="$commit_short" DV_BRANCH="$branch" \
+        DV_DIRTY="$dirty" DV_DEPLOYED_BY="$deployed_by" DV_DEPLOYED_AT="$deployed_at" \
+        python3 -c '
+import json, os
+print(json.dumps({
+    "commit": os.environ["DV_COMMIT"],
+    "commit_short": os.environ["DV_COMMIT_SHORT"],
+    "branch": os.environ["DV_BRANCH"],
+    "dirty": os.environ["DV_DIRTY"] == "true",
+    "deployed_by": os.environ["DV_DEPLOYED_BY"],
+    "deployed_at": os.environ["DV_DEPLOYED_AT"],
+    "source": "deploy",
+}, indent=2))
+'
+    )
+    # Piped over ssh so no version file is written locally. Default umask makes it world-readable,
+    # which the service user (energetica) needs to read it for /healthz.
+    printf '%s\n' "$json" | ssh "$ssh_target" "cat > $remote_path/DEPLOYED_VERSION.json"
     log_success "Stamped deployed version"
 }

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,70 @@
+"""Unit tests for deployed-version reporting (``energetica.utils.version``).
+
+These exercise the read logic that ``/healthz`` relies on: the deploy stamp is preferred, a
+missing or corrupt stamp falls back to git, and each half is read independently. They patch the
+module's resolved paths rather than touching a real checkout, so they are deterministic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from energetica.utils import version
+
+
+def test_backend_version_prefers_stamp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stamp = tmp_path / "DEPLOYED_VERSION.json"
+    stamp.write_text('{"commit": "abc123", "commit_short": "abc123", "source": "deploy"}')
+    monkeypatch.setattr(version, "_BACKEND_STAMP", stamp)
+    # If the stamp is read, the git fallback must never run.
+    monkeypatch.setattr(version, "_git_fallback", lambda: pytest.fail("git fallback should not run"))
+
+    assert version.backend_version() == {"commit": "abc123", "commit_short": "abc123", "source": "deploy"}
+
+
+def test_backend_version_falls_back_to_git_when_no_stamp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(version, "_BACKEND_STAMP", tmp_path / "missing.json")
+    monkeypatch.setattr(version, "_git_fallback", lambda: {"commit": "deadbeef", "source": "git"})
+
+    assert version.backend_version() == {"commit": "deadbeef", "source": "git"}
+
+
+def test_backend_version_falls_back_on_corrupt_stamp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stamp = tmp_path / "DEPLOYED_VERSION.json"
+    stamp.write_text("not json {{{")
+    monkeypatch.setattr(version, "_BACKEND_STAMP", stamp)
+    monkeypatch.setattr(version, "_git_fallback", lambda: {"source": "git"})
+
+    assert version.backend_version() == {"source": "git"}
+
+
+def test_backend_version_is_none_when_nothing_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(version, "_BACKEND_STAMP", tmp_path / "missing.json")
+    monkeypatch.setattr(version, "_git_fallback", lambda: None)
+
+    assert version.backend_version() is None
+
+
+def test_frontend_version_reads_bundle_stamp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bundle = tmp_path / "dist-lobby"
+    bundle.mkdir()
+    (bundle / "build-info.json").write_text('{"commit_short": "feed0000", "source": "build"}')
+    monkeypatch.setattr(version, "REPO_ROOT", tmp_path)
+
+    assert version.frontend_version("dist-lobby") == {"commit_short": "feed0000", "source": "build"}
+
+
+def test_frontend_version_is_none_when_bundle_unstamped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(version, "REPO_ROOT", tmp_path)
+
+    assert version.frontend_version("dist-lobby") is None


### PR DESCRIPTION
## Why

The game server has no git checkout (deploys rsync with `--exclude='.git'`), so a running component could not report which commit it was serving. `/healthz` has a `git_sha` field but it is always `null` in production, and every deploy reports the same hard-coded `__version__`. Answering "is my bug fix actually live?" meant blob-matching the deployed source against history by hand.

This is the **visibility** groundwork. It does not change *what* gets deployed or *when* — automated deployment / CD is deliberately out of scope and tracked in a follow-up issue that depends on this landing first.

## What

Backend and frontend are shipped by different steps and can drift apart (a frontend-only redeploy from a dirty tree is routine), so each half is stamped **independently**:

- **Backend** — `deploy-instance.sh` / `deploy-lobby.sh` write `DEPLOYED_VERSION.json` (commit, branch, dirty flag, deployer, timestamp) at rsync time, on the deploy machine, which *does* have git. It is excluded from the rsync `--delete` so it survives between deploys and is overwritten each time. In local dev (where a checkout exists) `energetica/utils/version.py` falls back to reading git directly.
- **Frontend** — a shared vite plugin (`buildInfoPlugin`) writes `build-info.json` into each bundle at build time; it rsyncs with the bundle.

`/healthz` reads both and returns a `version` block:

```json
{ "status": "ok",
  "version": {
    "backend":  { "commit_short": "abc123def", "dirty": false, "deployed_by": "you", "source": "deploy" },
    "frontend": { "commit_short": "abc123def", "dirty": false, "source": "build" } } }
```

- The **lobby** had no `/healthz` at all — it gets one (version-only; it is engine-free).
- `git_sha` is kept at the top level for backward compatibility with older probes.
- **`scripts/deployed-versions.sh`** curls every instance + the lobby on a server and prints a deployed-vs-`main` table, with a `*` marking anything built/deployed from a dirty tree.

## Testing

- `tests/unit/test_version.py` — stamp preferred, git fallback on missing/corrupt stamp, independent frontend read.
- Existing `tests/integration/test_health_route.py` still passes.
- Pyright, frontend typecheck/lint/format clean; a real `build:lobby` confirmed `build-info.json` is emitted; deploy scripts syntax-checked and the shared lib sources correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds deployed-version reporting for the game and lobby services.

- Stamps backend versions during deployment.
- Emits frontend build metadata in each bundle.
- Returns backend and frontend versions from `/healthz`.
- Adds a script to compare deployed versions with a Git reference.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/deploy-instance.sh | Writes the instance version stamp after the service health check succeeds. |
| scripts/deploy-lobby.sh | Writes the lobby version stamp after the service health check succeeds. |
| scripts/lib/version-stamp.sh | Serializes deployment metadata as JSON before writing the remote stamp. |
| scripts/deployed-versions.sh | Compares deployed backend commits with a reference using Git ancestry. |

<sub>Reviews (2): Last reviewed commit: ["fix(deploy): address review — stamp afte..."](https://github.com/felixvonsamson/energetica/commit/a60cfd50395479554cb3132d50693f8f1347a5ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45368967)</sub>

<!-- /greptile_comment -->