### PR TITLE
refactor: replace hardcoded 72s with engine.days_per_year

### DIFF
--- a/energetica/utils/misc.py
+++ b/energetica/utils/misc.py
@@ -358,7 +358,7 @@ def calculate_solar_irradiance(
 
     # Calculate the real day and time in a year for a given tick
     start_date = datetime(2023, 7, 1)  # 6 months offset because i'm using the southern hemisphere
-    day_of_year = int((total_seconds / 3600 / 24 / 72) % 1 * 365)
+    day_of_year = int((total_seconds / 3600 / 24 / engine.days_per_year) % 1 * 365)
     time_of_day = total_seconds % (3600 * 24)
     weather_datetime = start_date + timedelta(days=day_of_year, seconds=time_of_day)
 
@@ -406,7 +406,7 @@ def calculate_wind_speed(position: tuple[float, float], total_seconds: float, ra
     wind_speed_noise = (1 - (1 - wind_speed_noise) ** 0.1282) ** 0.4673
     return (
         wind_speed_noise
-        * (1 + 0.4 * math.sin(t / 60 / 24 / 72 * math.pi * 2 + 0.5 * math.pi))
+        * (1 + 0.4 * math.sin(t / 60 / 24 / engine.days_per_year * math.pi * 2 + 0.5 * math.pi))
         * (1 + 0.1 * math.sin(t / 60 / 24 * math.pi * 2 + 0.4 * math.pi))
         * 85
     )  # type: ignore
@@ -416,8 +416,10 @@ def calculate_river_speed(total_seconds: float) -> float:
     """Calculate the river flow speed by interpolating the values from the seasonal variation."""
     days_since_start = math.floor(total_seconds / 3600 / 24)
     current_day_fraction = (total_seconds % (3600 * 24)) / (3600 * 24)
-    flow_factor = river_flow_speed_seasonal[days_since_start % 72] + current_day_fraction * (
-        river_flow_speed_seasonal[(days_since_start + 1) % 72] - river_flow_speed_seasonal[days_since_start % 72]
+    days_per_year = engine.days_per_year
+    flow_factor = river_flow_speed_seasonal[days_since_start % days_per_year] + current_day_fraction * (
+        river_flow_speed_seasonal[(days_since_start + 1) % days_per_year]
+        - river_flow_speed_seasonal[days_since_start % days_per_year]
     )
     return flow_factor * 2.5  # in m/s
 
@@ -432,7 +434,7 @@ def package_weather_data(player: Player) -> WeatherOut:
     wind_speed = calculate_wind_speed((x, y), total_seconds, random_seed)
     river_flow_speed = calculate_river_speed(total_seconds)
     return WeatherOut(
-        year_progress=(total_seconds / 3600 / 24 / 72) % 1,
+        year_progress=(total_seconds / 3600 / 24 / engine.days_per_year) % 1,
         month_number=1 + math.floor((total_seconds / 3600 / 24 / 6) % 12),
         solar_irradiance=solar_irradiance,
         clear_sky_value=clear_sky_value,


### PR DESCRIPTION
## Summary

- `utils/misc.py` hardcoded the game's year length (72 days) inline in four places: solar irradiance's day-of-year calc, wind speed's seasonal sine term, river flow's seasonal-array indexing, and the weather payload's `year_progress`.
- Points all four at `engine.days_per_year`, the constant introduced in #937 as the single source of truth for the game's seasonal-cycle length (used there to parameterize `demand_shape_factor` instead of inferring the year length from the seasonal array).
- No behavior change: `days_per_year` is still 72, so this is a pure literal-to-constant substitution.

Stacked on #937 — this branch is based on `feat/875-demand-shape-seam` because it depends on `GameEngine.days_per_year`, which doesn't exist on `main` yet.

## Test plan

- [x] `pytest tests/unit tests/integration` — 231 passed
- [x] `pyright energetica/utils/misc.py` — 0 errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces four explicit 72-day seasonal-cycle literals in weather calculations with `engine.days_per_year`.
- Solar irradiance, wind seasonality, river-flow indexing, and weather year progress now share the engine constant.
- The weather month calculation still implicitly assumes a 72-day year through fixed six-day months.

<h3>Confidence Score: 4/5</h3>

The PR is safe to merge, though the weather month calculation should also derive from the configured year length to complete the refactor.

Current behavior is unchanged because `days_per_year` remains 72, but changing that source of truth later would make `month_number` disagree with the newly parameterized seasonal calculations.

**Files Needing Attention:** energetica/utils/misc.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| energetica/utils/misc.py | Centralizes four seasonal-cycle calculations, but leaves the adjacent month calculation coupled to the old 72-day assumption. |

<sub>Reviews (1): Last reviewed commit: ["refactor: replace hardcoded 72s with eng..."](https://github.com/felixvonsamson/energetica/commit/e8171a8dfcf86edeb5e27fb5feaedf49ddfca254) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50108180)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->