### PR TITLE
feat(config): surface facility lifetime/lag/O&M as a round-unit seam

### DIFF
--- a/energetica/config/assets.py
+++ b/energetica/config/assets.py
@@ -4,10 +4,20 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
-from energetica.enums import Fuel, FunctionalFacilityType, TechnologyType, WorkerType
+from energetica.enums import (
+    ExtractionFacilityType,
+    Fuel,
+    FunctionalFacilityType,
+    PowerFacilityType,
+    StorageFacilityType,
+    TechnologyType,
+    WorkerType,
+    power_facility_types,
+)
 
 if TYPE_CHECKING:
     from energetica.database.player import Player
@@ -899,12 +909,55 @@ def warehouse_capacity_for_level(warehouse_level: int, fuel: Fuel) -> float | No
         )
 
 
+_ROUND_ECONOMICS_FACILITY_TYPES = (*power_facility_types, *StorageFacilityType, *ExtractionFacilityType)
+
+
+@dataclass(frozen=True)
+class FacilityRoundEconomics:
+    """A facility's construction lag, lifetime, and O&M cost, translated into round units.
+
+    ``om_fraction_of_price_per_round`` is a fraction of the facility's price, not an
+    absolute currency amount: a direct unit-translation of ``O&M_factor_per_day``
+    (fraction of ``base_price`` per in-game day), which is the only O&M model
+    ``assets.py`` has today. A caller multiplies it by whatever price it assigns the
+    facility (persistent-world ``base_price``, or a Workshop-specific one) to get the
+    round's O&M cost; nothing here assumes which.
+    """
+
+    construction_lag_rounds: float
+    lifetime_rounds: float
+    om_fraction_of_price_per_round: float
+
+
 class Config(object):
     """Config object that contains the modified data for a specific player considering the technologies he owns."""
 
     def __init__(self) -> None:
         """Constructor of the Config object."""
         self.for_player: dict = {}
+
+    @staticmethod
+    def facility_round_economics(
+        facility_type: PowerFacilityType | StorageFacilityType | ExtractionFacilityType,
+        seconds_per_round: float,
+    ) -> FacilityRoundEconomics:
+        """Translate a facility type's lifetime/construction-lag/O&M into round units.
+
+        Only defined for generation, storage, and extraction facility types -- the
+        subset ``const_config["assets"]`` carries these three fields for (confirmed by
+        the S0 seam audit, issue #872). Functional facilities and technologies have no
+        lifespan/construction-lag/O&M and raise ``ValueError``.
+        """
+        if facility_type not in _ROUND_ECONOMICS_FACILITY_TYPES:
+            raise ValueError(
+                f"{facility_type!r} has no round economics: not a generation, storage, or extraction facility",
+            )
+        data = const_config["assets"][facility_type]
+        return FacilityRoundEconomics(
+            construction_lag_rounds=data["base_construction_time"] / seconds_per_round,
+            lifetime_rounds=data["lifespan"] / seconds_per_round,
+            om_fraction_of_price_per_round=data["O&M_factor_per_day"] * seconds_per_round / 86400,
+        )
 
     def update_config_for_user(self, player: Player) -> None:
         """Update the config values according to the players technology level."""

--- a/tests/unit/test_facility_round_economics.py
+++ b/tests/unit/test_facility_round_economics.py
@@ -1,0 +1,47 @@
+"""Unit tests for the facility round-economics seam (issue #874, S2).
+
+The point of the seam is that ``Config.facility_round_economics`` is a pure
+translation of fields ``energetica/config/assets.py`` already carries
+(``lifespan``, ``base_construction_time``, ``O&M_factor_per_day``) into
+round units given an arbitrary ``seconds_per_round`` -- no new data, no
+Workshop-specific state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from energetica.config.assets import Config, const_config
+from energetica.enums import ControllableFacilityType, FunctionalFacilityType, TechnologyType
+
+ONE_IN_GAME_DAY = 86400
+
+
+def test_translates_seconds_into_rounds_for_a_one_day_round() -> None:
+    """With a round the length of one in-game day, lifetime/lag land in the same
+    units the raw config already documents them in (days), and the O&M fraction
+    passes through unchanged.
+    """
+    economics = Config.facility_round_economics(ControllableFacilityType.STEAM_ENGINE, ONE_IN_GAME_DAY)
+
+    steam_engine = const_config["assets"]["steam_engine"]
+    assert economics.lifetime_rounds == steam_engine["lifespan"] / ONE_IN_GAME_DAY
+    assert economics.construction_lag_rounds == steam_engine["base_construction_time"] / ONE_IN_GAME_DAY
+    assert economics.om_fraction_of_price_per_round == pytest.approx(steam_engine["O&M_factor_per_day"])
+
+
+def test_om_fraction_scales_with_round_length() -> None:
+    """A round twice as long accrues twice the O&M fraction per round."""
+    short_round = Config.facility_round_economics(ControllableFacilityType.STEAM_ENGINE, ONE_IN_GAME_DAY)
+    long_round = Config.facility_round_economics(ControllableFacilityType.STEAM_ENGINE, 2 * ONE_IN_GAME_DAY)
+
+    assert long_round.om_fraction_of_price_per_round == pytest.approx(2 * short_round.om_fraction_of_price_per_round)
+
+
+@pytest.mark.parametrize("facility_type", [FunctionalFacilityType.INDUSTRY, TechnologyType.PHYSICS])
+def test_rejects_facility_types_without_round_economics(facility_type: object) -> None:
+    """Functional facilities and technologies carry no lifespan/O&M in ``assets.py``,
+    so asking for their round economics is a caller bug, not a silent zero.
+    """
+    with pytest.raises(ValueError, match="no round economics"):
+        Config.facility_round_economics(facility_type, ONE_IN_GAME_DAY)


### PR DESCRIPTION
## Summary

- `energetica/config/assets.py` already carries `lifespan`, `base_construction_time`, and `O&M_factor_per_day` per generation/storage/extraction facility (confirmed by the S0 seam audit, #872) — Workshop Mode needs these in round units instead of seconds, without any new persisted data.
- Adds `Config.facility_round_economics(facility_type, seconds_per_round) -> FacilityRoundEconomics`, a pure read-only translation (option A, per S0), covering the `PowerFacilityType | StorageFacilityType | ExtractionFacilityType` subset that actually carries these fields (the same union already used at `production_update.py:843`); other facility types raise `ValueError` instead of returning a silent default.
- Resolves the ticket's flagged open question (proportional vs. absolute O&M): keeps the existing proportional model — `om_fraction_of_price_per_round` is a fraction of price per round, a direct unit-translation of the existing `O&M_factor_per_day` — since Workshop's own facility price catalog isn't decided yet (still open in the wayfinder map's "Not yet specified"). Reasoning captured on the ticket.

Resolves S2 (#874) on the Workshop Mode wayfinder map (#880).

## Test plan

- [x] `tests/unit/test_facility_round_economics.py` — translation into round units, scaling with round length, rejection of ineligible facility types
- [x] `.venv/bin/python -m pytest tests/unit -q` — full unit suite passes (154 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpMPHXMMgXJ8sExjrdSL7b

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a read-only facility economics conversion seam.
- Introduces an immutable `FacilityRoundEconomics` value object.
- Converts construction time, lifespan, and proportional O&M from in-game seconds/days into caller-supplied round units.
- Restricts the API to generation, storage, and extraction facilities and adds focused unit coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failure identified.

The helper consistently translates the existing facility fields, covers the same generation/storage/extraction set used by current economics logic, and rejects unsupported categories explicitly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/config/assets.py | Adds the round-unit economics model and conversion helper; current eligible facility enums all have the required configuration fields. |
| tests/unit/test_facility_round_economics.py | Covers time conversion, O&M scaling, and rejection of unsupported facility categories. |

<sub>Reviews (1): Last reviewed commit: ["feat(config): surface facility lifetime/..."](https://github.com/felixvonsamson/energetica/commit/5bb3206385026d86787e97f3915a62f8d5127b2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48784975)</sub>

**Context used:**

- Knowledge Base — [Game Config and Balance](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/game-config-and-balance.md)

<!-- /greptile_comment -->