### PR TITLE
feat(recap): retrospection framing — produced + captured columns, drop rank (T9, #907)

### DIFF
--- a/energetica/database/player.py
+++ b/energetica/database/player.py
@@ -539,6 +539,16 @@ class Player(DBModel):
         data = WorkersOut.from_player(self).model_dump()
         self.emit("worker_info", data)
 
+    def calculate_produced_co2(self) -> float:
+        """Calculate the gross CO2 the player produced, in kg.
+
+        The positive categories of the cumulative emissions are the emitting facilities; negative
+        categories are sinks (capture). Gross produced sums only the positive ones, so the recap can
+        show produced and captured un-netted (ADR-0005) rather than only the collapsed net figure.
+        """
+        cumulative_emissions = self.cumul_emissions.get_all()
+        return sum(value for value in cumulative_emissions.values() if value > 0)
+
     def calculate_net_emissions(self) -> float:
         """Calculate the net emissions of the player."""
         cumulative_emissions = self.cumul_emissions.get_all()

--- a/energetica/schemas/recap.py
+++ b/energetica/schemas/recap.py
@@ -171,8 +171,11 @@ class Recap(BaseModel):
             freeze_at=config.freeze_at,
             ended_at=config.ended_at,
             player_count=len(rows),
-            total_produced_co2=sum(player.calculate_produced_co2() for player in ordered),
-            total_captured_co2=sum(player.progression_metrics.get("captured_co2", 0) for player in ordered),
+            # Column totals are summed from the rows just built, not re-derived from the players, so
+            # each header total structurally equals its column (no second traversal to drift from).
+            # net_emissions is sourced from the players because it is not a row column.
+            total_produced_co2=sum(row.produced_co2 for row in rows),
+            total_captured_co2=sum(row.captured_co2 for row in rows),
             total_net_emissions=sum(player.calculate_net_emissions() for player in ordered),
             rows=rows,
             tiles=list(tiles),

--- a/energetica/schemas/recap.py
+++ b/energetica/schemas/recap.py
@@ -1,10 +1,17 @@
-"""The recap: a frozen JSON tombstone of an instance's final leaderboard (G1, #859).
+"""The recap: a frozen JSON tombstone of an instance's final state (G1, #859).
 
 A recap is a **write-once, immutable snapshot** minted at the ``active → freeze`` transition and
 published to the lobby (``recaps/{slug}.json``), where it outlives the instance process (T7). It is a
-**curated projection** — a single income-ranked table plus a small instance-totals header — *not* the
+**curated projection** — a single per-player table plus a small instance-totals header — *not* the
 verbatim :class:`~energetica.schemas.leaderboards.PlayerDetailStats`: the extra columns are cheap as
 data but costly as render/parse surface, and they graduate from the fog as full-recap features later.
+
+**A retrospective, not a scoreboard (ADR-0005, supersedes G1's competitive framing).** The recap
+crowns no winner: there is no rank and no medal. CO2 is laid bare as two un-netted columns — gross
+``produced_co2`` and ``captured_co2`` — so a heavy emitter who also captures heavily reads as exactly
+that, the relationship visible rather than collapsed. Rows default to ``operating_income`` descending
+as a soft "most consequential first" ordering, not a verdict; any per-column notability is derived
+client-side, never minted into the payload.
 
 **Frozen-photograph semantics:** every row captures the player's identity *as it was at freeze*
 (``username_at_freeze``, ``network_name``). The immutable ``account_id`` FK is retained so a future
@@ -49,19 +56,21 @@ class RecapPlayer(Protocol):
     @property
     def progression_metrics(self) -> Mapping[str, float]: ...
 
+    def calculate_produced_co2(self) -> float: ...
+
     def calculate_net_emissions(self) -> float: ...
 
 
 class RecapRow(BaseModel):
-    """One player's final standing, one row of the income-ranked leaderboard."""
+    """One player's final standing, one row of the per-player table (no rank — ADR-0005)."""
 
-    rank: int = Field(description="1-based placement by operating_income desc — the medal")
     account_id: int = Field(description="Server-wide account FK, retained for future identity resolution")
     username_at_freeze: str = Field(description="The player's name as it was at freeze (frozen photograph)")
     network_name: str | None = Field(description="The player's network/team at freeze, or None if unaffiliated")
-    operating_income: float = Field(description="Lifetime cumulated operating income — the sort key, 'who won'")
+    operating_income: float = Field(description="Lifetime cumulated operating income — the default sort key")
     xp: float = Field(description="Experience points — 'how far I got'")
-    captured_co2: float = Field(description="Total captured CO2 in kg — the on-theme brag stat")
+    produced_co2: float = Field(description="Gross CO2 produced in kg — shown un-netted against captured (ADR-0005)")
+    captured_co2: float = Field(description="Total captured CO2 in kg — shown un-netted against produced (ADR-0005)")
 
 
 class RecapTile(BaseModel):
@@ -92,9 +101,9 @@ class RecapTile(BaseModel):
 
 
 class Recap(BaseModel):
-    """The full published recap payload: an identity/totals header plus the income-ranked table.
+    """The full published recap payload: an identity/totals header plus the per-player table.
 
-    Sized for a single payload (~100 players × 7 fields ≈ 15 KB), so the lobby fetches and renders it
+    Sized for a single payload (~100 players × 8 fields ≈ 15 KB), so the lobby fetches and renders it
     with no live backend. Carries the same transition timestamps the fragment does, so the lobby can
     render start/end dates without a second lookup.
     """
@@ -108,6 +117,7 @@ class Recap(BaseModel):
     freeze_at: AwareDatetime | None = None
     ended_at: AwareDatetime | None = None
     player_count: int
+    total_produced_co2: float = Field(description="Sum of produced_co2 (gross) across all players, in kg")
     total_captured_co2: float = Field(description="Sum of captured_co2 across all players, in kg")
     total_net_emissions: float = Field(description="Sum of net CO2 emissions across all players, in kg")
     rows: list[RecapRow]
@@ -128,30 +138,31 @@ class Recap(BaseModel):
     ) -> Recap:
         """Project the live final game state into the frozen recap payload.
 
-        Players are ranked by ``operating_income`` descending (rank 1 = the winner); the totals header
-        sums ``captured_co2`` and ``net_emissions`` across everyone. Ties break on the immutable
-        ``account_id`` (ascending), so the ranking — and every row's ``rank`` — is fully reproducible:
-        a re-mint (admin regenerate) yields the identical frozen photograph rather than reshuffling
-        equal-income players by enumeration order.
+        Rows are emitted in ``operating_income``-descending order — the default "most consequential
+        first" view, not a ranking (ADR-0005): no row carries a rank. The totals header sums
+        ``produced_co2``, ``captured_co2`` and ``net_emissions`` across everyone. Order ties break on
+        the immutable ``account_id`` (ascending), so the frozen photograph is fully reproducible: a
+        re-mint (admin regenerate) yields the identical row order rather than reshuffling equal-income
+        players by enumeration order.
 
         ``tiles`` is the already-projected frozen map snapshot (built by the caller, which owns the
         game-domain read); it is carried through verbatim so the whole recap is one payload.
         """
-        ranked = sorted(
+        ordered = sorted(
             players,
             key=lambda player: (-player.progression_metrics.get("operating_income", 0), player.user.account_id),
         )
         rows = [
             RecapRow(
-                rank=rank,
                 account_id=player.user.account_id,
                 username_at_freeze=player.username,
                 network_name=player.network.name if player.network else None,
                 operating_income=player.progression_metrics.get("operating_income", 0),
                 xp=player.progression_metrics.get("xp", 0),
+                produced_co2=player.calculate_produced_co2(),
                 captured_co2=player.progression_metrics.get("captured_co2", 0),
             )
-            for rank, player in enumerate(ranked, start=1)
+            for player in ordered
         ]
         return cls(
             slug=slug,
@@ -160,8 +171,9 @@ class Recap(BaseModel):
             freeze_at=config.freeze_at,
             ended_at=config.ended_at,
             player_count=len(rows),
-            total_captured_co2=sum(player.progression_metrics.get("captured_co2", 0) for player in ranked),
-            total_net_emissions=sum(player.calculate_net_emissions() for player in ranked),
+            total_produced_co2=sum(player.calculate_produced_co2() for player in ordered),
+            total_captured_co2=sum(player.progression_metrics.get("captured_co2", 0) for player in ordered),
+            total_net_emissions=sum(player.calculate_net_emissions() for player in ordered),
             rows=rows,
             tiles=list(tiles),
         )

--- a/tests/unit/test_player_emissions.py
+++ b/tests/unit/test_player_emissions.py
@@ -1,0 +1,49 @@
+"""Tests for the player's CO2 emission summaries used by the recap (ADR-0005).
+
+``calculate_produced_co2`` (gross, positive categories) and ``calculate_net_emissions`` (all
+categories) both read ``cumul_emissions``, where emitting facilities record positive values and
+capture records a negative one (``production_update`` adds ``-captured_co2`` under ``carbon_capture``).
+The recap shows produced and captured un-netted, so gross-produced must exclude the capture sink.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from energetica import create_app
+from energetica.database.map.hex_tile import HexTile
+from energetica.database.player import Player
+from energetica.database.user import User
+from energetica.utils.map_helpers import confirm_location
+
+
+@pytest.fixture
+def player() -> Player:
+    """A fresh player settled on a fresh engine + map (Player construction needs both)."""
+    create_app(rm_instance=True, skip_adding_handlers=True, env="prod")
+    user = User("emitter", "pwhash", role="player", account_id=1)
+    return confirm_location(user, HexTile.getitem(1))
+
+
+def test_produced_co2_sums_only_positive_categories(player: Player) -> None:
+    """Gross produced is the emitting facilities; the negative capture category is excluded."""
+    player.cumul_emissions.add("steam_engine", 300.0)
+    player.cumul_emissions.add("construction", 50.0)
+    player.cumul_emissions.add_category("carbon_capture")
+    player.cumul_emissions.add("carbon_capture", -120.0)  # capture is stored negative
+
+    assert player.calculate_produced_co2() == 350.0  # 300 + 50, capture excluded
+
+
+def test_net_emissions_sums_all_categories(player: Player) -> None:
+    """Net still nets the capture back out — the collapsed figure the recap shows alongside."""
+    player.cumul_emissions.add("steam_engine", 300.0)
+    player.cumul_emissions.add("construction", 50.0)
+    player.cumul_emissions.add_category("carbon_capture")
+    player.cumul_emissions.add("carbon_capture", -120.0)
+
+    assert player.calculate_net_emissions() == 230.0  # 300 + 50 - 120
+
+
+def test_produced_co2_is_zero_with_no_emissions(player: Player) -> None:
+    assert player.calculate_produced_co2() == 0.0

--- a/tests/unit/test_recap.py
+++ b/tests/unit/test_recap.py
@@ -43,6 +43,7 @@ class _FakePlayer:
     operating_income: float
     xp: float
     captured_co2: float
+    produced_co2: float
     net_emissions: float
     network_name: str | None = None
 
@@ -61,6 +62,9 @@ class _FakePlayer:
     @property
     def progression_metrics(self) -> dict[str, float]:
         return {"operating_income": self.operating_income, "xp": self.xp, "captured_co2": self.captured_co2}
+
+    def calculate_produced_co2(self) -> float:
+        return self.produced_co2
 
     def calculate_net_emissions(self) -> float:
         return self.net_emissions
@@ -133,28 +137,54 @@ def _config() -> InstanceConfig:
 
 def _players() -> list[_FakePlayer]:
     return [
-        _FakePlayer(account_id=10, _username="alice", operating_income=500, xp=42, captured_co2=100, net_emissions=-5),
+        _FakePlayer(
+            account_id=10,
+            _username="alice",
+            operating_income=500,
+            xp=42,
+            captured_co2=100,
+            produced_co2=95,  # net = 95 - 100 = -5
+            net_emissions=-5,
+        ),
         _FakePlayer(
             account_id=20,
             _username="bob",
             operating_income=1500,
             xp=99,
             captured_co2=250,
+            produced_co2=280,  # net = 280 - 250 = 30
             net_emissions=30,
             network_name="Grid Co",
         ),
-        _FakePlayer(account_id=30, _username="carol", operating_income=900, xp=70, captured_co2=0, net_emissions=12),
+        _FakePlayer(
+            account_id=30,
+            _username="carol",
+            operating_income=900,
+            xp=70,
+            captured_co2=0,
+            produced_co2=12,  # net = 12 - 0 = 12
+            net_emissions=12,
+        ),
     ]
 
 
 # --- Recap.from_players (schema projection, G1) ------------------------------------------------
 
 
-def test_from_players_ranks_by_operating_income_desc() -> None:
+def test_from_players_orders_by_operating_income_desc() -> None:
+    """Default order is operating_income descending — 'most consequential first', not a ranking
+    (ADR-0005). No row carries a rank/medal.
+    """
     recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
 
     assert [row.username_at_freeze for row in recap.rows] == ["bob", "carol", "alice"]
-    assert [row.rank for row in recap.rows] == [1, 2, 3]
+
+
+def test_from_players_has_no_rank_field() -> None:
+    """The recap crowns no winner: there is no global rank on a row (ADR-0005)."""
+    recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
+
+    assert "rank" not in recap.rows[0].model_dump()
 
 
 def test_from_players_ties_break_on_account_id_reproducibly() -> None:
@@ -162,9 +192,27 @@ def test_from_players_ties_break_on_account_id_reproducibly() -> None:
     regardless of the order Player.all() enumerates them in.
     """
     tied = [
-        _FakePlayer(account_id=30, _username="carol", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
-        _FakePlayer(account_id=10, _username="alice", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
-        _FakePlayer(account_id=20, _username="bob", operating_income=100, xp=0, captured_co2=0, net_emissions=0),
+        _FakePlayer(
+            account_id=30,
+            _username="carol",
+            operating_income=100,
+            xp=0,
+            captured_co2=0,
+            produced_co2=0,
+            net_emissions=0,
+        ),
+        _FakePlayer(
+            account_id=10,
+            _username="alice",
+            operating_income=100,
+            xp=0,
+            captured_co2=0,
+            produced_co2=0,
+            net_emissions=0,
+        ),
+        _FakePlayer(
+            account_id=20, _username="bob", operating_income=100, xp=0, captured_co2=0, produced_co2=0, net_emissions=0
+        ),
     ]
     forward = Recap.from_players(slug=SLUG, config=_config(), players=tied)
     reshuffled = Recap.from_players(slug=SLUG, config=_config(), players=list(reversed(tied)))
@@ -182,6 +230,8 @@ def test_from_players_projects_the_curated_columns() -> None:
     assert winner.network_name == "Grid Co"
     assert winner.operating_income == 1500
     assert winner.xp == 99
+    # CO2 laid bare as two un-netted columns — produced and captured, not collapsed (ADR-0005).
+    assert winner.produced_co2 == 280
     assert winner.captured_co2 == 250
 
 
@@ -195,6 +245,7 @@ def test_from_players_totals_header() -> None:
     recap = Recap.from_players(slug=SLUG, config=_config(), players=_players())
 
     assert recap.player_count == 3
+    assert recap.total_produced_co2 == 387  # 95 + 280 + 12
     assert recap.total_captured_co2 == 350  # 100 + 250 + 0
     assert recap.total_net_emissions == 37  # -5 + 30 + 12
 
@@ -214,6 +265,7 @@ def test_from_players_empty_instance() -> None:
 
     assert recap.player_count == 0
     assert recap.rows == []
+    assert recap.total_produced_co2 == 0
     assert recap.total_captured_co2 == 0
     assert recap.total_net_emissions == 0
     assert recap.tiles == []  # no tiles passed → empty snapshot (only from_players' test-only default)
@@ -365,7 +417,13 @@ def test_mint_recap_if_needed_is_mint_once(configured: Path, monkeypatch: pytest
         classmethod(
             lambda cls: [
                 _FakePlayer(
-                    account_id=99, _username="latecomer", operating_income=9999, xp=0, captured_co2=0, net_emissions=0
+                    account_id=99,
+                    _username="latecomer",
+                    operating_income=9999,
+                    xp=0,
+                    captured_co2=0,
+                    produced_co2=0,
+                    net_emissions=0,
                 )
             ]
         ),


### PR DESCRIPTION
Stacked on #892 (base `feat/863-recap-map-snapshot`) so the map snapshot (`tiles`) and these columns land together, per [T9 (#907)](https://github.com/felixvonsamson/Energetica/issues/907).

Applies [ADR-0005](../blob/research/docs-audit/docs/adr/0005-recap-is-retrospective-not-a-scoreboard.md): the recap is a **retrospective, not a scoreboard**.

## Changes
- **`RecapRow`**: drop the global `rank` field (no winner, no medal); add gross **`produced_co2`** beside the kept `captured_co2` — CO2 laid bare as two un-netted columns.
- **`Recap`**: add `total_produced_co2` to the totals header (symmetric with the existing captured/net totals).
- **`Recap.from_players`**: no longer assigns rank; still emits rows in `operating_income`-descending order ("most consequential first"), account_id tiebreak kept for reproducible re-mints.
- **`Player.calculate_produced_co2`**: new, mirrors `calculate_net_emissions` — sums the **positive** categories of `cumul_emissions` (capture is a negative `carbon_capture` entry, so positives = gross produced). No new sim metric.

Per-column top-3 emphasis stays client-side (T6) and is never minted into the payload.

## Tests
- Updated `tests/unit/test_recap.py` (drop-rank, produced/captured columns, `total_produced_co2`).
- Added `tests/unit/test_player_emissions.py` locking the produced/net sign convention against a real settled `Player`.
- 26 pass; ruff + pyright clean.

**Unblocks T6 (#864)** — the recap page renders these columns and drops the medal.

Closes #907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies ADR-0005 to the recap schema: the `rank` field is removed from `RecapRow`, and CO2 is now exposed as two un-netted columns (`produced_co2` / `captured_co2`) rather than a collapsed net figure. A new `total_produced_co2` header field mirrors the existing captured/net totals.

- **`Player.calculate_produced_co2()`** sums only positive `cumul_emissions` values; because `production_update.py` is the sole writer and only `carbon_capture` ever adds a negative value, the positive-filter invariant is stable and is locked by the new `test_player_emissions.py`.
- **`Recap.from_players()`** now derives all column totals from the already-built `rows` list (addressing the previous review comment about double-traversal), with `total_net_emissions` remaining a player-traversal because it has no row column.
- The `produced_co2` field on `RecapRow` is required (no default), so old on-disk recaps that lack it will fail to deserialize and self-heal via the existing re-mint path, consistent with how `tiles` was introduced.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive schema adjustments with no new sim logic and clean test coverage.

The implementation is consistent with the existing emission-tracking convention: production_update.py is the sole writer of cumul_emissions, only carbon_capture ever contributes a negative value, and the positive-filter in calculate_produced_co2 is directly verified by the new unit tests. Column totals are derived from rows rather than re-traversing players. No behavioral regressions were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/database/player.py | Adds calculate_produced_co2() that sums only positive cumul_emissions values; sign convention is enforced by production_update (only carbon_capture ever goes negative), so the filter is correct. |
| energetica/schemas/recap.py | Drops rank from RecapRow, adds produced_co2; total_produced_co2/total_captured_co2 are now derived from the already-built rows (addressing the previous review comment), and total_net_emissions still traverses players because it has no row column. |
| tests/unit/test_player_emissions.py | New test file locking the produced/net sign convention: covers the positive-only sum, the full-sum net, and the zero-emissions base case against a real settled Player. |
| tests/unit/test_recap.py | Updated to drop rank assertions, adds produced_co2 to all fake players, and verifies the new total_produced_co2 header field alongside the existing totals tests. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PU["production_update.py\n(each tick)"]
    PM["player.progression_metrics\n['captured_co2'] += captured"]
    CE["player.cumul_emissions\n['carbon_capture'] += -captured\nother facilities += +emissions"]

    PU --> PM
    PU --> CE

    subgraph from_players ["Recap.from_players()"]
        OD["ordered = sorted(players, -operating_income, account_id)"]
        RR["RecapRow\n• produced_co2 = calculate_produced_co2()\n  (sum positive cumul_emissions)\n• captured_co2 = progression_metrics['captured_co2']\n• rank REMOVED"]
        TOTALS["Totals header\n• total_produced_co2 = sum(row.produced_co2)\n• total_captured_co2 = sum(row.captured_co2)\n• total_net_emissions = sum(player.calculate_net_emissions())"]
    end

    CE -->|"calculate_produced_co2()\nfilter value > 0"| RR
    PM -->|"progression_metrics.get('captured_co2')"| RR
    OD --> RR
    RR --> TOTALS
    TOTALS --> SNAP["Recap JSON snapshot\n(immutable, published to lobby)"]
```

<sub>Reviews (2): Last reviewed commit: ["refactor(recap): derive column totals fr..."](https://github.com/felixvonsamson/energetica/commit/b7095872a8cf24b5471ecba65de88b1ea46f6080) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46464608)</sub>

<!-- /greptile_comment -->