### PR TITLE
fix(dev): symlink lobby picker manifest to the live aggregate (#886)

### DIFF
--- a/frontend/vite.config.lobby.ts
+++ b/frontend/vite.config.lobby.ts
@@ -81,8 +81,10 @@ export default defineConfig(({ mode }) => {
             proxy: {
                 // Lobby API (auth + my-runs). /instances.json is deliberately
                 // not proxied: in production Apache aliases it from the shared
-                // landing dir; in dev it 404s and the picker degrades to "no
-                // open runs".
+                // landing dir; in dev the seed (scripts/lib/dev-env.sh) symlinks
+                // frontend/public/instances.json to the live landing aggregate,
+                // so Vite serves the current manifest statically — no proxy, and
+                // no stale copy (issue #886).
                 "^/api": {
                     target: backendUrl,
                     changeOrigin: true,

--- a/scripts/lib/dev-env.sh
+++ b/scripts/lib/dev-env.sh
@@ -87,9 +87,17 @@ accounts.record_membership(account_id=account_id, slug="poc-3", settled_at="2026
 accounts.record_membership(account_id=account_id, slug="private-beta", settled_at="2026-07-02T10:00:00+00:00")
 
 # The dev frontend serves /instances.json from frontend/public/ (Apache aliases it in prod).
+# Symlink it to the live landing aggregate rather than copying: a one-time copy goes stale the
+# moment a fragment's lifecycle timestamps are edited and re-aggregated, so the picker's phase
+# lags the app's (issue #886). The symlink tracks the path, so it keeps serving the live manifest
+# — including across aggregate_instances()'s atomic temp-then-rename — with no restart. Absolute
+# target so it resolves regardless of the frontend dev server's CWD.
 public = Path("frontend/public/instances.json")
 public.parent.mkdir(parents=True, exist_ok=True)
-public.write_text((landing / "instances.json").read_text(encoding="utf-8"), encoding="utf-8")
+# Idempotent: the path starts life as a real file (and this seed re-runs), so drop any existing
+# file or stale symlink before linking. missing_ok tolerates the first run / a prior rm-instance.
+public.unlink(missing_ok=True)
+public.symlink_to((landing / "instances.json").resolve())
 
 print("Seeded lobby dev data: demo / demo1234 (member of poc-3, private-beta) · advertised: poc-3, summer-2026")
 PY


### PR DESCRIPTION
Closes #886.

## Problem

The lobby dev seed copied the aggregated `instances.json` into `frontend/public/` exactly once at dev-stack startup. Editing a local instance's lifecycle timestamps (`starts_at`/`freeze_at`/`ended_at`) and re-aggregating updated the *live* landing aggregate but left that static copy untouched. Because the picker derives phase in the browser from the copy's timestamps, its label drifted out of sync with the app (which reads the live engine endpoint) — e.g. showing "Running since …" for a run still `announced`. It looked like a product bug but was a dev-fixture artifact: two sources of truth, no refresh could reconcile them.

## Fix

Symlink `frontend/public/instances.json` to the live landing aggregate instead of copying it. Vite resolves the symlink per request, so the picker always reads the current manifest — including across `aggregate_instances()`'s atomic temp-then-rename — with no dev-server restart. One source of truth, so the copy-drift class of bug is gone.

The link is created idempotently (unlink-if-present, then symlink), since the path starts life as a real file and the seed re-runs. The target is absolute so it resolves regardless of the frontend dev server's CWD.

Also fixes the now-stale proxy comment in `vite.config.lobby.ts`, which claimed dev `/instances.json` 404s and degrades — it was actually served from the static copy all along.

## Acceptance criteria

- [x] Editing a local instance's lifecycle timestamps and re-aggregating is reflected in the picker on the next refresh, no dev-server restart — verified directly: pushed `poc-3`'s `starts_at` to 2099, re-aggregated, and the symlink served the new value with no seed re-run.
- [x] No change to production behavior — Apache still serves the landing dir's file directly; only the dev seed changed.
- [x] Existing dev seeding (demo account + sample runs) still works unchanged.

## Out of scope

`derivePhase` and the card components (both already correct), and the production `instances.json` serving path — all untouched.

## Notes

Symlinks are fully portable across macOS and Linux (both POSIX; Vite follows symlinks when serving `public/`, and the file is gitignored so git's symlink handling never enters the picture). Windows would need Developer Mode/admin for `os.symlink`, but the dev stack is already bash-only and no one on the team is on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the lobby development manifest track the live aggregate.

- Replaces the one-time manifest copy with an absolute symlink.
- Recreates the generated path safely on repeated seeding.
- Updates the Vite proxy comment to describe the dev behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/lib/dev-env.sh | The development seed now links the public manifest to the live landing aggregate. |
| frontend/vite.config.lobby.ts | The proxy comment now documents the static manifest symlink used in development. |

<sub>Reviews (1): Last reviewed commit: ["fix(dev): symlink lobby picker manifest ..."](https://github.com/felixvonsamson/energetica/commit/672ecdfdf5197cfd1a23c97722be12749f8603f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45374711)</sub>

<!-- /greptile_comment -->