### PR TITLE
feat(recap): baseline recap page on the lobby (T6, #864)

### DIFF
--- a/frontend/src/components/lobby/recap/recap-map-tooltip.tsx
+++ b/frontend/src/components/lobby/recap/recap-map-tooltip.tsx
@@ -1,38 +1,37 @@
 /**
- * MapTooltip component - displays resource information when hovering over a
- * tile.
+ * The recap map's hover panel — same resource-bar info as the in-game
+ * `MapTooltip` (via the shared `buildResourceBars`/`calculateTooltipPosition`
+ * helpers in `map-resources.ts`), minus the pieces that only make sense for a
+ * live session: no "Distance" line (there's no "my tile" to measure from in a
+ * frozen recap, no current player) and no activity dot / "You" badge (a frozen
+ * photograph has no online presence to show).
  */
 
-import { PlayerName } from "@/components/ui/player-name";
 import {
     buildResourceBars,
     calculateTooltipPosition,
     TOOLTIP_WIDTH,
 } from "@/lib/map-resources";
-import type { ApiResponse } from "@/types/api-helpers";
-import type { Player } from "@/types/players";
+import type { HexTileResources } from "@/types/map";
 
-type HexTileData = ApiResponse<"/api/v1/map", "get">[number];
-
-interface MapTooltipProps {
-    tile: HexTileData;
-    player: Player | null;
-    distance: number;
+interface RecapMapTooltipProps {
+    tile: HexTileResources;
+    /** The settling player's username at freeze, or null for a vacant tile. */
+    ownerName: string | null;
     x: number;
     y: number;
     viewportWidth: number;
     viewportHeight: number;
 }
 
-export function MapTooltip({
+export function RecapMapTooltip({
     tile,
-    player,
-    distance,
+    ownerName,
     x,
     y,
     viewportWidth,
     viewportHeight,
-}: MapTooltipProps) {
+}: RecapMapTooltipProps) {
     const { left, top } = calculateTooltipPosition(
         x,
         y,
@@ -53,11 +52,8 @@ export function MapTooltip({
             <div className="bg-card border border-border px-6 py-3 rounded shadow-lg">
                 {/* Title */}
                 <div className="text-center text-xl mb-3">
-                    {player ? (
-                        <PlayerName
-                            player={player}
-                            className="justify-center"
-                        />
+                    {ownerName ? (
+                        <span>{ownerName}</span>
                     ) : (
                         <span className="text-brand-green dark:text-gray-100">
                             Vacant tile
@@ -88,15 +84,6 @@ export function MapTooltip({
                             </div>
                         );
                     })}
-                </div>
-
-                {/* Distance */}
-                <div className="text-center text-foreground text-base mt-4">
-                    Distance:{" "}
-                    {Number.isInteger(distance)
-                        ? distance
-                        : distance.toFixed(1)}{" "}
-                    {distance === 1 ? "tile" : "tiles"}
                 </div>
             </div>
         </div>

--- a/frontend/src/components/lobby/recap/recap-map.tsx
+++ b/frontend/src/components/lobby/recap/recap-map.tsx
@@ -1,74 +1,63 @@
 /**
- * The recap's frozen map snapshot. A self-contained SVG hex map: no
- * `MapContext`, no live game data — just the `RecapTile[]` frozen at freeze
- * (T5/G1). It reuses the pure geometry (`hex-utils`) and the resource-heatmap
- * colouring (`map-resources`) the in-game map already uses, so the snapshot
- * mimics the live view and the world survives instance teardown.
+ * The recap's frozen map snapshot. No `MapContext` provider of its own — it
+ * hands the frozen `RecapTile[]` (adapted to the live `HexTileOut` shape) to
+ * the _same_ `MapCanvas`/`MapTiles` the in-game community map renders with, so
+ * the snapshot isn't a lookalike reimplementation but the actual map component
+ * displaying old data. That also fixes the recap map's sizing: it previously
+ * hard-coded a 14px hex (`recap-map.tsx` pre-#915) instead of
+ * `calculateHexSizeWithConstraints`, so it never matched the live map's scale.
  *
  * With no resource selected it shows the world as it was — settled tiles
- * (labelled with the owner) against vacant land and rivers (hydro potential).
- * The `ResourceButton` row (the same control as the in-game community map)
- * swaps in a per-resource potential/reserve heatmap; clicking the active
- * resource toggles back to the territory view. Extraction/depletion is
- * deliberately absent: the frozen tiles carry only remaining reserves, not the
- * original, so a true "what was pulled from here" map needs a newly minted
- * metric (parked — see #864 discussion).
+ * (labelled with the owner) against vacant land. The `ResourceButton` row (the
+ * same control as the in-game community map) swaps in a per-resource
+ * potential/reserve heatmap; clicking the active resource toggles back to the
+ * territory view. Extraction/depletion is deliberately absent: the frozen tiles
+ * carry only remaining reserves, not the original, so a true "what was pulled
+ * from here" map needs a newly minted metric (parked — see #864 discussion).
+ *
+ * Hovering a tile shows the same info panel as the in-game map (owner, or
+ * "Vacant tile", plus every resource's level) via `RecapMapTooltip` — a
+ * recap-specific shell (no "Distance", no activity dot — neither applies to a
+ * frozen photograph with no current player) built on the same
+ * `buildResourceBars`/`calculateTooltipPosition` helpers `MapTooltip` uses, so
+ * the numbers can't drift between the two.
  */
 
 import { useMemo, useState } from "react";
 
+import { MapCanvas } from "@/components/map/map-canvas";
+import { MapTiles } from "@/components/map/map-tiles";
 import { ResourceButton } from "@/components/map/resource-button";
-import { useTheme } from "@/contexts/theme-context";
-import { getHexPosition, getHexagonPoints } from "@/lib/hex-utils";
-import {
-    RESOURCES,
-    ResourceId,
-    calculateTileFillWithResource,
-} from "@/lib/map-resources";
+import { useMapContext } from "@/contexts/map-context";
+import { getHexPosition } from "@/lib/hex-utils";
+import { RESOURCES, ResourceId } from "@/lib/map-resources";
 import type { RecapTile } from "@/lib/recap";
+import type { HexTileResources } from "@/types/map";
 
-const S = 14; // hex size (centre → vertex)
-const W = S * Math.sqrt(3);
+import { RecapMapTooltip } from "./recap-map-tooltip";
 
 type Props = {
     tiles: RecapTile[];
     /** Account_id → username at freeze, for the settled-tile labels. */
     ownerNames: Record<number, string>;
-    /** When set, the tile owned by this account is outlined (table↔map echo). */
-    highlightAccountId?: number | null;
-    onHoverOwner?: (accountId: number | null) => void;
 };
 
-export function RecapMap({
-    tiles,
-    ownerNames,
-    highlightAccountId,
-    onHoverOwner,
-}: Props) {
-    const { theme } = useTheme();
+export function RecapMap({ tiles, ownerNames }: Props) {
     const [overlay, setOverlay] = useState<ResourceId | undefined>(undefined);
 
-    const { points, viewBox } = useMemo(() => {
-        const placed = tiles.map((tile) => {
-            const { x, y } = getHexPosition(tile.q, tile.r, S, W);
-            return { tile, x, y };
-        });
-        const xs = placed.map((p) => p.x);
-        const ys = placed.map((p) => p.y);
-        const minX = Math.min(...xs);
-        const minY = Math.min(...ys);
-        const maxX = Math.max(...xs);
-        const maxY = Math.max(...ys);
-        const pad = S * 2;
-        return {
-            points: placed,
-            viewBox: `${minX - pad} ${minY - pad} ${maxX - minX + 2 * pad} ${
-                maxY - minY + 2 * pad
-            }`,
-        };
-    }, [tiles]);
-
-    const hexPoints = getHexagonPoints(S, W);
+    // MapTiles/HexTile expect the live HexTileOut shape: a numeric `id` (used
+    // only as the React key + hover lookup here, never round-tripped anywhere)
+    // and `player_id` in place of the recap's durable `owner_account_id`. The
+    // index is stable — `tiles` is a fixed prop, not a live-updating list.
+    const mapData: HexTileResources[] = useMemo(
+        () =>
+            tiles.map((tile, index) => ({
+                ...tile,
+                id: index,
+                player_id: tile.owner_account_id,
+            })),
+        [tiles],
+    );
 
     const toggleOverlay = (id: ResourceId) =>
         setOverlay((current) => (current === id ? undefined : id));
@@ -93,67 +82,57 @@ export function RecapMap({
                     />
                 ))}
             </div>
-            <svg
-                viewBox={viewBox}
-                className="w-full"
-                style={{ maxHeight: "70vh" }}
-            >
-                {points.map(({ tile, x, y }) => {
-                    const owned = tile.owner_account_id != null;
-                    const isRiver = tile.hydro > 0;
-                    const base = owned
-                        ? "var(--map-tile-other-player, oklch(0.55 0.02 250))"
-                        : isRiver
-                          ? "oklch(0.86 0.05 230)"
-                          : "var(--map-tile-vacant, oklch(0.92 0.005 90))";
-                    const { fill, labelColor } = calculateTileFillWithResource(
-                        { ...tile, player_id: tile.owner_account_id },
-                        overlay,
-                        theme,
-                        base,
-                        owned ? "white" : "black",
-                    );
-                    const highlighted =
-                        highlightAccountId != null &&
-                        tile.owner_account_id === highlightAccountId;
-                    const name =
-                        tile.owner_account_id != null
-                            ? ownerNames[tile.owner_account_id]
-                            : undefined;
-                    return (
-                        <g
-                            key={`${tile.q},${tile.r}`}
-                            transform={`translate(${x}, ${y})`}
-                            onMouseEnter={() =>
-                                onHoverOwner?.(tile.owner_account_id)
-                            }
-                            onMouseLeave={() => onHoverOwner?.(null)}
-                        >
-                            <polygon
-                                points={hexPoints}
-                                style={{
-                                    fill,
-                                    stroke: highlighted
-                                        ? "var(--foreground, #000)"
-                                        : "rgba(0,0,0,0.18)",
-                                    strokeWidth: highlighted ? 2.5 : 1,
-                                }}
-                            />
-                            {owned && (
-                                <text
-                                    textAnchor="middle"
-                                    dominantBaseline="middle"
-                                    fontSize={7}
-                                    fill={labelColor}
-                                >
-                                    {/* 3 chars, centred on the tile — matches the in-game map's owner-label convention (map-resources.ts, calculateTileLabel). */}
-                                    {name?.slice(0, 3)}
-                                </text>
-                            )}
-                        </g>
-                    );
-                })}
-            </svg>
+            {/* Fixed aspect-ratio box (same ratio as the settle/community-map
+                pages): MapCanvas measures its container and sizes hexes to fit,
+                so this keeps the frozen snapshot at the live map's scale
+                instead of a hard-coded pixel size. */}
+            <div className="w-full relative pt-[86.60%]">
+                <MapCanvas className="absolute inset-0" mapData={mapData}>
+                    <MapTiles
+                        mapData={mapData}
+                        playerMap={ownerNames}
+                        activeResourceId={overlay}
+                    />
+                    <RecapMapTooltipLayer ownerNames={ownerNames} />
+                </MapCanvas>
+            </div>
         </div>
+    );
+}
+
+/**
+ * Renders the hovered-tile info panel; must be inside a MapCanvas (uses
+ * context).
+ */
+function RecapMapTooltipLayer({
+    ownerNames,
+}: {
+    ownerNames: Record<number, string>;
+}) {
+    const { width, height, s, w, hoveredTile } = useMapContext();
+    if (!hoveredTile) return null;
+    const { x, y } = getHexPosition(hoveredTile.q, hoveredTile.r, s, w);
+    return (
+        <foreignObject
+            x={-width / 2}
+            y={-height / 2}
+            width={width}
+            height={height}
+            overflow="visible"
+            style={{ pointerEvents: "none" }}
+        >
+            <RecapMapTooltip
+                tile={hoveredTile}
+                ownerName={
+                    hoveredTile.player_id
+                        ? (ownerNames[hoveredTile.player_id] ?? null)
+                        : null
+                }
+                x={x}
+                y={y}
+                viewportWidth={width}
+                viewportHeight={height}
+            />
+        </foreignObject>
     );
 }

--- a/frontend/src/components/lobby/recap/recap-map.tsx
+++ b/frontend/src/components/lobby/recap/recap-map.tsx
@@ -106,12 +106,12 @@ export function RecapMap({
                         : isRiver
                           ? "oklch(0.86 0.05 230)"
                           : "var(--map-tile-vacant, oklch(0.92 0.005 90))";
-                    const { fill } = calculateTileFillWithResource(
+                    const { fill, labelColor } = calculateTileFillWithResource(
                         { ...tile, player_id: tile.owner_account_id },
                         overlay,
                         theme,
                         base,
-                        "black",
+                        owned ? "white" : "black",
                     );
                     const highlighted =
                         highlightAccountId != null &&
@@ -139,18 +139,16 @@ export function RecapMap({
                                     strokeWidth: highlighted ? 2.5 : 1,
                                 }}
                             />
-                            {owned && overlay === undefined && (
-                                <>
-                                    <circle r={3} fill="white" />
-                                    <text
-                                        y={S * 0.9}
-                                        textAnchor="middle"
-                                        fontSize={7}
-                                        fill="var(--foreground, #111)"
-                                    >
-                                        {name?.slice(0, 6)}
-                                    </text>
-                                </>
+                            {owned && (
+                                <text
+                                    textAnchor="middle"
+                                    dominantBaseline="middle"
+                                    fontSize={7}
+                                    fill={labelColor}
+                                >
+                                    {/* 3 chars, centred on the tile — matches the in-game map's owner-label convention (map-resources.ts, calculateTileLabel). */}
+                                    {name?.slice(0, 3)}
+                                </text>
                             )}
                         </g>
                     );

--- a/frontend/src/components/lobby/recap/recap-map.tsx
+++ b/frontend/src/components/lobby/recap/recap-map.tsx
@@ -73,6 +73,14 @@ export function RecapMap({
     const toggleOverlay = (id: ResourceId) =>
         setOverlay((current) => (current === id ? undefined : id));
 
+    if (tiles.length === 0) {
+        return (
+            <p className="text-muted-foreground text-sm">
+                No map data for this recap.
+            </p>
+        );
+    }
+
     return (
         <div>
             <div className="mb-4 grid grid-cols-4 gap-2 sm:grid-cols-7">

--- a/frontend/src/components/lobby/recap/recap-map.tsx
+++ b/frontend/src/components/lobby/recap/recap-map.tsx
@@ -1,0 +1,153 @@
+/**
+ * The recap's frozen map snapshot. A self-contained SVG hex map: no
+ * `MapContext`, no live game data — just the `RecapTile[]` frozen at freeze
+ * (T5/G1). It reuses the pure geometry (`hex-utils`) and the resource-heatmap
+ * colouring (`map-resources`) the in-game map already uses, so the snapshot
+ * mimics the live view and the world survives instance teardown.
+ *
+ * With no resource selected it shows the world as it was — settled tiles
+ * (labelled with the owner) against vacant land and rivers (hydro potential).
+ * The `ResourceButton` row (the same control as the in-game community map)
+ * swaps in a per-resource potential/reserve heatmap; clicking the active
+ * resource toggles back to the territory view. Extraction/depletion is
+ * deliberately absent: the frozen tiles carry only remaining reserves, not the
+ * original, so a true "what was pulled from here" map needs a newly minted
+ * metric (parked — see #864 discussion).
+ */
+
+import { useMemo, useState } from "react";
+
+import { ResourceButton } from "@/components/map/resource-button";
+import { useTheme } from "@/contexts/theme-context";
+import { getHexPosition, getHexagonPoints } from "@/lib/hex-utils";
+import {
+    RESOURCES,
+    ResourceId,
+    calculateTileFillWithResource,
+} from "@/lib/map-resources";
+import type { RecapTile } from "@/lib/recap";
+
+const S = 14; // hex size (centre → vertex)
+const W = S * Math.sqrt(3);
+
+type Props = {
+    tiles: RecapTile[];
+    /** Account_id → username at freeze, for the settled-tile labels. */
+    ownerNames: Record<number, string>;
+    /** When set, the tile owned by this account is outlined (table↔map echo). */
+    highlightAccountId?: number | null;
+    onHoverOwner?: (accountId: number | null) => void;
+};
+
+export function RecapMap({
+    tiles,
+    ownerNames,
+    highlightAccountId,
+    onHoverOwner,
+}: Props) {
+    const { theme } = useTheme();
+    const [overlay, setOverlay] = useState<ResourceId | undefined>(undefined);
+
+    const { points, viewBox } = useMemo(() => {
+        const placed = tiles.map((tile) => {
+            const { x, y } = getHexPosition(tile.q, tile.r, S, W);
+            return { tile, x, y };
+        });
+        const xs = placed.map((p) => p.x);
+        const ys = placed.map((p) => p.y);
+        const minX = Math.min(...xs);
+        const minY = Math.min(...ys);
+        const maxX = Math.max(...xs);
+        const maxY = Math.max(...ys);
+        const pad = S * 2;
+        return {
+            points: placed,
+            viewBox: `${minX - pad} ${minY - pad} ${maxX - minX + 2 * pad} ${
+                maxY - minY + 2 * pad
+            }`,
+        };
+    }, [tiles]);
+
+    const hexPoints = getHexagonPoints(S, W);
+
+    const toggleOverlay = (id: ResourceId) =>
+        setOverlay((current) => (current === id ? undefined : id));
+
+    return (
+        <div>
+            <div className="mb-4 grid grid-cols-4 gap-2 sm:grid-cols-7">
+                {RESOURCES.map((resource) => (
+                    <ResourceButton
+                        key={resource.id}
+                        resource={resource}
+                        isActive={overlay === resource.id}
+                        onClick={() => toggleOverlay(resource.id)}
+                    />
+                ))}
+            </div>
+            <svg
+                viewBox={viewBox}
+                className="w-full"
+                style={{ maxHeight: "70vh" }}
+            >
+                {points.map(({ tile, x, y }) => {
+                    const owned = tile.owner_account_id != null;
+                    const isRiver = tile.hydro > 0;
+                    const base = owned
+                        ? "var(--map-tile-other-player, oklch(0.55 0.02 250))"
+                        : isRiver
+                          ? "oklch(0.86 0.05 230)"
+                          : "var(--map-tile-vacant, oklch(0.92 0.005 90))";
+                    const { fill } = calculateTileFillWithResource(
+                        { ...tile, player_id: tile.owner_account_id },
+                        overlay,
+                        theme,
+                        base,
+                        "black",
+                    );
+                    const highlighted =
+                        highlightAccountId != null &&
+                        tile.owner_account_id === highlightAccountId;
+                    const name =
+                        tile.owner_account_id != null
+                            ? ownerNames[tile.owner_account_id]
+                            : undefined;
+                    return (
+                        <g
+                            key={`${tile.q},${tile.r}`}
+                            transform={`translate(${x}, ${y})`}
+                            onMouseEnter={() =>
+                                onHoverOwner?.(tile.owner_account_id)
+                            }
+                            onMouseLeave={() => onHoverOwner?.(null)}
+                        >
+                            <polygon
+                                points={hexPoints}
+                                style={{
+                                    fill,
+                                    stroke: highlighted
+                                        ? "var(--foreground, #000)"
+                                        : "rgba(0,0,0,0.18)",
+                                    strokeWidth: highlighted ? 2.5 : 1,
+                                }}
+                            />
+                            {owned && overlay === undefined && (
+                                <>
+                                    <circle r={3} fill="white" />
+                                    <text
+                                        y={S * 0.9}
+                                        textAnchor="middle"
+                                        fontSize={7}
+                                        fill="var(--foreground, #111)"
+                                    >
+                                        {name?.slice(0, 6)}
+                                    </text>
+                                </>
+                            )}
+                        </g>
+                    );
+                })}
+            </svg>
+        </div>
+    );
+}

--- a/frontend/src/components/lobby/run-cards.tsx
+++ b/frontend/src/components/lobby/run-cards.tsx
@@ -7,9 +7,17 @@
  * Both render as plain `<a href>`: run links are cross-origin
  * (`{slug}.{apex}/app`), and the logged-out variant's `/login?return={slug}` is
  * an internal path where a full page load is harmless.
+ *
+ * Once a run reaches `freeze` (its recap is minted and published, T5/G1), both
+ * cards grow a secondary "View recap" row — a same-origin, in-lobby route, so
+ * it uses TanStack Router's `Link` rather than the frame's cross-origin `<a>`.
+ * It sits alongside, not instead of, the primary action: freeze keeps the live
+ * instance up and readable (G2), so "Continue"/"Join" into the live run is
+ * still meaningful even after the recap exists.
  */
 
-import { ChevronRight, Zap } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { ChevronRight, FileClock, Zap } from "lucide-react";
 
 import { TypographyMuted } from "@/components/ui/typography";
 import type { MyRun } from "@/lib/api/lobby";
@@ -26,26 +34,48 @@ function formatMonthYear(iso: string): string | null {
     }).format(date);
 }
 
+/** The "View recap" row, shown once a run's recap can exist (`freeze`/`ended`). */
+function ViewRecapRow({ slug }: { slug: string }) {
+    return (
+        <Link
+            to="/runs/$slug/recap"
+            params={{ slug }}
+            className="flex flex-row items-center gap-1.5 px-5 py-2.5 text-sm text-muted-foreground hover:text-primary transition-colors border-t border-border"
+        >
+            <FileClock className="w-4 h-4" />
+            View recap
+        </Link>
+    );
+}
+
 function RunCardFrame({
     href,
     cta,
+    slug,
+    phase,
     children,
 }: {
     href: string;
     cta: string;
+    slug: string;
+    phase: ReturnType<typeof derivePhase>;
     children: React.ReactNode;
 }) {
+    const recapAvailable = phase === "freeze" || phase === "ended";
     return (
-        <a
-            href={href}
-            className="bg-card text-foreground border border-border p-5 rounded-4xl flex flex-row justify-between items-center gap-4 shadow-md hover:bg-muted hover:shadow-lg active:scale-[0.99] transition-all"
-        >
-            {children}
-            <div className="flex flex-row items-center gap-1 text-primary shrink-0">
-                <p className="font-semibold">{cta}</p>
-                <ChevronRight />
-            </div>
-        </a>
+        <div className="bg-card text-foreground border border-border rounded-4xl shadow-md overflow-hidden">
+            <a
+                href={href}
+                className="p-5 flex flex-row justify-between items-center gap-4 hover:bg-muted transition-all"
+            >
+                {children}
+                <div className="flex flex-row items-center gap-1 text-primary shrink-0">
+                    <p className="font-semibold">{cta}</p>
+                    <ChevronRight />
+                </div>
+            </a>
+            {recapAvailable && <ViewRecapRow slug={slug} />}
+        </div>
     );
 }
 
@@ -53,7 +83,12 @@ function RunCardFrame({
 export function MyRunCard({ run }: { run: MyRun }) {
     const joined = formatMonthYear(run.settled_at);
     return (
-        <RunCardFrame href={runAppHref(run.slug)} cta="Continue">
+        <RunCardFrame
+            href={runAppHref(run.slug)}
+            cta="Continue"
+            slug={run.slug}
+            phase={derivePhase(run)}
+        >
             <div className="flex flex-row items-center gap-4 min-w-0">
                 <div className="bg-primary/10 text-primary rounded-2xl p-3 shrink-0">
                     <Zap className="w-6 h-6" />
@@ -82,15 +117,15 @@ export function OpenRunCard({
     loggedIn: boolean;
 }) {
     const when = formatMonthYear(instance.starts_at);
+    const phase = derivePhase(instance);
     // An announced run advertises before it's playable (#862, T4): the fragment is published at
     // creation with a future `starts_at`, so the card must say "Starts …", not "Running since …".
-    const label =
-        derivePhase(instance) === "announced" ? "Starts" : "Running since";
+    const label = phase === "announced" ? "Starts" : "Running since";
     const href = loggedIn
         ? runAppHref(instance.slug)
         : `/login?return=${encodeURIComponent(instance.slug)}`;
     return (
-        <RunCardFrame href={href} cta="Join">
+        <RunCardFrame href={href} cta="Join" slug={instance.slug} phase={phase}>
             <div className="flex flex-col min-w-0">
                 <p className="text-lg font-semibold truncate">
                     {instance.name}

--- a/frontend/src/hooks/use-lobby.ts
+++ b/frontend/src/hooks/use-lobby.ts
@@ -80,6 +80,13 @@ export function useRecap(slug: string) {
                 throw error;
             }
         },
+        // "Not minted yet" (`null`) is a transient state waiting on the next
+        // tick to publish, not a stable answer — the lobby's default 30s
+        // staleTime would otherwise cache it and hide a recap published
+        // moments later. Poll until it appears; a published recap is frozen
+        // forever, so it's cached indefinitely once found.
+        staleTime: (query) => (query.state.data == null ? 0 : Infinity),
+        refetchInterval: (query) => (query.state.data == null ? 5000 : false),
     });
 }
 

--- a/frontend/src/hooks/use-lobby.ts
+++ b/frontend/src/hooks/use-lobby.ts
@@ -9,6 +9,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { lobbyApi, lobbyAuthApi, type MyRunsResponse } from "@/lib/api/lobby";
 import { ApiClientError } from "@/lib/api-client";
 import { fetchInstances, type InstanceFragment } from "@/lib/instances";
+import { fetchRecap, RecapNotMintedError, type Recap } from "@/lib/recap";
 import type { LoginRequest, SignupRequest } from "@/types/auth";
 
 /**
@@ -19,6 +20,7 @@ import type { LoginRequest, SignupRequest } from "@/types/auth";
 export const lobbyQueryKeys = {
     myRuns: ["lobby", "my-runs"] as const,
     instances: ["lobby", "instances"] as const,
+    recap: (slug: string) => ["lobby", "recap", slug] as const,
 };
 
 /**
@@ -55,6 +57,29 @@ export function useInstancesManifest() {
     return useQuery<InstanceFragment[]>({
         queryKey: lobbyQueryKeys.instances,
         queryFn: ({ signal }) => fetchInstances(signal).catch(() => []),
+    });
+}
+
+/**
+ * A run's published recap (`/recaps/{slug}.json`). `data` is `null` while the
+ * run hasn't reached `freeze` yet — {@link RecapNotMintedError} (a 404) is
+ * swallowed rather than surfaced as a query error, since "not frozen yet" is an
+ * expected, common state, not a failure. Other errors (network, malformed
+ * payload) surface normally so the page can distinguish "not minted" from
+ * "broken". (`null`, not `undefined`: React Query's `queryFn` must resolve to a
+ * defined value.)
+ */
+export function useRecap(slug: string) {
+    return useQuery<Recap | null>({
+        queryKey: lobbyQueryKeys.recap(slug),
+        queryFn: async ({ signal }) => {
+            try {
+                return await fetchRecap(slug, signal);
+            } catch (error) {
+                if (error instanceof RecapNotMintedError) return null;
+                throw error;
+            }
+        },
     });
 }
 

--- a/frontend/src/lib/map-resources.ts
+++ b/frontend/src/lib/map-resources.ts
@@ -165,3 +165,122 @@ export function calculateTileLabel(
     }
     return { label: null, size: MAX_LABEL_SIZE };
 }
+
+// --- tile info panel (hover tooltip) --------------------------------------
+//
+// Shared by the in-game map's MapTooltip and the recap's frozen-map tooltip,
+// so the two panels' resource numbers and bar colours can't drift apart.
+
+export interface ResourceBarInfo {
+    name: string;
+    value: number;
+    maxValue: number;
+    /**
+     * CSS colour for the bar fill (an HSL string — distinct from the oklch
+     * heatmap palette above; chosen for contrast on a thin 4px bar).
+     */
+    color: string;
+    displayValue: string;
+}
+
+// HSL hues, one per RESOURCES entry (solar, wind, hydro, coal, gas, uranium,
+// climate risk) — a different scale than RESOURCES[].color (heatmap tiles),
+// tuned instead for legibility as a thin progress-bar fill.
+const BAR_HUES = [59, 186, 239, 0, 275, 109, 320] as const;
+
+/**
+ * Fuel reserves in whole tons with a thousands separator, e.g. "1'500 tons".
+ * Deliberately not the shared adaptive-unit {@link formatMass} (kg/t/Mt) — this
+ * is the info panel's own long-standing display format, kept as-is.
+ */
+function formatMassInTons(mass: number): string {
+    const massInTons = mass / 1000;
+    return `${massInTons.toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, "'")} tons`;
+}
+
+/**
+ * Per-resource rows for a tile's info panel: value, formatted display string,
+ * and bar-fill color.
+ */
+export function buildResourceBars(tile: TileWithResources): ResourceBarInfo[] {
+    return [
+        {
+            name: "Solar",
+            value: tile.solar,
+            maxValue: MAX_VALUES[0],
+            color: `hsl(${BAR_HUES[0]}, 95%, 50%)`,
+            displayValue: `${Math.round(tile.solar * 1000)} W/m²`,
+        },
+        {
+            name: "Wind",
+            value: tile.wind,
+            maxValue: MAX_VALUES[1],
+            color: `hsl(${BAR_HUES[1]}, 95%, 50%)`,
+            displayValue: `${Math.round(Math.pow(tile.wind, 0.5) * 50)} km/h`,
+        },
+        {
+            name: "Hydro",
+            value: tile.hydro,
+            maxValue: MAX_VALUES[2],
+            color: `hsl(${BAR_HUES[2]}, 95%, 50%)`,
+            displayValue: `${Math.round(tile.hydro * 150)} m³/s`,
+        },
+        {
+            name: "Coal",
+            value: tile.coal,
+            maxValue: MAX_VALUES[3],
+            color: `hsl(${BAR_HUES[3]}, 95%, 50%)`,
+            displayValue: formatMassInTons(tile.coal),
+        },
+        {
+            name: "Gas",
+            value: tile.gas,
+            maxValue: MAX_VALUES[4],
+            color: `hsl(${BAR_HUES[4]}, 95%, 50%)`,
+            displayValue: formatMassInTons(tile.gas),
+        },
+        {
+            name: "Uranium",
+            value: tile.uranium,
+            maxValue: MAX_VALUES[5],
+            color: `hsl(${BAR_HUES[5]}, 95%, 50%)`,
+            displayValue: formatMassInTons(tile.uranium),
+        },
+        {
+            name: "Climate risk",
+            value: tile.climate_risk,
+            maxValue: MAX_VALUES[6],
+            color: `hsl(${BAR_HUES[6]}, 95%, 50%)`,
+            displayValue: `${tile.climate_risk} / 10`,
+        },
+    ];
+}
+
+const TOOLTIP_WIDTH = 200;
+const TOOLTIP_HEIGHT = 360;
+
+/**
+ * Where to draw a tile info panel so it stays inside the map's SVG viewport:
+ * offset down-right from the tile by default, flipped to whichever side keeps
+ * it on screen. `x`/`y` are the tile's centre in the same SVG-local coordinate
+ * space as the viewport dimensions (both centred on the map's own origin).
+ */
+export function calculateTooltipPosition(
+    x: number,
+    y: number,
+    viewportWidth: number,
+    viewportHeight: number,
+): { left: number; top: number } {
+    let left = x + 40;
+    let top = y - 40;
+
+    if (left + TOOLTIP_WIDTH > viewportWidth / 2) {
+        left -= TOOLTIP_WIDTH + 80;
+    }
+    if (top + TOOLTIP_HEIGHT > viewportHeight / 2) {
+        top = viewportHeight / 2 - TOOLTIP_HEIGHT - 10;
+    }
+    return { left, top };
+}
+
+export { TOOLTIP_WIDTH, TOOLTIP_HEIGHT };

--- a/frontend/src/lib/recap.ts
+++ b/frontend/src/lib/recap.ts
@@ -1,0 +1,107 @@
+/**
+ * Lobby-side consumer of a run's published recap — the frozen JSON tombstone
+ * minted once at `active → freeze` (G1/T5) and served statically beside the
+ * instance fragment (`/recaps/{slug}.json`, Apache-aliased in prod from the
+ * shared landing dir; see `docs/architecture/static-serving-and-deployment.md`
+ * § Recap publication).
+ *
+ * Mirrors the backend `Recap`/`RecapRow`/`RecapTile` models
+ * (`energetica/schemas/recap.py`). Hand-mirrored rather than
+ * `generate-types`-derived: the recap is never served through a FastAPI route
+ * (it's a static file, sized to be fetched with no live backend), so it never
+ * reaches the OpenAPI schema `generate-types` reads.
+ *
+ * The recap is a retrospective, not a scoreboard (ADR-0005): there is no
+ * `rank`, and CO2 is laid bare as two un-netted columns — gross `produced_co2`
+ * and `captured_co2` — so a heavy emitter who also captures heavily reads as
+ * exactly that, not as a single netted number.
+ */
+
+import type { Lifecycle } from "./instances";
+
+/** One player's row of the per-player retrospective table (no rank — ADR-0005). */
+export type RecapRow = {
+    /** Server-wide account FK, retained for future identity resolution. */
+    account_id: number;
+    /** The player's name as it was at freeze (frozen photograph). */
+    username_at_freeze: string;
+    /** The player's network/team at freeze, or null if unaffiliated. */
+    network_name: string | null;
+    /** Lifetime cumulated operating income. Default (un-ranked) row order. */
+    operating_income: number;
+    /** Experience points — how far the player progressed. */
+    xp: number;
+    /** Gross CO2 produced, in kg — shown un-netted against captured. */
+    produced_co2: number;
+    /** Total CO2 captured, in kg — shown un-netted against produced. */
+    captured_co2: number;
+};
+
+/**
+ * One tile of the frozen map snapshot: `HexTileOut` minus `id`, with live
+ * `player_id` swapped for the durable `owner_account_id` (joins {@link RecapRow}
+ * by `account_id`). Renewable fields are 0–1 potentials; fuel fields are the
+ * reserves remaining at freeze, in kg.
+ */
+export type RecapTile = {
+    q: number;
+    r: number;
+    solar: number;
+    wind: number;
+    hydro: number;
+    coal: number;
+    gas: number;
+    uranium: number;
+    climate_risk: number;
+    owner_account_id: number | null;
+};
+
+/**
+ * The full published recap payload: an identity/totals header, the per-player
+ * table, and the map snapshot. Satisfies {@link Lifecycle} so it can share phase
+ * helpers with instance fragments, though by the time a recap is fetchable its
+ * phase is always `freeze` or `ended`.
+ */
+export type Recap = Lifecycle & {
+    slug: string;
+    name: string;
+    player_count: number;
+    /** Sum of gross CO2 produced across all players, in kg. */
+    total_produced_co2: number;
+    /** Sum of CO2 captured across all players, in kg. */
+    total_captured_co2: number;
+    /** Sum of net CO2 emissions across all players, in kg. */
+    total_net_emissions: number;
+    rows: RecapRow[];
+    tiles: RecapTile[];
+};
+
+/**
+ * Thrown by {@link fetchRecap} when the run hasn't reached `freeze` yet, so no
+ * recap has been minted.
+ */
+export class RecapNotMintedError extends Error {
+    constructor(slug: string) {
+        super(`No recap published yet for "${slug}" — the run hasn't frozen.`);
+        this.name = "RecapNotMintedError";
+    }
+}
+
+/**
+ * Fetch a run's published recap.
+ *
+ * @throws {RecapNotMintedError} When the run is not yet in `freeze`/`ended` (no
+ *   recap has been minted, i.e. a 404).
+ */
+export async function fetchRecap(
+    slug: string,
+    signal?: AbortSignal,
+): Promise<Recap> {
+    const response = await fetch(`/recaps/${slug}.json`, { signal });
+    if (response.status === 404) throw new RecapNotMintedError(slug);
+    if (!response.ok)
+        throw new Error(
+            `Failed to fetch recap for ${slug}: ${response.status}`,
+        );
+    return (await response.json()) as Recap;
+}

--- a/frontend/src/routeTree.lobby.gen.ts
+++ b/frontend/src/routeTree.lobby.gen.ts
@@ -14,6 +14,7 @@ import { Route as LogoutRouteImport } from './routes-lobby/logout'
 import { Route as LoginRouteImport } from './routes-lobby/login'
 import { Route as AccountRouteImport } from './routes-lobby/account'
 import { Route as IndexRouteImport } from './routes-lobby/index'
+import { Route as RunsSlugRecapRouteImport } from './routes-lobby/runs.$slug.recap'
 
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
@@ -40,6 +41,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const RunsSlugRecapRoute = RunsSlugRecapRouteImport.update({
+  id: '/runs/$slug/recap',
+  path: '/runs/$slug/recap',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -47,6 +53,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/signup': typeof SignupRoute
+  '/runs/$slug/recap': typeof RunsSlugRecapRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -54,6 +61,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/signup': typeof SignupRoute
+  '/runs/$slug/recap': typeof RunsSlugRecapRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -62,13 +70,27 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/signup': typeof SignupRoute
+  '/runs/$slug/recap': typeof RunsSlugRecapRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/account' | '/login' | '/logout' | '/signup'
+  fullPaths:
+    | '/'
+    | '/account'
+    | '/login'
+    | '/logout'
+    | '/signup'
+    | '/runs/$slug/recap'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/account' | '/login' | '/logout' | '/signup'
-  id: '__root__' | '/' | '/account' | '/login' | '/logout' | '/signup'
+  to: '/' | '/account' | '/login' | '/logout' | '/signup' | '/runs/$slug/recap'
+  id:
+    | '__root__'
+    | '/'
+    | '/account'
+    | '/login'
+    | '/logout'
+    | '/signup'
+    | '/runs/$slug/recap'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -77,6 +99,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   LogoutRoute: typeof LogoutRoute
   SignupRoute: typeof SignupRoute
+  RunsSlugRecapRoute: typeof RunsSlugRecapRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -116,6 +139,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/runs/$slug/recap': {
+      id: '/runs/$slug/recap'
+      path: '/runs/$slug/recap'
+      fullPath: '/runs/$slug/recap'
+      preLoaderRoute: typeof RunsSlugRecapRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -125,6 +155,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   LogoutRoute: LogoutRoute,
   SignupRoute: SignupRoute,
+  RunsSlugRecapRoute: RunsSlugRecapRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes-lobby/runs.$slug.recap.tsx
+++ b/frontend/src/routes-lobby/runs.$slug.recap.tsx
@@ -2,12 +2,16 @@
  * The v1 baseline recap page — renders a run's published recap (the frozen
  * tombstone minted at `active → freeze`, T5/G1) on the lobby, once it exists.
  *
- * A retrospective, not a scoreboard (ADR-0005 / G3): no winner, no rank. CO2 is
- * laid bare, un-netted (captured is dropped from view for now, see below). Rows
- * carry no position; the per-player table defaults to operating-income order
- * ("most consequential first") but every column is sortable, and the top three
- * in each column get a single, uniform emphasis — deliberately not a 1/2/3
- * podium.
+ * A retrospective, not a full scoreboard (ADR-0005 / G3) — with one scoped
+ * exception (PR #915): operating income, the recap's main metric, gets an
+ * actual 1/2/3 podium — gold/silver/bronze medal plus a matching cell tint for
+ * the top three. XP and CO2 produced get the same three-tone tint for their own
+ * top three (independently ranked, lowest wins for CO2 — the cleanest three,
+ * not the biggest emitters) but no medal, so the colour reads as "notable"
+ * without a second overall ranking. CO2 is laid bare, un-netted (captured is
+ * dropped from view for now, see below). Rows otherwise carry no position; the
+ * per-player table defaults to operating-income order ("most consequential
+ * first") but every column is sortable.
  *
  * Deliberately baseline, not the full spec (see #864). The layout was settled
  * via a `/prototype` UI exploration (three variants — ledger table, faceted
@@ -23,6 +27,7 @@ import {
     ArrowUpDown,
     Factory,
     Scale,
+    Users,
 } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -99,13 +104,15 @@ function RecapPage() {
                         : data.freeze_at
                           ? ` – ${formatTimestamp(data.freeze_at)}`
                           : ""}
-                    {" · "}
-                    {data.player_count} player
-                    {data.player_count === 1 ? "" : "s"}
                 </p>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <StatCard
+                    icon={Users}
+                    label="Players"
+                    value={data.player_count.toLocaleString()}
+                />
                 <StatCard
                     icon={Factory}
                     label="CO₂ produced"
@@ -199,58 +206,71 @@ type MeasureKey = "operating_income" | "produced_co2" | "captured_co2" | "xp";
 type SortKey = MeasureKey | "username_at_freeze" | "network_name";
 type SortDir = "asc" | "desc";
 
+/** 0 = gold, 1 = silver, 2 = bronze. */
+type Tier = 0 | 1 | 2;
+
 type Column = {
     key: SortKey;
     label: string;
-    align: "left" | "right";
-    /** Measure columns are numeric, right-aligned, and get top-3 emphasis. */
-    measure: boolean;
+    /**
+     * Every column is centred; this only switches the cell to tabular/mono
+     * digits.
+     */
+    numeric: boolean;
     render: (row: RecapRow) => React.ReactNode;
+    /**
+     * Podium config for this column, or omitted for columns with no ranking
+     * (Player, Network). `direction` picks which extreme takes gold — "desc"
+     * for income/XP (highest first), "asc" for CO2 (lowest first). `medal`
+     * additionally draws the medal icon — reserved for income, the recap's one
+     * ranked metric; XP and CO2 get the tint only.
+     */
+    podium?: { direction: SortDir; medal?: boolean };
 };
 
 const COLUMNS: Column[] = [
     {
         key: "username_at_freeze",
         label: "Player",
-        align: "left",
-        measure: false,
+        numeric: false,
         render: (row) => row.username_at_freeze,
     },
     {
         key: "network_name",
         label: "Network",
-        align: "left",
-        measure: false,
+        numeric: false,
         render: (row) => row.network_name ?? "—",
     },
     {
         key: "operating_income",
         label: "Income",
-        align: "right",
-        measure: true,
+        numeric: true,
         render: (row) => <Money amount={row.operating_income} />,
+        podium: { direction: "desc", medal: true },
     },
     {
         key: "produced_co2",
         label: "CO₂ produced",
-        align: "right",
-        measure: true,
+        numeric: true,
         render: (row) => formatEmissions(row.produced_co2),
+        // Lower is better: the three cleanest players take gold, not the
+        // three biggest emitters.
+        podium: { direction: "asc" },
     },
     // CO2 captured: dropped for now, may return later.
     // {
     //     key: "captured_co2",
     //     label: "CO₂ captured",
-    //     align: "right",
-    //     measure: true,
+    //     numeric: true,
     //     render: (row) => formatEmissions(row.captured_co2),
+    //     podium: { direction: "desc" },
     // },
     {
         key: "xp",
         label: "XP",
-        align: "right",
-        measure: true,
+        numeric: true,
         render: (row) => Math.round(row.xp).toLocaleString(),
+        podium: { direction: "desc" },
     },
 ];
 
@@ -264,13 +284,6 @@ const DEFAULT_DIR: Record<SortKey, SortDir> = {
     xp: "desc",
 };
 
-const MEASURE_KEYS: MeasureKey[] = [
-    "operating_income",
-    "produced_co2",
-    // "captured_co2", — dropped for now, may return later (see COLUMNS above).
-    "xp",
-];
-
 function compare(a: RecapRow, b: RecapRow, key: SortKey): number {
     const av = a[key];
     const bv = b[key];
@@ -282,17 +295,45 @@ function compare(a: RecapRow, b: RecapRow, key: SortKey): number {
     return av - bv;
 }
 
-/** Account_ids in the top three by each measure — the (uniform) emphasis set. */
-function topThreeByMeasure(rows: RecapRow[]): Record<MeasureKey, Set<number>> {
-    const out = {} as Record<MeasureKey, Set<number>>;
-    for (const key of MEASURE_KEYS) {
-        const ranked = [...rows]
-            .sort((a, b) => b[key] - a[key])
-            .slice(0, 3)
-            .map((row) => row.account_id);
-        out[key] = new Set(ranked);
-    }
-    return out;
+// Faint gold/silver/bronze cell tints, paired with the medal emoji below by
+// index. Kept separate (rather than derived) so the tint always pairs with
+// its metal — tweak one without hunting for the other.
+const TIER_CELL_BG: Record<Tier, string> = {
+    // Gold runs more saturated than silver/bronze: amber sits close in hue to
+    // this page's warm tan surface, so a tint as faint as the other two all
+    // but vanishes on it — bumped until it reads at a glance.
+    0: "bg-amber-500/35 dark:bg-amber-400/20",
+    1: "bg-slate-400/25 dark:bg-slate-300/15",
+    2: "bg-orange-700/20 dark:bg-orange-500/15",
+};
+const TIER_MEDAL_EMOJI: Record<Tier, string> = {
+    0: "\u{1F947}", // 🥇
+    1: "\u{1F948}", // 🥈
+    2: "\u{1F949}", // 🥉
+};
+const TIER_LABEL: Record<Tier, string> = {
+    0: "Gold",
+    1: "Silver",
+    2: "Bronze",
+};
+
+/**
+ * Account_id → tier for one podium column, ranked independently of the other
+ * columns (and of the table's current sort/display order) so a player can
+ * podium in income without podiuming in XP or CO2.
+ */
+function computePodium(
+    rows: RecapRow[],
+    key: MeasureKey,
+    direction: SortDir,
+): Map<number, Tier> {
+    const dirMul = direction === "desc" ? -1 : 1;
+    const podium = new Map<number, Tier>();
+    [...rows]
+        .sort((a, b) => dirMul * (a[key] - b[key]))
+        .slice(0, 3)
+        .forEach((row, i) => podium.set(row.account_id, i as Tier));
+    return podium;
 }
 
 function RecapTable({ rows }: { rows: RecapRow[] }) {
@@ -301,7 +342,23 @@ function RecapTable({ rows }: { rows: RecapRow[] }) {
         dir: "desc",
     });
 
-    const tops = useMemo(() => topThreeByMeasure(rows), [rows]);
+    // One podium per opted-in column (income, CO2 produced, XP).
+    const podiums = useMemo(() => {
+        const out = new Map<SortKey, Map<number, Tier>>();
+        for (const col of COLUMNS) {
+            if (col.podium) {
+                out.set(
+                    col.key,
+                    computePodium(
+                        rows,
+                        col.key as MeasureKey,
+                        col.podium.direction,
+                    ),
+                );
+            }
+        }
+        return out;
+    }, [rows]);
     const sorted = useMemo(() => {
         const withDir = sort.dir === "asc" ? 1 : -1;
         return [...rows].sort((a, b) => withDir * compare(a, b, sort.key));
@@ -328,22 +385,16 @@ function RecapTable({ rows }: { rows: RecapRow[] }) {
     return (
         <table className="w-full text-sm">
             <thead>
-                <tr className="bg-secondary text-left">
+                <tr className="bg-surface-sunken">
                     {COLUMNS.map((col) => (
                         <th
                             key={col.key}
-                            className={cn(
-                                "py-3 px-4 font-semibold whitespace-nowrap",
-                                col.align === "right"
-                                    ? "text-right"
-                                    : "text-left",
-                            )}
+                            className="py-3 px-4 font-semibold whitespace-nowrap text-center"
                         >
                             <button
                                 onClick={() => toggleSort(col.key)}
                                 className={cn(
-                                    "inline-flex items-center gap-1 hover:text-primary transition-colors",
-                                    col.align === "right" && "flex-row-reverse",
+                                    "inline-flex items-center justify-center gap-1 hover:text-primary transition-colors",
                                     sort.key === col.key && "text-primary",
                                 )}
                             >
@@ -364,29 +415,46 @@ function RecapTable({ rows }: { rows: RecapRow[] }) {
                         className="border-b border-gray-200 dark:border-gray-700 transition-colors hover:bg-tan-green/20 dark:hover:bg-muted/30"
                     >
                         {COLUMNS.map((col) => {
-                            const emphasised =
-                                col.measure &&
-                                tops[col.key as MeasureKey].has(row.account_id);
+                            const tier = podiums
+                                .get(col.key)
+                                ?.get(row.account_id);
                             return (
                                 <td
                                     key={col.key}
                                     className={cn(
-                                        "py-3 px-4 whitespace-nowrap",
-                                        col.align === "right"
-                                            ? "text-right font-mono"
-                                            : "text-left",
+                                        "py-3 px-4 whitespace-nowrap text-center",
+                                        col.numeric && "font-mono",
                                         col.key === "username_at_freeze" &&
                                             "font-medium",
                                         col.key === "network_name" &&
                                             "text-muted-foreground",
-                                        // Top-3 emphasis lives on the cell box, not an
+                                        // Podium tint lives on the cell box, not an
                                         // inner span, so it can't nudge the number off
-                                        // the column's right edge.
-                                        emphasised &&
-                                            "bg-primary/10 font-semibold text-foreground",
+                                        // centre.
+                                        tier !== undefined && [
+                                            TIER_CELL_BG[tier],
+                                            "font-semibold text-foreground",
+                                        ],
                                     )}
                                 >
-                                    {col.render(row)}
+                                    {col.podium?.medal && tier !== undefined ? (
+                                        <span className="inline-flex w-full items-center justify-center gap-1.5">
+                                            <span
+                                                className="shrink-0"
+                                                role="img"
+                                                aria-label={`${TIER_LABEL[tier]} medal`}
+                                            >
+                                                {TIER_MEDAL_EMOJI[tier]}
+                                            </span>
+                                            <span
+                                                title={`${TIER_LABEL[tier]} — top 3 by income`}
+                                            >
+                                                {col.render(row)}
+                                            </span>
+                                        </span>
+                                    ) : (
+                                        col.render(row)
+                                    )}
                                 </td>
                             );
                         })}

--- a/frontend/src/routes-lobby/runs.$slug.recap.tsx
+++ b/frontend/src/routes-lobby/runs.$slug.recap.tsx
@@ -3,10 +3,11 @@
  * tombstone minted at `active → freeze`, T5/G1) on the lobby, once it exists.
  *
  * A retrospective, not a scoreboard (ADR-0005 / G3): no winner, no rank. CO2 is
- * laid bare as two un-netted columns — gross produced and captured. Rows carry
- * no position; the per-player table defaults to operating-income order ("most
- * consequential first") but every column is sortable, and the top three in each
- * column get a single, uniform emphasis — deliberately not a 1/2/3 podium.
+ * laid bare, un-netted (captured is dropped from view for now, see below). Rows
+ * carry no position; the per-player table defaults to operating-income order
+ * ("most consequential first") but every column is sortable, and the top three
+ * in each column get a single, uniform emphasis — deliberately not a 1/2/3
+ * podium.
  *
  * Deliberately baseline, not the full spec (see #864). The layout was settled
  * via a `/prototype` UI exploration (three variants — ledger table, faceted
@@ -21,7 +22,6 @@ import {
     ArrowUp,
     ArrowUpDown,
     Factory,
-    Leaf,
     Scale,
 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -105,17 +105,19 @@ function RecapPage() {
                 </p>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <StatCard
                     icon={Factory}
                     label="CO₂ produced"
                     value={formatEmissions(data.total_produced_co2)}
                 />
+                {/* CO2 captured: dropped for now, may return later.
                 <StatCard
                     icon={Leaf}
                     label="CO₂ captured"
                     value={formatEmissions(data.total_captured_co2)}
                 />
+                */}
                 <StatCard
                     icon={Scale}
                     label="Net emissions"
@@ -141,7 +143,7 @@ function RecapPage() {
 
             <section className="flex flex-col gap-3">
                 <h2 className="text-lg font-semibold text-primary font-titles">
-                    The world you played in
+                    The map
                 </h2>
                 <Card>
                     <CardContent>
@@ -235,13 +237,14 @@ const COLUMNS: Column[] = [
         measure: true,
         render: (row) => formatEmissions(row.produced_co2),
     },
-    {
-        key: "captured_co2",
-        label: "CO₂ captured",
-        align: "right",
-        measure: true,
-        render: (row) => formatEmissions(row.captured_co2),
-    },
+    // CO2 captured: dropped for now, may return later.
+    // {
+    //     key: "captured_co2",
+    //     label: "CO₂ captured",
+    //     align: "right",
+    //     measure: true,
+    //     render: (row) => formatEmissions(row.captured_co2),
+    // },
     {
         key: "xp",
         label: "XP",
@@ -264,7 +267,7 @@ const DEFAULT_DIR: Record<SortKey, SortDir> = {
 const MEASURE_KEYS: MeasureKey[] = [
     "operating_income",
     "produced_co2",
-    "captured_co2",
+    // "captured_co2", — dropped for now, may return later (see COLUMNS above).
     "xp",
 ];
 

--- a/frontend/src/routes-lobby/runs.$slug.recap.tsx
+++ b/frontend/src/routes-lobby/runs.$slug.recap.tsx
@@ -1,0 +1,404 @@
+/**
+ * The v1 baseline recap page — renders a run's published recap (the frozen
+ * tombstone minted at `active → freeze`, T5/G1) on the lobby, once it exists.
+ *
+ * A retrospective, not a scoreboard (ADR-0005 / G3): no winner, no rank. CO2 is
+ * laid bare as two un-netted columns — gross produced and captured. Rows carry
+ * no position; the per-player table defaults to operating-income order ("most
+ * consequential first") but every column is sortable, and the top three in each
+ * column get a single, uniform emphasis — deliberately not a 1/2/3 podium.
+ *
+ * Deliberately baseline, not the full spec (see #864). The layout was settled
+ * via a `/prototype` UI exploration (three variants — ledger table, faceted
+ * top-movers, map-hero atlas); the ledger won. The full variant set is on the
+ * `prototype/864-recap-retrospection` branch.
+ */
+
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+    ArrowDown,
+    ArrowLeft,
+    ArrowUp,
+    ArrowUpDown,
+    Factory,
+    Leaf,
+    Scale,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { RecapMap } from "@/components/lobby/recap/recap-map";
+import { Card, CardContent } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { InfoBanner } from "@/components/ui/info-banner";
+import { Money } from "@/components/ui/money";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyH1, TypographyMuted } from "@/components/ui/typography";
+import { useRecap } from "@/hooks/use-lobby";
+import { formatEmissions, formatTimestamp } from "@/lib/format-utils";
+import type { RecapRow } from "@/lib/recap";
+import { cn } from "@/lib/utils";
+
+export const Route = createFileRoute("/runs/$slug/recap")({
+    component: RecapPage,
+    staticData: { title: "Run recap" },
+});
+
+function RecapPage() {
+    const { slug } = Route.useParams();
+    const recap = useRecap(slug);
+
+    if (recap.isPending) {
+        return (
+            <div className="flex justify-center py-24">
+                <Spinner />
+            </div>
+        );
+    }
+
+    if (recap.isError) {
+        return (
+            <div className="py-12 max-w-md mx-auto">
+                <InfoBanner variant="error">
+                    Couldn&apos;t load the recap for this run. Try again in a
+                    moment.
+                </InfoBanner>
+            </div>
+        );
+    }
+
+    if (recap.data === null) {
+        return (
+            <div className="py-12">
+                <BackLink />
+                <EmptyState
+                    icon={Scale}
+                    title="No recap yet"
+                    description="This run hasn't frozen yet — its recap will appear here once play ends."
+                />
+            </div>
+        );
+    }
+
+    const data = recap.data;
+    const ownerNames = Object.fromEntries(
+        data.rows.map((row) => [row.account_id, row.username_at_freeze]),
+    );
+
+    return (
+        <div className="flex flex-col gap-10 py-8">
+            <BackLink />
+
+            <div className="flex flex-col gap-1">
+                <TypographyH1 className="text-primary">
+                    {data.name}
+                </TypographyH1>
+                <p className="text-foreground/80">
+                    {formatTimestamp(data.starts_at)}
+                    {data.ended_at
+                        ? ` – ${formatTimestamp(data.ended_at)}`
+                        : data.freeze_at
+                          ? ` – ${formatTimestamp(data.freeze_at)}`
+                          : ""}
+                    {" · "}
+                    {data.player_count} player
+                    {data.player_count === 1 ? "" : "s"}
+                </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <StatCard
+                    icon={Factory}
+                    label="CO₂ produced"
+                    value={formatEmissions(data.total_produced_co2)}
+                />
+                <StatCard
+                    icon={Leaf}
+                    label="CO₂ captured"
+                    value={formatEmissions(data.total_captured_co2)}
+                />
+                <StatCard
+                    icon={Scale}
+                    label="Net emissions"
+                    value={formatEmissions(data.total_net_emissions)}
+                />
+            </div>
+
+            <section className="flex flex-col gap-3">
+                <div className="flex flex-col gap-0.5">
+                    <h2 className="text-lg font-semibold text-primary font-titles">
+                        Players
+                    </h2>
+                    <p className="text-sm text-foreground/70">
+                        Click a column to sort the table.
+                    </p>
+                </div>
+                <Card>
+                    <CardContent className="overflow-x-auto px-0">
+                        <RecapTable rows={data.rows} />
+                    </CardContent>
+                </Card>
+            </section>
+
+            <section className="flex flex-col gap-3">
+                <h2 className="text-lg font-semibold text-primary font-titles">
+                    The world you played in
+                </h2>
+                <Card>
+                    <CardContent>
+                        <RecapMap tiles={data.tiles} ownerNames={ownerNames} />
+                    </CardContent>
+                </Card>
+            </section>
+        </div>
+    );
+}
+
+function BackLink() {
+    return (
+        <Link
+            to="/"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors w-fit"
+        >
+            <ArrowLeft className="w-4 h-4" />
+            Back to lobby
+        </Link>
+    );
+}
+
+function StatCard({
+    icon: Icon,
+    label,
+    value,
+}: {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    value: string;
+}) {
+    return (
+        <Card className="py-4">
+            <CardContent className="flex flex-row items-center gap-3">
+                <Icon className="w-6 h-6 text-primary shrink-0" />
+                <div className="flex flex-col min-w-0">
+                    <TypographyMuted className="text-xs">
+                        {label}
+                    </TypographyMuted>
+                    <p className="text-xl font-semibold tabular-nums truncate">
+                        {value}
+                    </p>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+// --- retrospective table ------------------------------------------------
+
+type MeasureKey = "operating_income" | "produced_co2" | "captured_co2" | "xp";
+type SortKey = MeasureKey | "username_at_freeze" | "network_name";
+type SortDir = "asc" | "desc";
+
+type Column = {
+    key: SortKey;
+    label: string;
+    align: "left" | "right";
+    /** Measure columns are numeric, right-aligned, and get top-3 emphasis. */
+    measure: boolean;
+    render: (row: RecapRow) => React.ReactNode;
+};
+
+const COLUMNS: Column[] = [
+    {
+        key: "username_at_freeze",
+        label: "Player",
+        align: "left",
+        measure: false,
+        render: (row) => row.username_at_freeze,
+    },
+    {
+        key: "network_name",
+        label: "Network",
+        align: "left",
+        measure: false,
+        render: (row) => row.network_name ?? "—",
+    },
+    {
+        key: "operating_income",
+        label: "Income",
+        align: "right",
+        measure: true,
+        render: (row) => <Money amount={row.operating_income} />,
+    },
+    {
+        key: "produced_co2",
+        label: "CO₂ produced",
+        align: "right",
+        measure: true,
+        render: (row) => formatEmissions(row.produced_co2),
+    },
+    {
+        key: "captured_co2",
+        label: "CO₂ captured",
+        align: "right",
+        measure: true,
+        render: (row) => formatEmissions(row.captured_co2),
+    },
+    {
+        key: "xp",
+        label: "XP",
+        align: "right",
+        measure: true,
+        render: (row) => Math.round(row.xp).toLocaleString(),
+    },
+];
+
+// First-click direction: numbers lead "best/most first" (desc), names A→Z.
+const DEFAULT_DIR: Record<SortKey, SortDir> = {
+    username_at_freeze: "asc",
+    network_name: "asc",
+    operating_income: "desc",
+    produced_co2: "desc",
+    captured_co2: "desc",
+    xp: "desc",
+};
+
+const MEASURE_KEYS: MeasureKey[] = [
+    "operating_income",
+    "produced_co2",
+    "captured_co2",
+    "xp",
+];
+
+function compare(a: RecapRow, b: RecapRow, key: SortKey): number {
+    const av = a[key];
+    const bv = b[key];
+    if (av === null) return bv === null ? 0 : 1;
+    if (bv === null) return -1;
+    if (typeof av === "string" || typeof bv === "string") {
+        return String(av).localeCompare(String(bv));
+    }
+    return av - bv;
+}
+
+/** Account_ids in the top three by each measure — the (uniform) emphasis set. */
+function topThreeByMeasure(rows: RecapRow[]): Record<MeasureKey, Set<number>> {
+    const out = {} as Record<MeasureKey, Set<number>>;
+    for (const key of MEASURE_KEYS) {
+        const ranked = [...rows]
+            .sort((a, b) => b[key] - a[key])
+            .slice(0, 3)
+            .map((row) => row.account_id);
+        out[key] = new Set(ranked);
+    }
+    return out;
+}
+
+function RecapTable({ rows }: { rows: RecapRow[] }) {
+    const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>({
+        key: "operating_income",
+        dir: "desc",
+    });
+
+    const tops = useMemo(() => topThreeByMeasure(rows), [rows]);
+    const sorted = useMemo(() => {
+        const withDir = sort.dir === "asc" ? 1 : -1;
+        return [...rows].sort((a, b) => withDir * compare(a, b, sort.key));
+    }, [rows, sort]);
+
+    const toggleSort = (key: SortKey) => {
+        setSort((prev) =>
+            prev.key === key
+                ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+                : { key, dir: DEFAULT_DIR[key] },
+        );
+    };
+
+    if (rows.length === 0) {
+        return (
+            <EmptyState
+                icon={Factory}
+                title="No players"
+                description="Nobody settled in this run before it froze."
+            />
+        );
+    }
+
+    return (
+        <table className="w-full text-sm">
+            <thead>
+                <tr className="bg-secondary text-left">
+                    {COLUMNS.map((col) => (
+                        <th
+                            key={col.key}
+                            className={cn(
+                                "py-3 px-4 font-semibold whitespace-nowrap",
+                                col.align === "right"
+                                    ? "text-right"
+                                    : "text-left",
+                            )}
+                        >
+                            <button
+                                onClick={() => toggleSort(col.key)}
+                                className={cn(
+                                    "inline-flex items-center gap-1 hover:text-primary transition-colors",
+                                    col.align === "right" && "flex-row-reverse",
+                                    sort.key === col.key && "text-primary",
+                                )}
+                            >
+                                {col.label}
+                                <SortIcon
+                                    active={sort.key === col.key}
+                                    dir={sort.dir}
+                                />
+                            </button>
+                        </th>
+                    ))}
+                </tr>
+            </thead>
+            <tbody>
+                {sorted.map((row) => (
+                    <tr
+                        key={row.account_id}
+                        className="border-b border-gray-200 dark:border-gray-700 transition-colors hover:bg-tan-green/20 dark:hover:bg-muted/30"
+                    >
+                        {COLUMNS.map((col) => {
+                            const emphasised =
+                                col.measure &&
+                                tops[col.key as MeasureKey].has(row.account_id);
+                            return (
+                                <td
+                                    key={col.key}
+                                    className={cn(
+                                        "py-3 px-4 whitespace-nowrap",
+                                        col.align === "right"
+                                            ? "text-right font-mono"
+                                            : "text-left",
+                                        col.key === "username_at_freeze" &&
+                                            "font-medium",
+                                        col.key === "network_name" &&
+                                            "text-muted-foreground",
+                                        // Top-3 emphasis lives on the cell box, not an
+                                        // inner span, so it can't nudge the number off
+                                        // the column's right edge.
+                                        emphasised &&
+                                            "bg-primary/10 font-semibold text-foreground",
+                                    )}
+                                >
+                                    {col.render(row)}
+                                </td>
+                            );
+                        })}
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+    if (!active) return <ArrowUpDown className="w-3.5 h-3.5 opacity-40" />;
+    return dir === "asc" ? (
+        <ArrowUp className="w-3.5 h-3.5" />
+    ) : (
+        <ArrowDown className="w-3.5 h-3.5" />
+    );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -31,6 +31,7 @@
         "src/main-lobby.tsx",
         "src/routes-lobby",
         "src/routeTree.lobby.gen.ts",
+        "src/components/lobby",
         "src/components/wiki/wiki-layout-public.tsx",
         "src/components/wiki/wiki-sidebar-public.tsx",
         "src/components/home-layout.tsx",

--- a/frontend/tsconfig.landing.json
+++ b/frontend/tsconfig.landing.json
@@ -20,6 +20,7 @@
         "src/main.tsx",
         "src/routes",
         "src/routeTree.gen.ts",
-        "src/router.d.ts"
+        "src/router.d.ts",
+        "src/components/lobby"
     ]
 }

--- a/frontend/vite.config.lobby.ts
+++ b/frontend/vite.config.lobby.ts
@@ -2,6 +2,7 @@ import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
+import svgr from "vite-plugin-svgr";
 import path from "path";
 
 import {
@@ -62,6 +63,27 @@ export default defineConfig(({ mode }) => {
                 generatedRouteTree: "./src/routeTree.lobby.gen.ts",
             }),
             tailwindcss(),
+            // components/ui is shared across bundles (Money/CoinIcon use `?react`
+            // SVG imports); landing's config already carries this — the lobby
+            // config didn't, because nothing lobby-side imported such a component
+            // until the recap page (T6, #864) started using `Money`.
+            svgr({
+                svgrOptions: {
+                    ref: true,
+                    svgoConfig: {
+                        plugins: [
+                            {
+                                name: "preset-default",
+                                params: {
+                                    overrides: {
+                                        removeViewBox: false,
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            }),
             react(),
         ],
         resolve: {


### PR DESCRIPTION
Renders a run's published recap on the lobby as a **retrospective, not a scoreboard** (ADR-0005 / G3): no winner, no rank, CO₂ laid bare as two un-netted columns (produced + captured). The render half of the announce→freeze→recap skeleton (T6 on the [server-lifecycle map](https://github.com/felixvonsamson/Energetica/issues/856)).

Stacked on the T9 re-mint (PR #908, merged into `feat/863-recap-map-snapshot`) — the schema this consumes (`produced_co2`, `tiles`, no `rank`) lands there. Base is `feat/863-recap-map-snapshot` (open as #892 into `main`).

## What's here
- **`lib/recap.ts`** — hand-mirrored T9 `Recap`/`RecapRow`/`RecapTile` + `fetchRecap`; `useRecap` swallows the pre-freeze 404 as a "not minted yet" state.
- **The page** (`runs.$slug.recap.tsx`) — identity header, three CO₂ totals, a per-player table (default operating-income order, every column sortable, a single uniform top-3 emphasis per column — not a 1/2/3 podium), and the frozen map snapshot. Reuses the app's leaderboard table language in a beige card for contrast on the green background.
- **`recap-map.tsx`** — self-contained SVG hex map reusing `hex-utils` geometry, `map-resources` colouring, and the in-game `ResourceButton` overlay row. Extraction/depletion deliberately out of scope (needs a newly minted per-tile metric — parked).
- Run cards grow a **"View recap"** row once a run reaches freeze/ended.

## Design provenance
Layout settled via a `/prototype` exploration (three variants — ledger table, faceted top-movers, map-hero atlas); the **ledger won**. Full variant set on the `prototype/864-recap-retrospection` branch. The **facets** idea is parked (which facets to show is its own design decision, and wants more data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the lobby recap experience for frozen and ended runs.
- Adds recap fetching with polling until the immutable snapshot is published.
- Adds a sortable retrospective player table, emissions totals, and frozen map visualization.
- Adds recap links to eligible run cards and updates the lobby build and route configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/lobby/recap/recap-map.tsx | Renders the frozen map through shared map components and now safely returns an explicit state for an empty tile set. |
| frontend/src/hooks/use-lobby.ts | Adds recap querying that polls while publication is pending and permanently caches the immutable snapshot after success. |
| frontend/src/routes-lobby/runs.$slug.recap.tsx | Implements the recap route with lifecycle states, aggregate statistics, a sortable player table, and the map snapshot. |
| frontend/src/components/lobby/run-cards.tsx | Adds same-origin recap navigation to run cards in the freeze and ended phases. |
| frontend/src/lib/recap.ts | Defines the lobby-side recap contract and static snapshot fetch behavior. |
| frontend/vite.config.lobby.ts | Enables SVG component imports required by shared UI used on the recap page. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Lobby as Lobby recap page
    participant Query as useRecap
    participant Static as /recaps/{slug}.json
    User->>Lobby: Open run recap
    Lobby->>Query: Request recap
    Query->>Static: Fetch snapshot
    alt Recap not published
        Static-->>Query: 404
        Query-->>Lobby: null
        Lobby-->>User: No recap yet
        loop Every 5 seconds
            Query->>Static: Retry fetch
        end
    else Recap published
        Static-->>Query: Immutable recap JSON
        Query-->>Lobby: Recap data
        Lobby-->>User: Totals, player table, and map
    end
```

<sub>Reviews (5): Last reviewed commit: ["feat(recap): podium tinting, centered ta..."](https://github.com/felixvonsamson/energetica/commit/3015c762dfa6203d17edf668cbf8a6951f9ad6e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47286016)</sub>

**Context used:**

- Knowledge Base — [Frontend App](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/frontend-app.md)
- Knowledge Base — [Recap: Freeze-Time Snapshot and Publish Flow](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/recap-flow.md)

<!-- /greptile_comment -->