### PR TITLE
feat(recap): freeze the map snapshot into the recap (T5 addendum, #863)

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -539,6 +539,16 @@ class Player(DBModel):
         data = WorkersOut.from_player(self).model_dump()
         self.emit("worker_info", data)
 
+    def calculate_produced_co2(self) -> float:
+        """Calculate the gross CO2 the player produced, in kg.
+
+        The positive categories of the cumulative emissions are the emitting facilities; negative
+        categories are sinks (capture). Gross produced sums only the positive ones, so the recap can
+        show produced and captured un-netted (ADR-0005) rather than only the collapsed net figure.
+        """
+        cumulative_emissions = self.cumul_emissions.get_all()
+        return sum(value for value in cumulative_emissions.values() if value > 0)
+
     def calculate_net_emissions(self) -> float:
         """Calculate the net emissions of the player."""
         cumulative_emissions = self.cumul_emissions.get_all()

--- a/energetica/schemas/recap.py
+++ b/energetica/schemas/recap.py
@@ -171,8 +171,11 @@ class Recap(BaseModel):
             freeze_at=config.freeze_at,
             ended_at=config.ended_at,
             player_count=len(rows),
-            total_produced_co2=sum(player.calculate_produced_co2() for player in ordered),
-            total_captured_co2=sum(player.progression_metrics.get("captured_co2", 0) for player in ordered),
+            # Column totals are summed from the rows just built, not re-derived from the players, so
+            # each header total structurally equals its column (no second traversal to drift from).
+            # net_emissions is sourced from the players because it is not a row column.
+            total_produced_co2=sum(row.produced_co2 for row in rows),
+            total_captured_co2=sum(row.captured_co2 for row in rows),
             total_net_emissions=sum(player.calculate_net_emissions() for player in ordered),
             rows=rows,
             tiles=list(tiles),

--- a/energetica/schemas/recap.py
+++ b/energetica/schemas/recap.py
@@ -64,6 +64,33 @@ class RecapRow(BaseModel):
     captured_co2: float = Field(description="Total captured CO2 in kg — the on-theme brag stat")
 
 
+class RecapTile(BaseModel):
+    """One frozen map tile: its terrain plus who settled it, at freeze (G1 addendum, #859).
+
+    The in-game :class:`~energetica.schemas.map.HexTileOut` shape minus the throwaway ``id``, with the
+    live ``player_id`` swapped for the durable ``owner_account_id``. Tiles join the leaderboard
+    :class:`RecapRow` s by ``account_id`` — settlement is 1:1 (one player per tile) — so no ``tile_id``
+    is needed on the rows and no second identity system enters the tombstone.
+
+    Terrain is frozen (not just ownership) because it is **un-recomputable** after the fact: the map is
+    regenerated manually between instances and never persisted, so only this frozen copy renders an old
+    recap on the terrain it was actually played on — the same frozen-photograph principle as usernames.
+    """
+
+    q: int
+    r: int
+    solar: float
+    wind: float
+    hydro: float
+    coal: float
+    gas: float
+    uranium: float
+    climate_risk: float
+    owner_account_id: int | None = Field(
+        description="Durable account FK of the player who settled this tile, or None if unsettled"
+    )
+
+
 class Recap(BaseModel):
     """The full published recap payload: an identity/totals header plus the income-ranked table.
 
@@ -84,6 +111,11 @@ class Recap(BaseModel):
     total_captured_co2: float = Field(description="Sum of captured_co2 across all players, in kg")
     total_net_emissions: float = Field(description="Sum of net CO2 emissions across all players, in kg")
     rows: list[RecapRow]
+    # Required (no default) on purpose: a pre-addendum recap on disk lacks this key, so it fails to
+    # load (``load_recap`` → None) and the mint-once guard re-mints it *with* the snapshot — the same
+    # self-heal path a corrupt artifact takes. The projection itself lives in ``utils.recap`` (it needs
+    # the game-domain Fuel/Renewable enums the leaf must not import), so this field is passed in built.
+    tiles: list[RecapTile] = Field(description="Frozen map snapshot: terrain + ownership at freeze")
 
     @classmethod
     def from_players(
@@ -92,6 +124,7 @@ class Recap(BaseModel):
         slug: str,
         config: InstanceConfig,
         players: Iterable[RecapPlayer],
+        tiles: Iterable[RecapTile] = (),
     ) -> Recap:
         """Project the live final game state into the frozen recap payload.
 
@@ -100,6 +133,9 @@ class Recap(BaseModel):
         ``account_id`` (ascending), so the ranking — and every row's ``rank`` — is fully reproducible:
         a re-mint (admin regenerate) yields the identical frozen photograph rather than reshuffling
         equal-income players by enumeration order.
+
+        ``tiles`` is the already-projected frozen map snapshot (built by the caller, which owns the
+        game-domain read); it is carried through verbatim so the whole recap is one payload.
         """
         ranked = sorted(
             players,
@@ -127,4 +163,5 @@ class Recap(BaseModel):
             total_captured_co2=sum(player.progression_metrics.get("captured_co2", 0) for player in ranked),
             total_net_emissions=sum(player.calculate_net_emissions() for player in ranked),
             rows=rows,
+            tiles=list(tiles),
         )

--- a/energetica/schemas/recap.py
+++ b/energetica/schemas/recap.py
@@ -1,10 +1,17 @@
-"""The recap: a frozen JSON tombstone of an instance's final leaderboard (G1, #859).
+"""The recap: a frozen JSON tombstone of an instance's final state (G1, #859).
 
 A recap is a **write-once, immutable snapshot** minted at the ``active → freeze`` transition and
 published to the lobby (``recaps/{slug}.json``), where it outlives the instance process (T7). It is a
-**curated projection** — a single income-ranked table plus a small instance-totals header — *not* the
+**curated projection** — a single per-player table plus a small instance-totals header — *not* the
 verbatim :class:`~energetica.schemas.leaderboards.PlayerDetailStats`: the extra columns are cheap as
 data but costly as render/parse surface, and they graduate from the fog as full-recap features later.
+
+**A retrospective, not a scoreboard (ADR-0005, supersedes G1's competitive framing).** The recap
+crowns no winner: there is no rank and no medal. CO2 is laid bare as two un-netted columns — gross
+``produced_co2`` and ``captured_co2`` — so a heavy emitter who also captures heavily reads as exactly
+that, the relationship visible rather than collapsed. Rows default to ``operating_income`` descending
+as a soft "most consequential first" ordering, not a verdict; any per-column notability is derived
+client-side, never minted into the payload.
 
 **Frozen-photograph semantics:** every row captures the player's identity *as it was at freeze*
 (``username_at_freeze``, ``network_name``). The immutable ``account_id`` FK is retained so a future
@@ -49,19 +56,21 @@ class RecapPlayer(Protocol):
     @property
     def progression_metrics(self) -> Mapping[str, float]: ...
 
+    def calculate_produced_co2(self) -> float: ...
+
     def calculate_net_emissions(self) -> float: ...
 
 
 class RecapRow(BaseModel):
-    """One player's final standing, one row of the income-ranked leaderboard."""
+    """One player's final standing, one row of the per-player table (no rank — ADR-0005)."""
 
-    rank: int = Field(description="1-based placement by operating_income desc — the medal")
     account_id: int = Field(description="Server-wide account FK, retained for future identity resolution")
     username_at_freeze: str = Field(description="The player's name as it was at freeze (frozen photograph)")
     network_name: str | None = Field(description="The player's network/team at freeze, or None if unaffiliated")
-    operating_income: float = Field(description="Lifetime cumulated operating income — the sort key, 'who won'")
+    operating_income: float = Field(description="Lifetime cumulated operating income — the default sort key")
     xp: float = Field(description="Experience points — 'how far I got'")
-    captured_co2: float = Field(description="Total captured CO2 in kg — the on-theme brag stat")
+    produced_co2: float = Field(description="Gross CO2 produced in kg — shown un-netted against captured (ADR-0005)")
+    captured_co2: float = Field(description="Total captured CO2 in kg — shown un-netted against produced (ADR-0005)")
 
 
 class RecapTile(BaseModel):
@@ -92,9 +101,9 @@ class RecapTile(BaseModel):
 
 
 class Recap(BaseModel):
-    """The full published recap payload: an identity/totals header plus the income-ranked table.
+    """The full published recap payload: an identity/totals header plus the per-player table.
 
-    Sized for a single payload (~100 players × 7 fields ≈ 15 KB), so the lobby fetches and renders it
+    Sized for a single payload (~100 players × 8 fields ≈ 15 KB), so the lobby fetches and renders it
     with no live backend. Carries the same transition timestamps the fragment does, so the lobby can
     render start/end dates without a second lookup.
     """
@@ -108,6 +117,7 @@ class Recap(BaseModel):
     freeze_at: AwareDatetime | None = None
     ended_at: AwareDatetime | None = None
     player_count: int
+    total_produced_co2: float = Field(description="Sum of produced_co2 (gross) across all players, in kg")
     total_captured_co2: float = Field(description="Sum of captured_co2 across all players, in kg")
     total_net_emissions: float = Field(description="Sum of net CO2 emissions across all players, in kg")
     rows: list[RecapRow]
@@ -128,30 +138,31 @@ class Recap(BaseModel):
     ) -> Recap:
         """Project the live final game state into the frozen recap payload.
 
-        Players are ranked by ``operating_income`` descending (rank 1 = the winner); the totals header
-        sums ``captured_co2`` and ``net_emissions`` across everyone. Ties break on the immutable
-        ``account_id`` (ascending), so the ranking — and every row's ``rank`` — is fully reproducible:
-        a re-mint (admin regenerate) yields the identical frozen photograph rather than reshuffling
-        equal-income players by enumeration order.
+        Rows are emitted in ``operating_income``-descending order — the default "most consequential
+        first" view, not a ranking (ADR-0005): no row carries a rank. The totals header sums
+        ``produced_co2``, ``captured_co2`` and ``net_emissions`` across everyone. Order ties break on
+        the immutable ``account_id`` (ascending), so the frozen photograph is fully reproducible: a
+        re-mint (admin regenerate) yields the identical row order rather than reshuffling equal-income
+        players by enumeration order.
 
         ``tiles`` is the already-projected frozen map snapshot (built by the caller, which owns the
         game-domain read); it is carried through verbatim so the whole recap is one payload.
         """
-        ranked = sorted(
+        ordered = sorted(
             players,
             key=lambda player: (-player.progression_metrics.get("operating_income", 0), player.user.account_id),
         )
         rows = [
             RecapRow(
-                rank=rank,
                 account_id=player.user.account_id,
                 username_at_freeze=player.username,
                 network_name=player.network.name if player.network else None,
                 operating_income=player.progression_metrics.get("operating_income", 0),
                 xp=player.progression_metrics.get("xp", 0),
+                produced_co2=player.calculate_produced_co2(),
                 captured_co2=player.progression_metrics.get("captured_co2", 0),
             )
-            for rank, player in enumerate(ranked, start=1)
+            for player in ordered
         ]
         return cls(
             slug=slug,
@@ -160,8 +171,9 @@ class Recap(BaseModel):
             freeze_at=config.freeze_at,
             ended_at=config.ended_at,
             player_count=len(rows),
-            total_captured_co2=sum(player.progression_metrics.get("captured_co2", 0) for player in ranked),
-            total_net_emissions=sum(player.calculate_net_emissions() for player in ranked),
+            total_produced_co2=sum(player.calculate_produced_co2() for player in ordered),
+            total_captured_co2=sum(player.progression_metrics.get("captured_co2", 0) for player in ordered),
+            total_net_emissions=sum(player.calculate_net_emissions() for player in ordered),
             rows=rows,
             tiles=list(tiles),
         )

--- a/energetica/utils/recap.py
+++ b/energetica/utils/recap.py
@@ -16,10 +16,38 @@ from __future__ import annotations
 import logging
 
 from energetica import instance_config
+from energetica.database.map.hex_tile import HexTile
 from energetica.database.player import Player
-from energetica.schemas.recap import Recap
+from energetica.enums import Fuel, Renewable
+from energetica.schemas.recap import Recap, RecapTile
 
 logger = logging.getLogger(__name__)
+
+
+def _freeze_tiles() -> list[RecapTile]:
+    """Project the live map into the frozen tile array — terrain plus ownership at freeze (G1 addendum).
+
+    Read here rather than in the schema so the schema leaf stays free of the game-domain ``Fuel`` /
+    ``Renewable`` vocabulary — the same module-boundary rule that keeps the ``Player`` read out of
+    ``instance_config``. Each tile resolves ``tile.player`` to the durable ``owner_account_id`` exactly
+    as the leaderboard rows resolve identity, so tiles join rows by ``account_id``. Sorted by ``(q, r)``
+    so a re-mint is a reproducible photograph, mirroring the leaderboard's ``account_id`` tiebreak.
+    """
+    return [
+        RecapTile(
+            q=tile.coordinates[0],
+            r=tile.coordinates[1],
+            solar=tile.potentials[Renewable.SOLAR],
+            wind=tile.potentials[Renewable.WIND],
+            hydro=tile.potentials[Renewable.HYDRO],
+            coal=tile.fuel_reserves[Fuel.COAL],
+            gas=tile.fuel_reserves[Fuel.GAS],
+            uranium=tile.fuel_reserves[Fuel.URANIUM],
+            climate_risk=tile.climate_risk,
+            owner_account_id=tile.player.user.account_id if tile.player else None,
+        )
+        for tile in sorted(HexTile.all(), key=lambda tile: tile.coordinates)
+    ]
 
 
 def build_recap() -> Recap | None:
@@ -34,7 +62,7 @@ def build_recap() -> Recap | None:
     config = instance_config.load_instance_config()
     if config is None:
         return None
-    return Recap.from_players(slug=slug, config=config, players=Player.all())
+    return Recap.from_players(slug=slug, config=config, players=Player.all(), tiles=_freeze_tiles())
 
 
 def mint_recap() -> None:

--- a/tests/unit/test_player_emissions.py
+++ b/tests/unit/test_player_emissions.py
@@ -1,0 +1,49 @@
+"""Tests for the player's CO2 emission summaries used by the recap (ADR-0005).
+
+``calculate_produced_co2`` (gross, positive categories) and ``calculate_net_emissions`` (all
+categories) both read ``cumul_emissions``, where emitting facilities record positive values and
+capture records a negative one (``production_update`` adds ``-captured_co2`` under ``carbon_capture``).
+The recap shows produced and captured un-netted, so gross-produced must exclude the capture sink.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from energetica import create_app
+from energetica.database.map.hex_tile import HexTile
+from energetica.database.player import Player
+from energetica.database.user import User
+from energetica.utils.map_helpers import confirm_location
+
+
+@pytest.fixture
+def player() -> Player:
+    """A fresh player settled on a fresh engine + map (Player construction needs both)."""
+    create_app(rm_instance=True, skip_adding_handlers=True, env="prod")
+    user = User("emitter", "pwhash", role="player", account_id=1)
+    return confirm_location(user, HexTile.getitem(1))
+
+
+def test_produced_co2_sums_only_positive_categories(player: Player) -> None:
+    """Gross produced is the emitting facilities; the negative capture category is excluded."""
+    player.cumul_emissions.add("steam_engine", 300.0)
+    player.cumul_emissions.add("construction", 50.0)
+    player.cumul_emissions.add_category("carbon_capture")
+    player.cumul_emissions.add("carbon_capture", -120.0)  # capture is stored negative
+
+    assert player.calculate_produced_co2() == 350.0  # 300 + 50, capture excluded
+
+
+def test_net_emissions_sums_all_categories(player: Player) -> None:
+    """Net still nets the capture back out — the collapsed figure the recap shows alongside."""
+    player.cumul_emissions.add("steam_engine", 300.0)
+    player.cumul_emissions.add("construction", 50.0)
+    player.cumul_emissions.add_category("carbon_capture")
+    player.cumul_emissions.add("carbon_capture", -120.0)
+
+    assert player.calculate_net_emissions() == 230.0  # 300 + 50 - 120
+
+
+def test_produced_co2_is_zero_with_no_emissions(player: Player) -> None:
+    assert player.calculate_produced_co2() == 0.0

--- a/tests/unit/test_recap.py
+++ b/tests/unit/test_recap.py
@@ -7,6 +7,7 @@ These tests exercise it without a running engine: the schema projection takes pl
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from energetica import instance_config
+from energetica.enums import Fuel, Renewable
 from energetica.instance_config import InstanceConfig, PublicAccess
 from energetica.schemas.recap import Recap
 from energetica.utils import recap as recap_util
@@ -62,6 +64,61 @@ class _FakePlayer:
 
     def calculate_net_emissions(self) -> float:
         return self.net_emissions
+
+
+# --- lightweight tile stand-ins (utils._freeze_tiles reads the ORM shape by attribute) ---------
+
+
+@dataclass
+class _FakeTileOwner:
+    """The narrow ``tile.player`` slice _freeze_tiles resolves — just ``.user.account_id``."""
+
+    account_id: int
+
+    @property
+    def user(self) -> _FakeUser:
+        return _FakeUser(account_id=self.account_id)
+
+
+@dataclass
+class _FakeTile:
+    """A HexTile stand-in: coordinates, enum-keyed terrain dicts, and an optional settling owner."""
+
+    q: int
+    r: int
+    owner_account_id: int | None = None
+    solar: float = 1.0
+    wind: float = 2.0
+    hydro: float = 3.0
+    coal: float = 4.0
+    gas: float = 5.0
+    uranium: float = 6.0
+    climate_risk: float = 0.5
+
+    @property
+    def coordinates(self) -> tuple[int, int]:
+        return (self.q, self.r)
+
+    @property
+    def potentials(self) -> dict[Renewable, float]:
+        return {Renewable.SOLAR: self.solar, Renewable.WIND: self.wind, Renewable.HYDRO: self.hydro}
+
+    @property
+    def fuel_reserves(self) -> dict[Fuel, float]:
+        return {Fuel.COAL: self.coal, Fuel.GAS: self.gas, Fuel.URANIUM: self.uranium}
+
+    @property
+    def player(self) -> _FakeTileOwner | None:
+        return _FakeTileOwner(account_id=self.owner_account_id) if self.owner_account_id is not None else None
+
+
+def _tiles() -> list[_FakeTile]:
+    """Two settled tiles (owned by bob/carol) and one unsettled — deliberately out of (q, r) order."""
+    return [
+        _FakeTile(q=1, r=0, owner_account_id=30),  # carol
+        _FakeTile(q=0, r=0, owner_account_id=20),  # bob
+        _FakeTile(q=0, r=1, owner_account_id=None),  # unsettled
+    ]
 
 
 def _config() -> InstanceConfig:
@@ -159,6 +216,39 @@ def test_from_players_empty_instance() -> None:
     assert recap.rows == []
     assert recap.total_captured_co2 == 0
     assert recap.total_net_emissions == 0
+    assert recap.tiles == []  # no tiles passed → empty snapshot (only from_players' test-only default)
+
+
+# --- _freeze_tiles (map-snapshot projection, G1 addendum) --------------------------------------
+
+
+def test_freeze_tiles_projects_terrain_and_resolves_ownership(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap_util.HexTile, "all", classmethod(lambda cls: _tiles()))
+
+    tiles = recap_util._freeze_tiles()
+    settled = next(tile for tile in tiles if tile.q == 0 and tile.r == 0)
+
+    assert settled.owner_account_id == 20  # bob's tile → durable account FK, not the live player_id
+    assert (settled.solar, settled.wind, settled.hydro) == (1.0, 2.0, 3.0)
+    assert (settled.coal, settled.gas, settled.uranium) == (4.0, 5.0, 6.0)
+    assert settled.climate_risk == 0.5
+
+
+def test_freeze_tiles_unsettled_owner_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap_util.HexTile, "all", classmethod(lambda cls: _tiles()))
+
+    unsettled = next(tile for tile in recap_util._freeze_tiles() if tile.owner_account_id is None)
+
+    assert (unsettled.q, unsettled.r) == (0, 1)
+
+
+def test_freeze_tiles_sorted_for_reproducibility(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tiles are ordered by (q, r) regardless of HexTile.all()'s enumeration, so a re-mint matches."""
+    monkeypatch.setattr(recap_util.HexTile, "all", classmethod(lambda cls: _tiles()))
+
+    coords = [(tile.q, tile.r) for tile in recap_util._freeze_tiles()]
+
+    assert coords == [(0, 0), (0, 1), (1, 0)]  # input was (1,0), (0,0), (0,1)
 
 
 # --- publish / load / exists primitives (instance_config) --------------------------------------
@@ -226,6 +316,7 @@ def configured(landing: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     target.write_text(_config().model_dump_json(), encoding="utf-8")
     monkeypatch.setenv("ENERGETICA_INSTANCE_CONFIG_DIR", str(config_dir))
     monkeypatch.setattr(recap_util.Player, "all", classmethod(lambda cls: _players()))
+    monkeypatch.setattr(recap_util.HexTile, "all", classmethod(lambda cls: _tiles()))
     return config_dir
 
 
@@ -236,6 +327,29 @@ def test_mint_recap_publishes(configured: Path) -> None:
     assert loaded is not None
     assert loaded.player_count == 3
     assert loaded.rows[0].username_at_freeze == "bob"
+    # The map snapshot is frozen alongside the leaderboard and survives the full JSON round-trip.
+    assert [(tile.q, tile.r) for tile in loaded.tiles] == [(0, 0), (0, 1), (1, 0)]
+    assert {tile.owner_account_id for tile in loaded.tiles} == {20, 30, None}
+
+
+def test_mint_recap_remigrates_pre_addendum_recap(configured: Path) -> None:
+    """A pre-addendum recap on disk lacks the ``tiles`` key, so it fails to load and is re-minted
+    with the map snapshot — the schema bump self-heals through the same mint-once guard as a corrupt
+    file, rather than stranding the lobby with a tile-less tombstone.
+    """
+    stale = Recap.from_players(slug=SLUG, config=_config(), players=_players()).model_dump(mode="json")
+    del stale["tiles"]
+    path = instance_config.recap_path(SLUG)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(stale), encoding="utf-8")
+
+    assert instance_config.load_recap(SLUG) is None  # missing required key → unreadable → re-mint
+
+    recap_util.mint_recap_if_needed()
+
+    healed = instance_config.load_recap(SLUG)
+    assert healed is not None
+    assert len(healed.tiles) == 3  # re-minted with the frozen map snapshot
 
 
 def test_mint_recap_if_needed_is_mint_once(configured: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_recap.py
+++ b/tests/unit/test_recap.py
@@ -43,6 +43,7 @@ class _FakePlayer:
     operating_income: float
     xp: float
     captured_co2: float
+    produced_co2: float
     net_emissions: float
     network_name: str | None = None
 
@@ -61,6 +62,9 @@ class _FakePlayer:
     @property
     def progression_metrics(self) -> dict[str, float]:
         return {"operating_income": self.operating_income, "xp": self.xp, "captured_co2": self.captured_co2}
+
+    def calculate_produced_co2(self) -> float:
+        return self.produced_co2
 
     def calculate_net_emissions(self) -> float:
         return self.net_emissions
@@ -133,28 +137,54 @@ def _config() -> InstanceConfig:
 
 def _players() -> list[_FakePlayer]:
     return [
-        _FakePlayer(account_id=10, _username="alice", operating_income=500, xp=42, captured_co2=100, net_emissions=-5),
+        _FakePlayer(
+            account_id=10,
+            _username="alice",
+            operating_income=500,
+            xp=42,
+            captured_co2=100,
+            produced_co2=95,  # net = 95 - 100 = -5
+            net_emissions=-5,
+        ),
         _FakePlayer(
             account_id=20,
             _username="bob",
             operating_income=1500,
             xp=99,
             captured_co2=250,
+            produced_co2=280,  # net = 280 - 250 = 30
             net_emissions=30,
             network_name="Grid Co",
         ),
-        _FakePlayer(account_id=30, _username="carol", operating_income=900, xp=70, captured_co2=0, net_emissions=12),
+        _FakePlayer(
+            account_id=30,
+            _username="carol",
+            operating_income=900,
+            xp=70,
+            captured_co2=0,
+            produced_co2=12,  # net = 12 - 0 = 12
+            net_emissions=12,
+        ),
     ]
 
 
 # --- Recap.from_players (schema projection, G1) ------------------------------------------------
 
 
-def test_from_players_ranks_by_operating_income_desc() -> None:
+def test_from_players_orders_by_operating_income_desc() -> None:
+    """Default order is operating_income descending — 'most consequential first', not a ranking
+    (ADR-0005). No row carries a rank/medal.
+    """
     recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
 
     assert [row.username_at_freeze for row in recap.rows] == ["bob", "carol", "alice"]
-    assert [row.rank for row in recap.rows] == [1, 2, 3]
+
+
+def test_from_players_has_no_rank_field() -> None:
+    """The recap crowns no winner: there is no global rank on a row (ADR-0005)."""
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+
+    assert "rank" not in recap.rows[0].model_dump()
 
 
 def test_from_players_ties_break_on_account_id_reproducibly() -> None:
@@ -162,9 +192,27 @@ def test_from_players_ties_break_on_account_id_reproducibly() -> None:
     regardless of the order Player.all() enumerates them in.
     """
     tied = [
-        _FakePlayer(account_id=30, _username="carol", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
-        _FakePlayer(account_id=10, _username="alice", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
-        _FakePlayer(account_id=20, _username="bob", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
+        _FakePlayer(
+            account_id=30,
+            _username="carol",
+            operating_income=100,
+            xp=0,
+            captured_co2=0,
+            produced_co2=0,
+            net_emissions=0,
+        ),
+        _FakePlayer(
+            account_id=10,
+            _username="alice",
+            operating_income=100,
+            xp=0,
+            captured_co2=0,
+            produced_co2=0,
+            net_emissions=0,
+        ),
+        _FakePlayer(
+            account_id=20, _username="bob", operating_income=100, xp=0, captured_co2=0, produced_co2=0, net_emissions=0
+        ),
     ]
     forward = Recap.from_players(slug=SLUG, config=_config(), players=tied)
     reshuffled = Recap.from_players(slug=SLUG, config=_config(), players=list(reversed(tied)))
@@ -182,6 +230,8 @@ def test_from_players_projects_the_curated_columns() -> None:
     assert winner.network_name == "Grid Co"
     assert winner.operating_income == 1500
     assert winner.xp == 99
+    # CO2 laid bare as two un-netted columns — produced and captured, not collapsed (ADR-0005).
+    assert winner.produced_co2 == 280
     assert winner.captured_co2 == 250
 
 
@@ -195,6 +245,7 @@ def test_from_players_totals_header() -> None:
     recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
 
     assert recap.player_count == 3
+    assert recap.total_produced_co2 == 387  # 95 + 280 + 12
     assert recap.total_captured_co2 == 350  # 100 + 250 + 0
     assert recap.total_net_emissions == 37  # -5 + 30 + 12
 
@@ -214,6 +265,7 @@ def test_from_players_empty_instance() -> None:
 
     assert recap.player_count == 0
     assert recap.rows == []
+    assert recap.total_produced_co2 == 0
     assert recap.total_captured_co2 == 0
     assert recap.total_net_emissions == 0
     assert recap.tiles == []  # no tiles passed → empty snapshot (only from_players' test-only default)
@@ -365,7 +417,13 @@ def test_mint_recap_if_needed_is_mint_once(configured: Path, monkeypatch: pytest
         classmethod(
             lambda cls: [
                 _FakePlayer(
-                    account_id=99, _username="latecomer", operating_income=9999, xp=0, captured_co2=0, net_emissions=0
+                    account_id=99,
+                    _username="latecomer",
+                    operating_income=9999,
+                    xp=0,
+                    captured_co2=0,
+                    produced_co2=0,
+                    net_emissions=0,
                 )
             ]
         ),


### PR DESCRIPTION
Completes **T5 · Recap mint + publish hook** (#863) by adding the piece the merged mint (#884) left out: the **G1 map-snapshot addendum** (#859). Part of the server-lifecycle epic (#856).

## Why

#884 froze the leaderboard tombstone but never carried the frozen **tile array** the G1 addendum folded into T5's scope — the `Recap` schema had no `tiles`, the mint never read the map, and no test touched it. Without it, **T6** (the baseline recap page, #864) can't render the map at all: its spec is to draw the frozen tiles with the hex-SVG renderer.

Terrain is **un-recomputable after the fact** — the map is regenerated manually between instances and never persisted — so freezing it is what lets an old recap render on the terrain it was actually played on. Same frozen-photograph principle G1 already commits to for usernames.

## Changes

- **`schemas/recap.py`** — `RecapTile` (the in-game `HexTileOut` shape minus the throwaway `id`, with live `player_id` resolved to a durable `owner_account_id`; tiles join leaderboard rows by `account_id`, settlement being 1:1). Adds a **required** `tiles` field to `Recap`.
- **`utils/recap.py`** — `_freeze_tiles` reads `HexTile.all()` with the `Fuel`/`Renewable` enums *here*, so the schema leaf stays free of game-domain vocabulary — the same module-boundary rule that keeps the `Player` read out of `instance_config`. Sorted by `(q, r)` so a re-mint is a reproducible photograph, mirroring the leaderboard's `account_id` tiebreak.
- **`tests/unit/test_recap.py`** — tile projection, ownership resolution, sort determinism, full mint→publish→load round-trip, and the self-heal migration below.

## Self-heal migration (why `tiles` is required)

Making `tiles` required (no default) means a **pre-addendum recap on disk lacks the key → fails to load (`load_recap` → `None`) → the mint-once guard re-mints it *with* the snapshot** — reusing the exact self-heal path a corrupt artifact already takes. The schema bump migrates itself; no admin step, no tile-less tombstone stranded on the lobby.

## Testing

`tests/unit/test_recap.py` + `test_freeze_enforcement.py`: **34 passing**. Full unit suite otherwise green — the 11 remaining failures are the pre-existing environmental ones #884 already documented (`test_daily_quiz_links` = live network, `test_server_runs` = spawns a `python` binary absent from this sandbox), identical on a clean tree. `ruff check`/`format` clean, `bun run typecheck` green, `generate-types` produces no diff (the recap is a static artifact, not an API-exposed schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the frozen recap payload with map terrain and gross CO₂ data.

- Adds a durable tile snapshot with ownership at freeze.
- Adds produced CO₂ fields and totals to recap rows.
- Re-mints older recap files that lack the new snapshot fields.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/schemas/recap.py | Adds frozen tile data and produced CO₂ fields to the recap schema. |
| energetica/utils/recap.py | Builds a deterministic map snapshot when the recap is minted. |
| energetica/database/player.py | Adds gross produced CO₂ calculation from cumulative emissions. |
| tests/unit/test_recap.py | Covers tile projection, recap round-trips, and reminting older artifacts. |
| tests/unit/test_player_emissions.py | Covers gross and net CO₂ emission calculations. |

<sub>Reviews (3): Last reviewed commit: ["refactor(recap): derive column totals fr..."](https://github.com/felixvonsamson/energetica/commit/fc982ad900a2021d1ad4575486ba34f425c12678) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45378026)</sub>

<!-- /greptile_comment -->