### PR TITLE
fix(docs): correct incident-recovery runbook's user, host, and paths

### DIFF
--- a/docs/backend/incident-recovery.md
+++ b/docs/backend/incident-recovery.md
@@ -36,8 +36,11 @@ The `--load_checkpoint` flag handles everything: it preserves the actions log, r
 
 > ⚠️ **Run the replay as `energetica`, not as yourself or `root`.** The systemd unit runs as `User=energetica` (`scripts/infra/energetica.service`). If you run the replay as a different user, every file it writes under `instance/` gets that user's ownership, and the next live tick fails with `PermissionError` — putting you straight into another crash loop. Use `sudo -u energetica`:
 
+> ⚠️ **Carry over the unit's `Environment=` variables.** The unit sets `ENERGETICA_INSTANCE_SLUG`, `ENERGETICA_INSTANCE_CONFIG_DIR`, `ENERGETICA_LANDING_DIR`, and `ENERGETICA_ACCOUNTS_DB_PATH` (`scripts/infra/energetica.service`); a plain SSH shell doesn't have them. Without `ENERGETICA_INSTANCE_SLUG` in particular, the instance starts thinking it's public and skips reading its own `instance.json`. Pull them straight from the unit instead of retyping them:
+
 ```bash
-sudo -u energetica .venv/bin/python main.py --env prod --no-reload --load_checkpoint
+sudo -u energetica env $(systemctl show energetica-{slug} --property=Environment --value) \
+    .venv/bin/python main.py --env prod --no-reload --load_checkpoint
 ```
 
 Pass the same SSL and port flags used by the production service. Watch for rapid tick replays (`t = XXXX`). Once the ticks slow to the normal 30-second cadence, recovery is complete. Stop the process with Ctrl+C.

--- a/docs/backend/incident-recovery.md
+++ b/docs/backend/incident-recovery.md
@@ -19,9 +19,9 @@ This happens when the process is killed mid-save (OOM kill, SIGKILL, power loss)
 ## Recovery procedure
 
 ```bash
-ssh root@energetica-edu
-cd /var/www/energetica
-systemctl stop energetica
+ssh energetica-game
+cd /var/www/energetica-{slug}
+sudo systemctl stop energetica-{slug}
 ```
 
 **Step 1 — back up the current instance folder:**
@@ -34,25 +34,25 @@ cp -r instance/ instance.bak.$(date +%Y%m%d_%H%M%S)/
 
 The `--load_checkpoint` flag handles everything: it preserves the actions log, removes the stale `instance/` folder, extracts `checkpoints/last_checkpoint.tar.gz`, puts the log back, and replays all recorded actions before resuming normal operation.
 
-> ⚠️ **Run the replay as `www-data`, not `root`.** The systemd service runs as `www-data`. If you run the replay as `root`, every file it writes under `instance/` becomes root-owned, and the next live tick fails with `PermissionError` — putting you straight into another crash loop. Use `sudo -u www-data`:
+> ⚠️ **Run the replay as `energetica`, not as yourself or `root`.** The systemd unit runs as `User=energetica` (`scripts/infra/energetica.service`). If you run the replay as a different user, every file it writes under `instance/` gets that user's ownership, and the next live tick fails with `PermissionError` — putting you straight into another crash loop. Use `sudo -u energetica`:
 
 ```bash
-sudo -u www-data python main.py --env prod --no-reload --load_checkpoint
+sudo -u energetica .venv/bin/python main.py --env prod --no-reload --load_checkpoint
 ```
 
 Pass the same SSL and port flags used by the production service. Watch for rapid tick replays (`t = XXXX`). Once the ticks slow to the normal 30-second cadence, recovery is complete. Stop the process with Ctrl+C.
 
-If you did run anything as `root` by mistake, fix ownership before starting the service:
+If you did run anything as the wrong user by mistake, fix ownership before starting the service:
 
 ```bash
-chown -R www-data:www-data instance/ checkpoints/
+sudo chown -R energetica:energetica instance/ checkpoints/
 ```
 
 **Step 3 — start the service:**
 
 ```bash
-systemctl start energetica
-journalctl -u energetica -f
+sudo systemctl start energetica-{slug}
+sudo journalctl -u energetica-{slug} -f
 ```
 
 ## Verifying recovery


### PR DESCRIPTION
## Summary
- The incident-recovery runbook told operators to replay as `www-data`, but both systemd units run as `energetica` (`scripts/infra/energetica.service`, `energetica-lobby.service`). Following the old instructions produces exactly the `PermissionError` crash loop it warns against.
- Also fixed stale infra references from before the multi-instance/slug migration: `ssh root@energetica-edu` → `ssh energetica-game` (matches the `deploy` SSH-user convention), `/var/www/energetica` → `/var/www/energetica-{slug}`, and `systemctl ... energetica` → `energetica-{slug}`, plus adding `sudo` where the non-root deploy user needs it.
- Replay command now invokes `.venv/bin/python` (matching the unit's `ExecStart`) instead of a bare `python`.

Fixes #947

Note: `scripts/DEPLOYMENT.md` is being moved to `docs/backend/deployment.md` by #940 (still open) — this PR doesn't touch that file, no conflict expected either way.

## Test plan
- [x] Diffed against `scripts/infra/energetica.service` / `energetica-lobby.service` and `scripts/DEPLOYMENT.md` to confirm the corrected user, ssh host, path, and service-name conventions match production infra.
- [x] `bun run lint` (docs-only change, no code affected).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The runbook now aligns incident recovery with the multi-instance production deployment.
- Uses the `energetica` service account and virtual-environment Python.
- Targets slug-specific deployment paths and systemd units.
- Carries the unit’s instance environment into checkpoint replay.
- Adds the required privilege escalation for service management and ownership repair.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The revised replay command now supplies the systemd unit environment that the previous thread identified as missing, and no blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/backend/incident-recovery.md | Updates recovery commands to use the production service identity, slug-specific infrastructure, virtual environment, and systemd-provided instance configuration. |

<sub>Reviews (2): Last reviewed commit: ["fix(docs): carry the unit&#39;s Environment=..."](https://github.com/felixvonsamson/energetica/commit/e1539e02e32362fcee4c2291abf2f3435072375c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49854415)</sub>

<!-- /greptile_comment -->