### PR TITLE
T7 · Teardown / reap at ended_at (#865)

### DIFF
--- a/docs/architecture/lobby.md
+++ b/docs/architecture/lobby.md
@@ -117,9 +117,18 @@ lobby.energetica-game.org
 ├── /api/auth/*    → ProxyPass → uvicorn (lobby)
 ├── /api/lobby/*   → ProxyPass → uvicorn (lobby)   (my-runs)
 ├── /logout        → ProxyPass → uvicorn (lobby)
+├── /instances.json → Alias → the shared landing dir  (the picker's manifest)
+├── /recaps/*.json → Alias → the shared landing dir  (published recaps)
 ├── /static/*      → Apache serves the lobby bundle
 └── /*             → FallbackResource → index.html  (SPA: /login, /signup, picker)
 ```
+
+Both aliases point at `/var/www/energetica-landing/`, which the instance backends write into —
+so the lobby always serves the live artifacts with no CORS and no second copy to keep fresh.
+Serving recaps here rather than from the instance's own vhost is what lets a recap outlive its
+run: the instance can be reaped, and torn down entirely, without taking its recap with it.
+`FallbackResource` is disabled under `/recaps/` so a run that has not frozen yet still 404s
+instead of being answered with `index.html` as a 200.
 
 ---
 
@@ -256,8 +265,9 @@ and the lobby shows them **zero runs with no error**, silently breaking the core
 - **`ends_at` + active/ended picker** (#809) — needs run end-of-life mechanics.
 - **Email / password reset** — lobby is the eventual home.
 - **A2 session isolation** (#813) — see Security.
-- **Membership cleanup on run teardown** — stale rows tolerated until `teardown-instance.sh`
-  exists.
+- **Membership cleanup on run teardown** — `teardown-instance.sh` leaves the rows behind. They
+  are inert: `resolve_my_runs` drops any membership whose fragment is gone. Purging them is a
+  chore, not a blocker.
 - **Cross-server identity** — accounts stay per-VPS (RFC).
 - **Per-instance `disable_signups` is obsolete** — its two jobs split into the server-wide
   signup toggle (`server.json`) and the `accounts.db` admin bootstrap. Remove it during

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -351,7 +351,11 @@ Why a periodic sweep rather than a timer armed at each `ended_at`: it keeps the 
 
 **What teardown must not strand.** `recaps/{slug}.json` is never touched — it is the artifact the whole lifecycle exists to produce. The fragment is subtler. It is not only the "run on offer" billboard: it is the *only* pointer by which either lobby surface finds a run at all — `my-runs` joins membership rows against it (`load_fragment`), and the picker reads it through `instances.json`. Deleting the fragment of a run that has a recap would therefore leave that recap on disk, served, and linked from nowhere. So:
 
-> **A recap promotes the fragment from billboard to headstone.** Teardown keeps the fragment whenever a recap exists; only a run that never froze — and so left nothing worth pointing at — loses it.
+> **A recap promotes the fragment from billboard to headstone.** Teardown keeps the fragment whenever a *loadable* recap exists; only a run that never froze — and so left nothing worth pointing at — loses it.
+
+"Loadable", not "present": the guard is `load_recap`, the same validating read the mint-once guard uses. A truncated or schema-invalid artifact is one the lobby cannot render, so holding the fragment open for it would leave the card advertising "View recap" over a file that never loads.
+
+That case gets its own treatment, because teardown is exactly when it stops being fixable. While the instance lives, a broken recap self-heals — the next freeze tick re-mints it — but teardown is about to delete the service, the venv and the pickle that re-mint depends on. So `teardown-instance.sh` **refuses to run** when the recap file is present but does not load, and points at the recovery: delete the file and let the instance re-mint it. There is no `--force`, because the escape hatch is the same `rm` either way — delete the corrupt file and re-run, and the run either keeps a freshly minted recap or retires as one that never froze. Both beat stranding it.
 
 The rule lives in `instance_config.retire_fragment` (tested in `tests/unit/test_instance_config.py`), which teardown calls through the instance's own venv before deleting it; the shell script is a thin wrapper, the same split as `whitelist-instance.sh` over `jq`. Nothing new is needed to make the kept fragment read as finished: `ended_at` has passed, so the phase derives to `ended`, and the lobby card turns from "Join" into "View recap" by itself.
 

--- a/docs/architecture/static-serving-and-deployment.md
+++ b/docs/architecture/static-serving-and-deployment.md
@@ -325,14 +325,37 @@ At the `active → freeze` transition (the sim's own clock passing `freeze_at`),
 - **Same atomic-write mechanism** as the fragment (`_atomic_write_json`: tmp-sibling → `chmod 0o640` → `os.replace`), but a **separate file** — the recap is **not** aggregated into `instances.json` (heavyweight-per-instance, read rarely; folding it in would bloat the manifest the picker downloads on every visit).
 - **Mint-once, re-runnable** — file-existence is the "already minted" flag (`instance_config.recap_exists`), so the repeated freeze-phase ticks and a process restart in freeze don't re-photograph it. **Admin regenerate is the manual delete/regenerate path**: an admin deletes `recaps/{slug}.json` and the next freeze tick re-mints it (scripts suffice for the baseline, as with force-freeze). `energetica.utils.recap.mint_recap` is the underlying unconditional force-overwrite primitive that a future admin control (the deferred admin dashboard, #279) can call directly. Re-minting is reproducible: ties break on the immutable `account_id`, so a regenerate yields the identical ranking.
 - **Visibility is phase-derived, not a flag** — reveal-at-freeze-start == publish-at-mint; the lobby offers "View recap" ⟺ the fragment's `freeze_at` has passed (no new discovery field).
-- **Survives teardown** — the artifact lives on the landing dir, not in the instance process, so it outlives the reap at `ended_at`. `teardown-instance.sh` deletes the *fragment* but **must leave the recap in place**.
+- **Survives teardown** — the artifact lives on the landing dir, not in the instance process, so it outlives the reap at `ended_at`. Both the reap and `teardown-instance.sh` leave the recap alone, and the lobby vhost serves it from the shared landing dir (`Alias /recaps`), so it stays reachable after the instance vhost is gone. Teardown keeps the *fragment* too when a recap exists — see [Reap and teardown](#reap-and-teardown).
 
 ### Operational notes
 
 - The landing's `instances/` subdirectory must be writable by every instance's systemd unit. Cleanest: create a shared group `energetica`, `chmod g+ws /var/www/energetica-landing/instances/`, and run each `energetica-{slug}.service` as a user in that group. Setgid ensures new fragment files inherit group ownership.
 - `/etc/energetica/{slug}/` is admin-owned (root:energetica, mode `0750`) so the instance unit can read but not modify its own policy. Admins edit `instance.json` via `sudo`.
-- A instance going down does not currently remove its fragment. If permanent removal is desired, `teardown-instance.sh` deletes the fragment and re-runs the aggregation. Stale fragments for stopped-but-not-removed instances are tolerated — the landing UI can surface `status` later (deferred per [7a](#deferred--out-of-scope)).
+- An instance going down does not remove its fragment, deliberately — a stopped run still has a phase, and after `ended_at` that phase is what turns its lobby card into "View recap". Permanent removal is `teardown-instance.sh`, which retires the fragment under the rule in [Reap and teardown](#reap-and-teardown).
 - No cross-instance reads. Each instance reads only its own `instance.json` under `/etc/energetica/{own-slug}/`. The aggregation step reads only files inside the landing-owned `instances/` dir.
+
+### Reap and teardown
+
+Two different acts, deliberately kept apart. **Reaping** ends a run; **teardown** removes an instance from the server. A run is normally reaped and then left alone for as long as you like — teardown may never happen at all.
+
+**The reap (`freeze → ended`, automatic).** The other two transitions are self-driven: each instance reads its own clock every tick and starts or freezes itself. A process cannot cleanly stop itself, so this one is driven from outside — `scripts/infra/reap-instances.sh`, run every 5 minutes by `energetica-reaper.timer` (installed server-wide by `setup-base.sh`). The sweep globs `/etc/energetica/*/instance.json`, and for any run whose `ended_at` has passed it does exactly two things:
+
+- `systemctl stop energetica-{slug}` — the run goes dark. Its sim already halted at `freeze_at`, so nothing is lost.
+- `systemctl disable energetica-{slug}` — without this the unit is still `Restart=always` and `WantedBy=multi-user.target`, so the next reboot would resurrect a run the clock has already ended.
+
+Everything else is left standing: the vhost, the certificate, the pickle, `/etc/energetica/{slug}/`, and the fragment and recap on the landing dir. The sweep is idempotent (an already-reaped run is skipped, a half-reaped one is completed) and re-reads every config each tick, so an admin who edits `ended_at` — pulling it in to end a run early, pushing it out to extend one — is obeyed on the next tick with nothing to re-arm. A run with `ended_at: null` is open-ended and is never reaped. A sweep is server-wide, so provisioning a new instance requires no timer of its own.
+
+Why a periodic sweep rather than a timer armed at each `ended_at`: it keeps the same "re-read the config, no restart" contract as the freeze clock and the whitelist, and leaves no per-instance systemd state to leak at teardown. Five minutes is coarse on purpose — `ended_at` is a wind-down boundary, not a starting gun, and the delay costs only a few extra minutes of an already read-only backend.
+
+**Teardown (manual).** `scripts/infra/teardown-instance.sh <slug> --domain <apex>` is the deliberate second act: stop and remove the unit, remove the vhost, archive the pickle (`--archive-to`), delete `/var/www/energetica-{slug}` and `/etc/energetica/{slug}`, retire the fragment, and release the certificate (`--keep-cert` to keep it). It is confirm-gated on typing the slug back, and refuses the reserved `landing`/`lobby` names.
+
+**What teardown must not strand.** `recaps/{slug}.json` is never touched — it is the artifact the whole lifecycle exists to produce. The fragment is subtler. It is not only the "run on offer" billboard: it is the *only* pointer by which either lobby surface finds a run at all — `my-runs` joins membership rows against it (`load_fragment`), and the picker reads it through `instances.json`. Deleting the fragment of a run that has a recap would therefore leave that recap on disk, served, and linked from nowhere. So:
+
+> **A recap promotes the fragment from billboard to headstone.** Teardown keeps the fragment whenever a recap exists; only a run that never froze — and so left nothing worth pointing at — loses it.
+
+The rule lives in `instance_config.retire_fragment` (tested in `tests/unit/test_instance_config.py`), which teardown calls through the instance's own venv before deleting it; the shell script is a thin wrapper, the same split as `whitelist-instance.sh` over `jq`. Nothing new is needed to make the kept fragment read as finished: `ended_at` has passed, so the phase derives to `ended`, and the lobby card turns from "Join" into "View recap" by itself.
+
+Accounts and `instance_membership` rows are server-wide and survive teardown. A membership pointing at a torn-down run with no recap now has no fragment to join against, so `my-runs` filters it out; purging those rows is a separate chore.
 
 ---
 
@@ -501,5 +524,5 @@ Today there is exactly one instance per VPS, so no cross-instance username colli
 - **Instance-picker UI** — landing currently sends the signup CTA to the most recent advertised instance (`instances.json` is sorted by `starts_at` desc; first `advertised: true` entry wins). Lateral navigation between active instances (a picker page or persistent header element — UI form factor TBD) is a frontend workstream that consumes the existing `instances.json` data and may motivate schema additions above.
 - **Password reset via email** — `accounts.email` is in the SQLite schema (nullable, unique) but not yet collected at signup. Adding the signup field and the reset-by-email flow (which requires an SMTP/transactional-mail dependency the project does not yet have) is a follow-up.
 - **Cross-instance session invalidation on password change** — changing the password updates `pwhash` in SQLite but does not invalidate session cookies already issued by other instance subdomains (see [Password change](#flows) flow). Fixing this would require either a `session_version` column on `accounts` (bumped on password change, checked on every request) or a short server-issued session-validity window combined with a periodic re-check against SQLite. Deferred until there is a concrete security-response use case driving the cost.
-- **`teardown-instance.sh`** — removing an instance cleanly (delete vhost, disable service, delete fragment, re-aggregate, optionally archive pickle) is not yet scripted. Stale fragments for stopped instances are tolerated until then.
+- **Purging `instance_membership` rows for a torn-down run** — teardown leaves them; `my-runs` filters out any whose fragment is gone, so they are inert. A cleanup pass is a chore, not a blocker.
 - **Cross-server accounts** — accounts are scoped to a single VPS. The same username on `energetica-game` and `energetica-edu` are unrelated. Unifying identity across servers would require either a remote auth service or replication and is explicitly out of scope.

--- a/energetica/instance_config.py
+++ b/energetica/instance_config.py
@@ -439,3 +439,35 @@ def load_recap(slug: str) -> Recap | None:
     from energetica.schemas.recap import Recap
 
     return _load_json_or_none(recap_path(slug), Recap, what="recap")
+
+
+# --- Teardown (T7) ----------------------------------------------------------------------------
+#
+# Reaping a run at ``ended_at`` only stops its process; the run's *artifacts* on the landing dir
+# outlive it. Tearing the instance down afterwards is a separate, manual act, and the one landing
+# artifact it must reason about is the fragment — see :func:`retire_fragment`.
+
+
+def retire_fragment(slug: str) -> bool:
+    """Delete a torn-down run's fragment and re-aggregate — **unless** it has a published recap.
+
+    Returns whether the fragment was deleted.
+
+    The fragment is not only the "run on offer" billboard: it is the *only* pointer by which
+    either lobby surface finds a run at all. :func:`load_fragment` backs ``my-runs`` (no fragment →
+    the membership reads as stale and is dropped) and :func:`list_advertised_fragments` backs the
+    picker. So deleting the fragment of a run that has a recap would leave the recap on disk and
+    unreachable — the exact opposite of the "survives teardown" guarantee it was minted for.
+
+    Hence the rule: **a recap promotes the fragment from billboard to headstone.** Once the recap
+    exists the fragment is kept forever, and the phase it carries (``ended_at`` passed → ``ended``)
+    is what turns the lobby's card from "Join this run" into "View recap" — no new field, the same
+    phase derivation as everywhere else. Only a run that never minted a recap (torn down before it
+    ever froze) leaves nothing behind worth pointing at, and its fragment goes.
+    """
+    if recap_exists(slug):
+        logger.info("keeping fragment for %s — its published recap needs the pointer", slug)
+        return False
+    (_landing_dir() / "instances" / f"{slug}.json").unlink(missing_ok=True)
+    aggregate_instances()
+    return True

--- a/energetica/instance_config.py
+++ b/energetica/instance_config.py
@@ -464,8 +464,17 @@ def retire_fragment(slug: str) -> bool:
     is what turns the lobby's card from "Join this run" into "View recap" — no new field, the same
     phase derivation as everywhere else. Only a run that never minted a recap (torn down before it
     ever froze) leaves nothing behind worth pointing at, and its fragment goes.
+
+    The guard is :func:`load_recap`, **not** :func:`recap_exists` — the same validating read the
+    mint-once guard uses, and for a related reason. A truncated or malformed artifact is one the
+    lobby cannot render, so keeping its fragment would leave the card advertising "View recap"
+    over a file that never loads. While the instance lives that state is self-healing (the next
+    freeze tick re-mints it), but teardown is exactly when the ability to re-mint is about to be
+    destroyed, so this must ask whether a *usable* recap survived, not whether a file is present.
+    ``teardown-instance.sh`` refuses outright in that case rather than reaching here, since the
+    run is still recoverable at that point; this stays total so any other caller fails safe.
     """
-    if recap_exists(slug):
+    if load_recap(slug) is not None:
         logger.info("keeping fragment for %s — its published recap needs the pointer", slug)
         return False
     (_landing_dir() / "instances" / f"{slug}.json").unlink(missing_ok=True)

--- a/frontend/src/components/lobby/run-cards.tsx
+++ b/frontend/src/components/lobby/run-cards.tsx
@@ -14,6 +14,11 @@
  * It sits alongside, not instead of, the primary action: freeze keeps the live
  * instance up and readable (G2), so "Continue"/"Join" into the live run is
  * still meaningful even after the recap exists.
+ *
+ * At `ended` it replaces that primary action instead of sitting beside it: the
+ * reap has stopped the instance (T7), so the cross-origin link would point at a
+ * subdomain that no longer answers. The recap is what survived, so it becomes
+ * the whole card's destination.
  */
 
 import { Link } from "@tanstack/react-router";
@@ -61,20 +66,38 @@ function RunCardFrame({
     phase: ReturnType<typeof derivePhase>;
     children: React.ReactNode;
 }) {
-    const recapAvailable = phase === "freeze" || phase === "ended";
+    // Once the run is `ended` its process has been reaped (T7) and `{slug}.{apex}` no longer
+    // answers, so "Continue"/"Join" would be a link into nothing. The recap is all that outlived
+    // the reap, so it becomes the card's primary — and only — action. During `freeze` the
+    // instance is still up and readable (G2), which is why the recap is merely an extra row there.
+    const reaped = phase === "ended";
+    const body = (
+        <>
+            {children}
+            <div className="flex flex-row items-center gap-1 text-primary shrink-0">
+                <p className="font-semibold">{reaped ? "View recap" : cta}</p>
+                <ChevronRight />
+            </div>
+        </>
+    );
+    const rowClasses =
+        "p-5 flex flex-row justify-between items-center gap-4 hover:bg-muted transition-all";
     return (
         <div className="bg-card text-foreground border border-border rounded-4xl shadow-md overflow-hidden">
-            <a
-                href={href}
-                className="p-5 flex flex-row justify-between items-center gap-4 hover:bg-muted transition-all"
-            >
-                {children}
-                <div className="flex flex-row items-center gap-1 text-primary shrink-0">
-                    <p className="font-semibold">{cta}</p>
-                    <ChevronRight />
-                </div>
-            </a>
-            {recapAvailable && <ViewRecapRow slug={slug} />}
+            {reaped ? (
+                <Link
+                    to="/runs/$slug/recap"
+                    params={{ slug }}
+                    className={rowClasses}
+                >
+                    {body}
+                </Link>
+            ) : (
+                <a href={href} className={rowClasses}>
+                    {body}
+                </a>
+            )}
+            {phase === "freeze" && <ViewRecapRow slug={slug} />}
         </div>
     );
 }

--- a/scripts/deploy-landing.sh
+++ b/scripts/deploy-landing.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 #        [--user <ssh-user>] [--yes] [--skip-build]
 #
 # Builds the landing bundle locally and rsyncs it to /var/www/energetica-landing/.
-# instances.json and instances/ are owned and written by the instance backends — they are
-# excluded from the sync (and from --delete) so a landing deploy never clobbers them.
+# instances.json, instances/ and recaps/ are owned and written by the instance backends — they
+# are excluded from the sync (and from --delete) so a landing deploy never clobbers them.
 
 REMOTE_HOST="${DEPLOY_HOST:-}"
 REMOTE_USER="${DEPLOY_USER:-deploy}"
@@ -57,17 +57,20 @@ fi
 
 if [ "$AUTO_CONFIRM" = false ]; then
     echo
-    echo "  Landing → $SSH:$LANDING_DIR/  (instances.json + instances/ preserved)"
+    echo "  Landing → $SSH:$LANDING_DIR/  (instances.json + instances/ + recaps/ preserved)"
     read -r -p "Continue? (y/n) " -n 1 -r; echo
     [[ $REPLY =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
 fi
 
 log_step "Syncing landing files..."
 # --delete prunes stale assets, but the excludes are honoured for deletion too, so the
-# instance-owned manifest/fragment dir and the separately-synced static/ tree survive.
+# instance-owned manifest/fragment/recap dirs and the separately-synced static/ tree survive.
+# recaps/ is the load-bearing one: a recap is minted once and is un-recomputable after the run
+# is reaped, so a deploy that pruned it would destroy the artifact for good.
 rsync -az --delete \
     --exclude='instances.json' \
     --exclude='instances/' \
+    --exclude='recaps/' \
     --exclude='static/' \
     ./frontend/dist-landing/ "$SSH:$LANDING_DIR/" >/dev/null
 log_success "Landing bundle deployed"

--- a/scripts/infra/apache-lobby.conf
+++ b/scripts/infra/apache-lobby.conf
@@ -58,6 +58,27 @@
         </Files>
     </Directory>
 
+    # --- Recaps (same-origin, from the shared landing dir) ------------------------
+    # The recap page's read (/runs/{slug}/recap fetches /recaps/{slug}.json). Aliased for the
+    # same reasons as the manifest: written by the instance backends into the landing dir, read
+    # by the lobby SPA, so aliasing the live file avoids CORS and a second copy.
+    #
+    # This is what makes the recap outlive the reap: it is served by the LOBBY vhost off the
+    # shared landing dir, so stopping (or tearing down) energetica-{slug} takes nothing with it.
+    # Serving it from the instance's own vhost would have tied the tombstone to the corpse.
+    #
+    # Scoped to *.json, and Options -Indexes, so the alias exposes recaps and never a directory
+    # listing of which runs exist. The recaps are world-readable by design — the same public
+    # information the manifest already carries — and hold no allowlist (the access block is
+    # stripped upstream, and a recap is a projection, not a config).
+    Alias /recaps /var/www/energetica-landing/recaps
+    <Directory "/var/www/energetica-landing/recaps">
+        Options -Indexes
+        <FilesMatch "\.json$">
+            Require all granted
+        </FilesMatch>
+    </Directory>
+
     # --- Caching ------------------------------------------------------------------
     # Content-hashed bundles (the filename IS a content hash) never change in place, so
     # cache them forever — a content change ships a new filename. "Header set" (not
@@ -80,6 +101,17 @@
     # the picker within a minute without explicit cache-busting.
     <LocationMatch "^/instances\.json$">
         Header set Cache-Control "max-age=60"
+    </LocationMatch>
+    # A recap is minted once and never rewritten, so it could be cached hard — but an admin CAN
+    # regenerate one (delete the file, let the next freeze tick re-mint it), and a year-long cache
+    # would make that invisible. Five minutes keeps the repeat visit cheap while leaving a
+    # regenerate observable. FallbackResource must be off here for the same reason as /assets:
+    # fetchRecap() distinguishes "no recap minted yet" from a real failure by the 404, and the
+    # vhost-wide SPA fallback would answer it with index.html as a 200, which then fails to parse
+    # as JSON — turning "this run hasn't frozen yet" into an unexplained error.
+    <LocationMatch "^/recaps/">
+        Header set Cache-Control "max-age=300"
+        FallbackResource disabled
     </LocationMatch>
 
     # --- Dynamic traffic proxied to the lobby uvicorn ------------------------------

--- a/scripts/infra/energetica-reaper.service
+++ b/scripts/infra/energetica-reaper.service
@@ -20,7 +20,11 @@ After=network.target
 Type=oneshot
 ExecStart=/usr/local/sbin/energetica-reap-instances
 
-# A failed sweep must not disable the timer. One broken instance config or a transient systemd
-# error should cost at most a single sweep — the next tick retries from scratch, and the sweep is
-# idempotent, so there is nothing to reconcile.
-SuccessExitStatus=0
+# The sweep exits non-zero when it could not reap something it should have (a stop/disable that
+# failed, or a config it could not read). That is deliberate and must NOT be masked: nobody watches
+# this run, so a failed activation showing up in `systemctl --failed` is the only way a persistently
+# unreapable instance gets noticed instead of quietly staying live past its end.
+#
+# Failing does not stop the schedule — a failed activation still counts as an activation, so the
+# timer's OnUnitActiveSec fires the next sweep as usual and it retries. The sweep is idempotent, so
+# there is nothing to reconcile between attempts.

--- a/scripts/infra/energetica-reaper.service
+++ b/scripts/infra/energetica-reaper.service
@@ -1,0 +1,26 @@
+# One sweep of the lifecycle reaper: stop + disable every instance whose ended_at has passed.
+#
+# Installed once per VPS by scripts/infra/setup-base.sh into
+# /etc/systemd/system/energetica-reaper.service. Server-wide, not per-instance — it discovers
+# runs by globbing /etc/energetica/*/instance.json, so a newly provisioned instance is swept
+# without touching this unit.
+#
+# Type=oneshot, driven by energetica-reaper.timer. Never enable this unit directly: enable the
+# timer, which is what schedules the sweeps.
+#
+# Runs as root because reaping means `systemctl stop`/`disable` on another unit, and the configs
+# it reads are root:energetica 0750.
+
+[Unit]
+Description=Energetica lifecycle reaper (stop instances past ended_at)
+Documentation=https://github.com/felixvonsamson/Energetica/issues/865
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/energetica-reap-instances
+
+# A failed sweep must not disable the timer. One broken instance config or a transient systemd
+# error should cost at most a single sweep — the next tick retries from scratch, and the sweep is
+# idempotent, so there is nothing to reconcile.
+SuccessExitStatus=0

--- a/scripts/infra/energetica-reaper.timer
+++ b/scripts/infra/energetica-reaper.timer
@@ -1,0 +1,27 @@
+# Schedules the lifecycle reaper sweep (energetica-reaper.service).
+#
+# Installed and enabled once per VPS by scripts/infra/setup-base.sh.
+#
+# Why a periodic sweep rather than a per-instance timer armed at ended_at: the sweep re-reads
+# every instance.json each tick, so an admin who edits ended_at — pulling it in to end a run
+# early, or pushing it out to extend one — is obeyed on the next tick with nothing to re-arm.
+# That is the same contract the rest of the lifecycle already keeps (the freeze clock and the
+# whitelist are both re-read, never cached), and it means there is no per-instance systemd state
+# to leak when a run is torn down.
+#
+# Every 5 minutes is deliberately coarse. `ended_at` is a wind-down boundary, not a starting gun:
+# the run's sim already halted at freeze_at, so the only thing the delay costs is a few minutes of
+# a read-only backend staying up. Persistent=true catches up one missed sweep after a reboot.
+
+[Unit]
+Description=Run the Energetica lifecycle reaper every 5 minutes
+Documentation=https://github.com/felixvonsamson/Energetica/issues/865
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+Unit=energetica-reaper.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/infra/reap-instances.sh
+++ b/scripts/infra/reap-instances.sh
@@ -51,6 +51,7 @@ command -v jq >/dev/null 2>&1 || { log_error "jq is required"; exit 1; }
 
 NOW_EPOCH="$(date -u +%s)"
 REAPED=0
+FAILED=0
 
 for config in "$CONFIG_ROOT"/*/instance.json; do
     # No instance configured yet: the glob stays literal, so there is nothing to sweep.
@@ -63,6 +64,7 @@ for config in "$CONFIG_ROOT"/*/instance.json; do
     # reaches it — but the reserved names would be catastrophic to stop, so refuse explicitly.
     if [ "$slug" = "landing" ] || [ "$slug" = "lobby" ]; then
         log_error "refusing to reap reserved slug '$slug'"
+        FAILED=$((FAILED + 1))
         continue
     fi
 
@@ -70,14 +72,21 @@ for config in "$CONFIG_ROOT"/*/instance.json; do
     # and the fix for a broken file is an admin edit, not a stalled reaper. (Reading a phase we
     # cannot trust also has to fail SAFE — an unparseable ended_at leaves the run up, matching
     # current_phase()'s fail-open-to-active: the clock only ever ends a run on a positive signal.)
+    #
+    # It does count as a failure of the sweep, though. We cannot tell whether this run has ended,
+    # so it may be one that will never be reaped — and the same broken file also defeats the
+    # instance's own current_phase(), which fails open to active, leaving the game running. Exactly
+    # the sort of thing that must not sit in the journal behind a zero exit status.
     ended_at="$(jq -r '.ended_at // empty' "$config" 2>/dev/null)" || {
         log_error "$slug: cannot read $config — skipping"
+        FAILED=$((FAILED + 1))
         continue
     }
     [ -n "$ended_at" ] || continue  # open-ended run, never reaped
 
     ended_epoch="$(date -u -d "$ended_at" +%s 2>/dev/null)" || {
         log_error "$slug: unparseable ended_at ($ended_at) — skipping"
+        FAILED=$((FAILED + 1))
         continue
     }
     [ "$NOW_EPOCH" -ge "$ended_epoch" ] || continue  # not ended yet
@@ -96,14 +105,41 @@ for config in "$CONFIG_ROOT"/*/instance.json; do
     fi
 
     log_step "reaping $slug (ended_at $ended_at has passed)..."
-    systemctl stop "$unit" || log_error "$slug: stop failed"
-    systemctl disable "$unit" >/dev/null 2>&1 || log_error "$slug: disable failed"
-    log_success "$slug reaped — its recap lives on at the lobby"
-    REAPED=$((REAPED + 1))
+    # Attempt both even if the first fails — disabling is independently worth doing, since it at
+    # least stops a reboot from resurrecting the run — but only claim the reap when BOTH succeed.
+    # Nobody watches this sweep run; the journal is the whole signal, so "stop failed" followed by
+    # "reaped" is worse than useless. A partial reap stays on the books as a failure and is picked
+    # up by the next sweep (a still-running or still-enabled unit fails the already-reaped guard).
+    reaped_ok=true
+    if ! systemctl stop "$unit"; then
+        log_error "$slug: stop FAILED — the run is still up past ended_at"
+        reaped_ok=false
+    fi
+    if ! systemctl disable "$unit" >/dev/null 2>&1; then
+        log_error "$slug: disable FAILED — a reboot would bring this ended run back"
+        reaped_ok=false
+    fi
+    if [ "$reaped_ok" = true ]; then
+        log_success "$slug reaped — its recap lives on at the lobby"
+        REAPED=$((REAPED + 1))
+    else
+        log_error "$slug NOT reaped — retrying on the next sweep"
+        FAILED=$((FAILED + 1))
+    fi
 done
 
 # Say nothing on a quiet sweep. This runs every few minutes under systemd, and a "nothing to do"
 # line each time would bury the one journal entry that matters: the run that actually got reaped.
 if [ "$REAPED" -gt 0 ]; then
     log_success "$REAPED instance(s) $([ "$DRY_RUN" = true ] && echo "would be reaped" || echo "reaped")"
+fi
+
+# Exit non-zero when anything was left unreaped, so systemd marks the sweep failed and it shows up
+# in `systemctl --failed` / the timer's status. Without this a persistently failing reap is
+# invisible: the unit keeps exiting 0 and an ended run stays live with nothing to notice it. This
+# does NOT stop the timer — a failed activation still counts as an activation, so the next sweep
+# fires on schedule and retries.
+if [ "$FAILED" -gt 0 ]; then
+    log_error "$FAILED instance(s) need attention — see above"
+    exit 1
 fi

--- a/scripts/infra/reap-instances.sh
+++ b/scripts/infra/reap-instances.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -euo pipefail
+
+# Energetica — reap every instance whose ended_at has passed. Run as root, on a timer.
+#
+#   sudo bash scripts/infra/reap-instances.sh [--dry-run] [--instance <slug>]
+#
+# This is the lifecycle's ONE external transition (T7, #865). announced→active and active→freeze
+# are self-driven: the instance reads its own clock each tick and pauses or freezes itself. But a
+# process cannot cleanly stop itself, so freeze→ended is driven from outside — this sweep, wired
+# to energetica-reaper.timer by setup-base.sh.
+#
+# Reaping is deliberately NARROW: stop the service and disable it, nothing else.
+#
+#   - stop     — the run goes dark. Its sim already halted at freeze_at (T3), so nothing is lost.
+#   - disable  — without this the unit is still Restart=always and WantedBy=multi-user.target, so
+#                the next reboot would resurrect a run the clock has already ended.
+#
+# Everything else is left standing: the vhost, the TLS cert, the pickle, /etc/energetica/{slug}/,
+# and — the point of the whole exercise — the recap and fragment on the landing dir, which is why
+# the recap outlives the process it was minted by. Removing an instance for good is a separate,
+# deliberate, manual act: scripts/infra/teardown-instance.sh.
+#
+# Idempotent and self-healing: an already-stopped run is skipped, and a sweep missed during
+# downtime simply reaps on the next tick. An admin editing ended_at (bringing it forward to force
+# an early reap, or pushing it back) takes effect on the next sweep with no re-arming — the same
+# "re-read the config, no restart" contract as the freeze clock and the whitelist.
+#
+# Requires jq. A run with ended_at: null is open-ended and is never reaped.
+
+CONFIG_ROOT="${ENERGETICA_INSTANCE_CONFIG_DIR:-/etc/energetica}"
+DRY_RUN=false
+ONLY_INSTANCE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true; shift ;;
+        --instance) ONLY_INSTANCE="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; echo "Usage: sudo bash reap-instances.sh [--dry-run] [--instance <slug>]"; exit 1 ;;
+    esac
+done
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+log_step()    { echo -e "${YELLOW}→ $1${NC}"; }
+log_success() { echo -e "${GREEN}✓ $1${NC}"; }
+log_error()   { echo -e "${RED}✗ $1${NC}"; }
+
+[ "$EUID" -eq 0 ] || { log_error "Must run as root (stopping units and reading root-owned configs)"; exit 1; }
+command -v jq >/dev/null 2>&1 || { log_error "jq is required"; exit 1; }
+[ -d "$CONFIG_ROOT" ] || { log_error "No instance config root at $CONFIG_ROOT"; exit 1; }
+
+NOW_EPOCH="$(date -u +%s)"
+REAPED=0
+
+for config in "$CONFIG_ROOT"/*/instance.json; do
+    # No instance configured yet: the glob stays literal, so there is nothing to sweep.
+    [ -e "$config" ] || continue
+
+    slug="$(basename "$(dirname "$config")")"
+    [ -z "$ONLY_INSTANCE" ] || [ "$slug" = "$ONLY_INSTANCE" ] || continue
+
+    # server.json is a sibling FILE under $CONFIG_ROOT, not a slug dir, so the glob never
+    # reaches it — but the reserved names would be catastrophic to stop, so refuse explicitly.
+    if [ "$slug" = "landing" ] || [ "$slug" = "lobby" ]; then
+        log_error "refusing to reap reserved slug '$slug'"
+        continue
+    fi
+
+    # A malformed config must not abort the sweep: the other runs on this box still need reaping,
+    # and the fix for a broken file is an admin edit, not a stalled reaper. (Reading a phase we
+    # cannot trust also has to fail SAFE — an unparseable ended_at leaves the run up, matching
+    # current_phase()'s fail-open-to-active: the clock only ever ends a run on a positive signal.)
+    ended_at="$(jq -r '.ended_at // empty' "$config" 2>/dev/null)" || {
+        log_error "$slug: cannot read $config — skipping"
+        continue
+    }
+    [ -n "$ended_at" ] || continue  # open-ended run, never reaped
+
+    ended_epoch="$(date -u -d "$ended_at" +%s 2>/dev/null)" || {
+        log_error "$slug: unparseable ended_at ($ended_at) — skipping"
+        continue
+    }
+    [ "$NOW_EPOCH" -ge "$ended_epoch" ] || continue  # not ended yet
+
+    unit="energetica-$slug"
+    # Already reaped: inactive AND not enabled. Checking both means a half-reaped run (stopped by
+    # hand but still enabled, so a reboot revives it) is completed rather than skipped.
+    if ! systemctl is-active --quiet "$unit" && ! systemctl is-enabled --quiet "$unit" 2>/dev/null; then
+        continue
+    fi
+
+    if [ "$DRY_RUN" = true ]; then
+        log_step "would reap $slug (ended_at $ended_at has passed)"
+        REAPED=$((REAPED + 1))
+        continue
+    fi
+
+    log_step "reaping $slug (ended_at $ended_at has passed)..."
+    systemctl stop "$unit" || log_error "$slug: stop failed"
+    systemctl disable "$unit" >/dev/null 2>&1 || log_error "$slug: disable failed"
+    log_success "$slug reaped — its recap lives on at the lobby"
+    REAPED=$((REAPED + 1))
+done
+
+# Say nothing on a quiet sweep. This runs every few minutes under systemd, and a "nothing to do"
+# line each time would bury the one journal entry that matters: the run that actually got reaped.
+if [ "$REAPED" -gt 0 ]; then
+    log_success "$REAPED instance(s) $([ "$DRY_RUN" = true ] && echo "would be reaped" || echo "reaped")"
+fi

--- a/scripts/infra/setup-base.sh
+++ b/scripts/infra/setup-base.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 
 DEPLOY_USER="${DEPLOY_USER:-deploy}"
 AUTO_CONFIRM=false
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -168,6 +169,24 @@ systemctl reload apache2
 HOOK
 chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-apache.sh
 log_success "Apache reload-on-renewal hook installed"
+
+# --- Lifecycle reaper (the ended_at sweep, T7) ----------------------------------
+log_section "LIFECYCLE REAPER"
+# announced→active and active→freeze are self-driven from each instance's own clock, but a
+# process cannot cleanly stop itself, so freeze→ended is driven from outside: a 5-minute sweep
+# that stops + disables any instance whose ended_at has passed. Server-wide (it globs
+# /etc/energetica/*/instance.json), so provisioning a new instance needs no timer of its own.
+#
+# The script is COPIED to /usr/local/sbin rather than run from the checkout: this repo is never
+# cloned onto the server (Option A — code arrives by rsync into per-instance dirs), so there is
+# no stable in-repo path a root-run unit could point at.
+install -m 0755 "$SCRIPT_DIR/reap-instances.sh" /usr/local/sbin/energetica-reap-instances
+install -m 0644 "$SCRIPT_DIR/energetica-reaper.service" /etc/systemd/system/energetica-reaper.service
+install -m 0644 "$SCRIPT_DIR/energetica-reaper.timer" /etc/systemd/system/energetica-reaper.timer
+systemctl daemon-reload
+# Enable the TIMER, not the service — the service is the oneshot the timer triggers.
+systemctl enable --now energetica-reaper.timer >/dev/null
+log_success "energetica-reaper.timer enabled (sweeps every 5 min; 'systemctl list-timers energetica-*' to check)"
 
 # --- Firewall -------------------------------------------------------------------
 log_section "FIREWALL"

--- a/scripts/infra/setup-landing.sh
+++ b/scripts/infra/setup-landing.sh
@@ -56,7 +56,13 @@ install -d -o "$DEPLOY_USER" -g energetica -m 2775 "$LANDING_DIR"
 # Fragment dir: every instance backend writes {slug}.json here. Setgid keeps new files
 # group=energetica regardless of which instance's service created them.
 install -d -o "$DEPLOY_USER" -g energetica -m 2775 "$LANDING_DIR/instances"
-log_success "$LANDING_DIR and $LANDING_DIR/instances (2775, setgid energetica)"
+# Recap dir: the instance backend mints {slug}.json here at active→freeze (T5). Created here
+# rather than left to the mint's own mkdir, which would take the service's umask and give the
+# dir no setgid bit — so a recap minted by one instance could end up in a group the lobby's
+# Apache cannot traverse. Same ownership as instances/ for the same reason: many writers, one
+# reader (www-data, via group energetica).
+install -d -o "$DEPLOY_USER" -g energetica -m 2775 "$LANDING_DIR/recaps"
+log_success "$LANDING_DIR and $LANDING_DIR/{instances,recaps} (2775, setgid energetica)"
 
 # --- Temporary HTTP vhost for ACME ---------------------------------------------
 log_section "TLS PROVISIONING"

--- a/scripts/infra/teardown-instance.sh
+++ b/scripts/infra/teardown-instance.sh
@@ -17,6 +17,10 @@ set -euo pipefail
 #   5. retire the landing fragment (see below), re-aggregating instances.json
 #   6. optionally release the TLS certificate
 #
+# Step 1 runs before step 5, not after: /auth/me on a still-running instance republishes the
+# fragment on every authenticated hit, so retiring it before the unit is stopped just loses the
+# race to the next request.
+#
 # What it must NEVER touch is recaps/{instance}.json on the landing dir. That artifact is the
 # whole point of the lifecycle: the run's recap is minted at freeze and published OUTSIDE the
 # instance, so it survives both the reap and this teardown. The instance can vanish entirely and
@@ -214,7 +218,24 @@ if [ -n "$ARCHIVE_TO" ]; then
     fi
 fi
 
-# --- 2. Retire the fragment (before the code it needs may be deleted) -----------
+# --- 2. Service --------------------------------------------------------------------
+# Stopped BEFORE the fragment is retired, deliberately. /auth/me (the entry gate) republishes
+# this instance's fragment on every authenticated hit while the process is alive — so retiring
+# the fragment first only wins the race until the next request. Stopping the unit first cuts
+# the instance off from the world; nothing is left that can resurrect what step 3 is about to
+# take away.
+log_section "SERVICE"
+if [ -f "$UNIT" ]; then
+    systemctl stop "energetica-$INSTANCE" 2>/dev/null || true
+    systemctl disable "energetica-$INSTANCE" >/dev/null 2>&1 || true
+    rm -f "$UNIT"
+    systemctl daemon-reload
+    log_success "energetica-$INSTANCE.service stopped, disabled and removed"
+else
+    log_success "No unit at $UNIT — already removed"
+fi
+
+# --- 3. Retire the fragment (before the code it needs may be deleted) -----------
 # The keep-or-delete rule lives in energetica.instance_config.retire_fragment, which also
 # re-aggregates instances.json. Done before step 5 removes the app dir, since that dir is the
 # preferred CODE_ROOT. A failure here aborts rather than warning: leaving a stale fragment behind
@@ -228,18 +249,6 @@ if ! run_landing_py "print('deleted' if instance_config.retire_fragment('$INSTAN
     exit 1
 fi
 log_success "Fragment retired and instances.json re-aggregated"
-
-# --- 3. Service ------------------------------------------------------------------
-log_section "SERVICE"
-if [ -f "$UNIT" ]; then
-    systemctl stop "energetica-$INSTANCE" 2>/dev/null || true
-    systemctl disable "energetica-$INSTANCE" >/dev/null 2>&1 || true
-    rm -f "$UNIT"
-    systemctl daemon-reload
-    log_success "energetica-$INSTANCE.service stopped, disabled and removed"
-else
-    log_success "No unit at $UNIT — already removed"
-fi
 
 # --- 4. Apache vhost -------------------------------------------------------------
 log_section "VHOST"

--- a/scripts/infra/teardown-instance.sh
+++ b/scripts/infra/teardown-instance.sh
@@ -79,6 +79,69 @@ UNIT="/etc/systemd/system/energetica-$INSTANCE.service"
 PICKLE="$APP_DIR/instance/engine_data.pck"
 RECAP="$LANDING_DIR/recaps/$INSTANCE.json"
 
+# --- Resolve a Python that can import `energetica` -------------------------------
+# Two steps below need it: validating the recap, and retiring the fragment. Both call landing-dir
+# logic (load_recap / retire_fragment) that reads nothing but the landing dir and knows nothing
+# about the game domain, so ANY deployed copy on this box answers identically. Prefer this
+# instance's own venv, then the lobby's, then any sibling instance's.
+#
+# Resolved as a hard precondition rather than checked at each use, because the failure mode of
+# "no interpreter" differs from the failure mode of every other missing path here. A missing unit
+# or vhost means the work is already done; a missing interpreter means we cannot tell whether the
+# recap is readable or retire the fragment correctly — and this script's next act is to delete the
+# state that would let anyone fix it afterwards. Not being able to check must never read as a
+# clean check, so it stops the whole thing.
+CODE_ROOT=""
+for candidate in "$APP_DIR" /var/www/energetica-lobby /var/www/energetica-*; do
+    if [ -x "$candidate/.venv/bin/python" ] && [ -f "$candidate/energetica/instance_config.py" ]; then
+        CODE_ROOT="$candidate"
+        break
+    fi
+done
+if [ -z "$CODE_ROOT" ]; then
+    log_error "Found no deployed Energetica code with a usable venv on this server."
+    log_error "Looked in $APP_DIR, /var/www/energetica-lobby, and every /var/www/energetica-*."
+    log_error "Without one this script cannot verify the recap or retire the landing fragment,"
+    log_error "and it would delete the state needed to repair either. Refusing to continue."
+    echo
+    echo "Deploy any instance or the lobby first, then re-run."
+    exit 1
+fi
+
+# Run a snippet against the landing dir. Dropped to the service user so anything it rewrites
+# (instances.json) keeps the ownership the instance backends expect, rather than becoming
+# root-owned behind their backs.
+#
+# Run from a throwaway cwd, because importing `energetica` constructs the dormant GameEngine,
+# whose __init__ does Path("instance").mkdir() — RELATIVE to the working directory. An admin
+# running this from /root or a home dir would otherwise either litter an empty instance/ there or,
+# where the service user cannot write, fail the import outright and make a permission error look
+# like a corrupt recap. A temp dir the service user owns is writable by definition and takes the
+# stray directory with it.
+run_landing_py() {
+    local workdir rc=0
+    workdir="$(mktemp -d)"
+    # mktemp -d is 0700 root-owned; without this the service user cannot even cd into it.
+    # A failure here returns non-zero rather than tripping set -e, so the caller reports it as
+    # "could not check" instead of the script dying with no explanation.
+    if ! chown energetica "$workdir"; then
+        rm -rf "$workdir"
+        return 1
+    fi
+    (
+        cd "$workdir" || exit 1
+        ENERGETICA_LANDING_DIR="$LANDING_DIR" ENERGETICA_INSTANCE_CONFIG_DIR=/etc/energetica \
+            sudo -u energetica -E "$CODE_ROOT/.venv/bin/python" -c "
+import sys
+sys.path.insert(0, '$CODE_ROOT')
+from energetica import instance_config
+$1
+"
+    ) || rc=$?
+    rm -rf "$workdir"
+    return "$rc"
+}
+
 log_section "TEAR DOWN INSTANCE: $INSTANCE ($FQDN)"
 echo "Will remove:"
 echo "  service   $UNIT"
@@ -100,14 +163,21 @@ echo
 # and re-run — if the instance re-mints first you keep the recap, and if you accept the loss the
 # run simply retires as one that never froze. Both paths are better than a flag that says "yes,
 # strand it", which is not an outcome anyone wants.
-VENV_PYTHON="$APP_DIR/.venv/bin/python"
+#
+# Exit 3 means specifically "read it, it does not parse". Anything else non-zero means the check
+# itself failed — a broken interpreter, an import error, a permissions problem — which is NOT
+# evidence about the recap and must not be reported as such. Both abort, but they abort with the
+# truth, because "could not check" and "checked, it is broken" call for different fixes.
+RECAP_CHECK_RC=0
 if [ -f "$RECAP" ]; then
-    if [ -x "$VENV_PYTHON" ] && ! ENERGETICA_LANDING_DIR="$LANDING_DIR" sudo -u energetica -E "$VENV_PYTHON" -c "
-import sys
-sys.path.insert(0, '$APP_DIR')
-from energetica import instance_config
-sys.exit(0 if instance_config.load_recap('$INSTANCE') is not None else 1)
-"; then
+    run_landing_py "sys.exit(0 if instance_config.load_recap('$INSTANCE') is not None else 3)" || RECAP_CHECK_RC=$?
+    if [ "$RECAP_CHECK_RC" -ne 0 ] && [ "$RECAP_CHECK_RC" -ne 3 ]; then
+        log_error "Could not verify the recap at $RECAP (checker exited $RECAP_CHECK_RC, ran against $CODE_ROOT)."
+        log_error "That is a failure of the check, not a verdict on the recap. Refusing to tear down"
+        log_error "an instance whose recap might still be readable — fix the checker and re-run."
+        exit 1
+    fi
+    if [ "$RECAP_CHECK_RC" -eq 3 ]; then
         log_error "The recap at $RECAP exists but does NOT load — it is corrupt or schema-invalid."
         log_error "Tearing down now would strand it: the lobby would advertise 'View recap' forever"
         log_error "over a file that never renders, with the game state needed to re-mint it deleted."
@@ -144,26 +214,20 @@ if [ -n "$ARCHIVE_TO" ]; then
     fi
 fi
 
-# --- 2. Retire the fragment (before the venv it needs is deleted) ---------------
+# --- 2. Retire the fragment (before the code it needs may be deleted) -----------
 # The keep-or-delete rule lives in energetica.instance_config.retire_fragment, which also
-# re-aggregates instances.json. Run it through THIS instance's venv, which means it has to happen
-# before step 5 removes the app dir. If the venv is already gone (a half-finished earlier
-# teardown), say so loudly rather than silently skipping — a stale fragment left in the manifest
-# points the picker at a subdomain that no longer answers.
+# re-aggregates instances.json. Done before step 5 removes the app dir, since that dir is the
+# preferred CODE_ROOT. A failure here aborts rather than warning: leaving a stale fragment behind
+# while the rest of the teardown proceeds would point the picker at a subdomain that no longer
+# answers, and by then the run is gone — the same "don't destroy what you couldn't check" stance
+# as the recap preflight. set -e would catch this anyway; it is spelled out for the message.
 log_section "LANDING FRAGMENT"
-if [ -x "$VENV_PYTHON" ]; then
-    ENERGETICA_LANDING_DIR="$LANDING_DIR" ENERGETICA_INSTANCE_CONFIG_DIR=/etc/energetica \
-        sudo -u energetica -E "$VENV_PYTHON" -c "
-import sys
-sys.path.insert(0, '$APP_DIR')
-from energetica import instance_config
-deleted = instance_config.retire_fragment('$INSTANCE')
-print('deleted' if deleted else 'kept')
-" && log_success "Fragment retired and instances.json re-aggregated"
-else
-    log_error "No venv at $VENV_PYTHON — could NOT retire the fragment."
-    log_error "Re-aggregate by hand from another instance's venv, or the picker will keep listing $INSTANCE."
+if ! run_landing_py "print('deleted' if instance_config.retire_fragment('$INSTANCE') else 'kept')"; then
+    log_error "Could not retire the fragment (ran against $CODE_ROOT). Stopping before anything is deleted."
+    log_error "The picker would otherwise keep listing $INSTANCE with nothing behind it."
+    exit 1
 fi
+log_success "Fragment retired and instances.json re-aggregated"
 
 # --- 3. Service ------------------------------------------------------------------
 log_section "SERVICE"

--- a/scripts/infra/teardown-instance.sh
+++ b/scripts/infra/teardown-instance.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+set -euo pipefail
+
+# Energetica — remove a game instance from this server for good. Run as root, by hand.
+#
+#   sudo bash scripts/infra/teardown-instance.sh <instance> --domain <apex-domain> \
+#        [--archive-to <dir>] [--keep-cert] [--yes]
+#
+# This is NOT the reap. Reaping (freeze→ended) is automatic, narrow, and reversible: the timer
+# stops + disables the unit and leaves everything else standing (see reap-instances.sh). Teardown
+# is the deliberate second act — it destroys the instance's presence on this box:
+#
+#   1. stop + disable energetica-{instance}, remove the unit
+#   2. disable + remove the Apache vhost
+#   3. archive the engine pickle (--archive-to), then remove /var/www/energetica-{instance}
+#   4. remove /etc/energetica/{instance}/
+#   5. retire the landing fragment (see below), re-aggregating instances.json
+#   6. optionally release the TLS certificate
+#
+# What it must NEVER touch is recaps/{instance}.json on the landing dir. That artifact is the
+# whole point of the lifecycle: the run's recap is minted at freeze and published OUTSIDE the
+# instance, so it survives both the reap and this teardown. The instance can vanish entirely and
+# the lobby still renders its recap.
+#
+# The fragment is subtler, and the rule lives in tested Python (instance_config.retire_fragment):
+# the fragment is the ONLY pointer by which the lobby finds a run — my-runs joins memberships
+# against it, and the picker reads it through instances.json. So deleting the fragment of a run
+# that HAS a recap would strand that recap: on disk, served, and linked from nowhere. A recap
+# therefore promotes the fragment from billboard to headstone and it is kept; only a run that
+# never froze loses its fragment here.
+#
+# Destructive and irreversible. Confirm-gated unless --yes, and it names what it will delete first.
+
+DOMAIN="${ENERGETICA_DOMAIN:-}"
+ARCHIVE_TO=""
+KEEP_CERT=false
+AUTO_CONFIRM=false
+LANDING_DIR=/var/www/energetica-landing
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --domain) DOMAIN="$2"; shift 2 ;;
+        --archive-to) ARCHIVE_TO="$2"; shift 2 ;;
+        --keep-cert) KEEP_CERT=true; shift ;;
+        --yes) AUTO_CONFIRM=true; shift ;;
+        -*) echo "Unknown option: $1"; exit 1 ;;
+        *) POSITIONAL+=("$1"); shift ;;
+    esac
+done
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log_step()    { echo -e "${YELLOW}→ $1${NC}"; }
+log_success() { echo -e "${GREEN}✓ $1${NC}"; }
+log_error()   { echo -e "${RED}✗ $1${NC}"; }
+log_section() { echo; echo -e "${BLUE}━━━ $1 ━━━${NC}"; }
+
+[ "$EUID" -eq 0 ] || { log_error "Must run as root"; exit 1; }
+[ "${#POSITIONAL[@]}" -eq 1 ] || { log_error "Usage: teardown-instance.sh <instance> --domain <apex-domain> [options]"; exit 1; }
+INSTANCE="${POSITIONAL[0]}"
+
+[ -n "$DOMAIN" ] || { log_error "--domain is required"; exit 1; }
+if ! [[ "$INSTANCE" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then
+    log_error "Instance slug must be lowercase kebab-case, max 63 chars (a DNS label): '$INSTANCE'"
+    exit 1
+fi
+# The same reserved names setup-instance.sh refuses to create. Tearing either of these down with
+# this script would delete the apex landing site or the lobby service out from under every run.
+if [ "$INSTANCE" = "landing" ] || [ "$INSTANCE" = "lobby" ]; then
+    log_error "'$INSTANCE' is reserved — this script tears down game instances only"
+    exit 1
+fi
+
+APP_DIR="/var/www/energetica-$INSTANCE"
+CONFIG_DIR="/etc/energetica/$INSTANCE"
+FQDN="$INSTANCE.$DOMAIN"
+VHOST="/etc/apache2/sites-available/energetica-$INSTANCE.conf"
+UNIT="/etc/systemd/system/energetica-$INSTANCE.service"
+PICKLE="$APP_DIR/instance/engine_data.pck"
+RECAP="$LANDING_DIR/recaps/$INSTANCE.json"
+
+log_section "TEAR DOWN INSTANCE: $INSTANCE ($FQDN)"
+echo "Will remove:"
+echo "  service   $UNIT"
+echo "  vhost     $VHOST"
+echo "  app dir   $APP_DIR   (game state, venv, code)"
+echo "  config    $CONFIG_DIR"
+[ "$KEEP_CERT" = true ] && echo "  cert      kept (--keep-cert)" || echo "  cert      /etc/letsencrypt/live/$FQDN (revoked + deleted)"
+[ -n "$ARCHIVE_TO" ] && echo "  pickle    archived to $ARCHIVE_TO before deletion" || echo "  pickle    NOT archived (pass --archive-to <dir> to keep it)"
+echo
+if [ -f "$RECAP" ]; then
+    log_success "recap $RECAP exists — it is KEPT, and so is the fragment that points at it"
+else
+    log_step "no recap at $RECAP — this run never froze, so its fragment will be removed too"
+fi
+
+if [ "$AUTO_CONFIRM" = false ]; then
+    echo
+    read -r -p "This is irreversible. Type the instance slug to confirm: " -r
+    [ "$REPLY" = "$INSTANCE" ] || { echo "Cancelled."; exit 0; }
+fi
+
+# --- 1. Archive the pickle BEFORE anything is deleted ---------------------------
+# Done first, while every path still exists: an archive taken after a partial teardown is worth
+# less than no archive at all, because it looks like a complete one.
+if [ -n "$ARCHIVE_TO" ]; then
+    log_section "ARCHIVE GAME STATE"
+    if [ -f "$PICKLE" ]; then
+        install -d -m 0750 "$ARCHIVE_TO"
+        ARCHIVE_PATH="$ARCHIVE_TO/$INSTANCE-$(date -u +%Y%m%dT%H%M%SZ)-engine_data.pck"
+        cp -p "$PICKLE" "$ARCHIVE_PATH"
+        log_success "Archived $ARCHIVE_PATH"
+    else
+        log_error "No pickle at $PICKLE — nothing to archive (continuing)"
+    fi
+fi
+
+# --- 2. Retire the fragment (before the venv it needs is deleted) ---------------
+# The keep-or-delete rule lives in energetica.instance_config.retire_fragment, which also
+# re-aggregates instances.json. Run it through THIS instance's venv, which means it has to happen
+# before step 5 removes the app dir. If the venv is already gone (a half-finished earlier
+# teardown), say so loudly rather than silently skipping — a stale fragment left in the manifest
+# points the picker at a subdomain that no longer answers.
+log_section "LANDING FRAGMENT"
+VENV_PYTHON="$APP_DIR/.venv/bin/python"
+if [ -x "$VENV_PYTHON" ]; then
+    ENERGETICA_LANDING_DIR="$LANDING_DIR" ENERGETICA_INSTANCE_CONFIG_DIR=/etc/energetica \
+        sudo -u energetica -E "$VENV_PYTHON" -c "
+import sys
+sys.path.insert(0, '$APP_DIR')
+from energetica import instance_config
+deleted = instance_config.retire_fragment('$INSTANCE')
+print('deleted' if deleted else 'kept')
+" && log_success "Fragment retired and instances.json re-aggregated"
+else
+    log_error "No venv at $VENV_PYTHON — could NOT retire the fragment."
+    log_error "Re-aggregate by hand from another instance's venv, or the picker will keep listing $INSTANCE."
+fi
+
+# --- 3. Service ------------------------------------------------------------------
+log_section "SERVICE"
+if [ -f "$UNIT" ]; then
+    systemctl stop "energetica-$INSTANCE" 2>/dev/null || true
+    systemctl disable "energetica-$INSTANCE" >/dev/null 2>&1 || true
+    rm -f "$UNIT"
+    systemctl daemon-reload
+    log_success "energetica-$INSTANCE.service stopped, disabled and removed"
+else
+    log_success "No unit at $UNIT — already removed"
+fi
+
+# --- 4. Apache vhost -------------------------------------------------------------
+log_section "VHOST"
+if [ -f "$VHOST" ]; then
+    a2dissite "energetica-$INSTANCE" >/dev/null 2>&1 || true
+    rm -f "$VHOST"
+    apache2ctl configtest
+    systemctl reload apache2
+    log_success "Vhost disabled and removed; Apache reloaded"
+else
+    log_success "No vhost at $VHOST — already removed"
+fi
+
+# --- 5. Directories ---------------------------------------------------------------
+log_section "DIRECTORIES"
+rm -rf "$APP_DIR"
+log_success "Removed $APP_DIR"
+rm -rf "$CONFIG_DIR"
+log_success "Removed $CONFIG_DIR"
+
+# --- 6. Certificate ----------------------------------------------------------------
+log_section "CERTIFICATE"
+if [ "$KEEP_CERT" = true ]; then
+    log_success "Keeping the certificate for $FQDN (--keep-cert)"
+elif [ -d "/etc/letsencrypt/live/$FQDN" ]; then
+    # Without this the renewal timer keeps trying to renew a cert for a subdomain that no longer
+    # has a vhost, and every renewal fails the http-01 challenge — noisy, and it counts against
+    # the Let's Encrypt failure rate limit for the apex.
+    certbot delete --cert-name "$FQDN" --non-interactive || log_error "certbot delete failed — remove the cert by hand"
+    log_success "Certificate for $FQDN released"
+else
+    log_success "No certificate for $FQDN — nothing to release"
+fi
+
+log_section "INSTANCE TORN DOWN"
+if [ -f "$RECAP" ]; then
+    echo "The run's recap outlived it, as designed:"
+    echo "  $RECAP  → https://lobby.$DOMAIN/runs/$INSTANCE/recap"
+else
+    echo "This run had no recap (it never reached freeze), so nothing of it remains."
+fi
+echo
+echo "Not touched (server-wide, shared by every run):"
+echo "  /var/lib/energetica/accounts.db — accounts and instance_membership rows persist."
+echo "  A membership row for a torn-down run with no recap now has no fragment to join against,"
+echo "  so my-runs filters it out. Harmless; purging those rows is a separate chore."
+echo
+echo "DNS for $FQDN can now be removed."

--- a/scripts/infra/teardown-instance.sh
+++ b/scripts/infra/teardown-instance.sh
@@ -88,8 +88,37 @@ echo "  config    $CONFIG_DIR"
 [ "$KEEP_CERT" = true ] && echo "  cert      kept (--keep-cert)" || echo "  cert      /etc/letsencrypt/live/$FQDN (revoked + deleted)"
 [ -n "$ARCHIVE_TO" ] && echo "  pickle    archived to $ARCHIVE_TO before deletion" || echo "  pickle    NOT archived (pass --archive-to <dir> to keep it)"
 echo
+
+# --- Refuse to destroy a recap that is still recoverable -------------------------
+# A recap FILE is not the same as a recap the lobby can render. If the artifact is truncated or
+# schema-invalid, the run is still salvageable *right now* — the instance and its player state are
+# untouched, and the documented regenerate path (delete the file; the next freeze tick re-mints it)
+# still works. A moment later this script will have deleted the service, the venv and the pickle,
+# and the recap becomes unrecoverable for good. So this is the one preflight that aborts.
+#
+# Note there is no --force: the escape hatch is the same `rm` either way. Delete the corrupt file
+# and re-run — if the instance re-mints first you keep the recap, and if you accept the loss the
+# run simply retires as one that never froze. Both paths are better than a flag that says "yes,
+# strand it", which is not an outcome anyone wants.
+VENV_PYTHON="$APP_DIR/.venv/bin/python"
 if [ -f "$RECAP" ]; then
-    log_success "recap $RECAP exists — it is KEPT, and so is the fragment that points at it"
+    if [ -x "$VENV_PYTHON" ] && ! ENERGETICA_LANDING_DIR="$LANDING_DIR" sudo -u energetica -E "$VENV_PYTHON" -c "
+import sys
+sys.path.insert(0, '$APP_DIR')
+from energetica import instance_config
+sys.exit(0 if instance_config.load_recap('$INSTANCE') is not None else 1)
+"; then
+        log_error "The recap at $RECAP exists but does NOT load — it is corrupt or schema-invalid."
+        log_error "Tearing down now would strand it: the lobby would advertise 'View recap' forever"
+        log_error "over a file that never renders, with the game state needed to re-mint it deleted."
+        echo
+        echo "Recover it while the instance is still here:"
+        echo "  sudo rm $RECAP     # the next freeze tick re-mints it (mint-once guard self-heals)"
+        echo "Then re-run this script. If the run is genuinely unsalvageable, delete the file anyway"
+        echo "and re-run — it will then retire as a run that never froze."
+        exit 1
+    fi
+    log_success "recap $RECAP loads — it is KEPT, and so is the fragment that points at it"
 else
     log_step "no recap at $RECAP — this run never froze, so its fragment will be removed too"
 fi
@@ -122,7 +151,6 @@ fi
 # teardown), say so loudly rather than silently skipping — a stale fragment left in the manifest
 # points the picker at a subdomain that no longer answers.
 log_section "LANDING FRAGMENT"
-VENV_PYTHON="$APP_DIR/.venv/bin/python"
 if [ -x "$VENV_PYTHON" ]; then
     ENERGETICA_LANDING_DIR="$LANDING_DIR" ENERGETICA_INSTANCE_CONFIG_DIR=/etc/energetica \
         sudo -u energetica -E "$VENV_PYTHON" -c "

--- a/tests/unit/test_instance_config.py
+++ b/tests/unit/test_instance_config.py
@@ -475,11 +475,28 @@ def test_current_phase_broken_config_fails_open_to_active(configured: Path) -> N
 # --- retire_fragment (teardown, T7) -----------------------------------------------------------
 
 
-def _touch_recap(landing_dir: Path, slug: str) -> None:
-    """Put *something* at recaps/{slug}.json — retire_fragment only asks whether one exists."""
+def _write_recap(landing_dir: Path, slug: str, payload: dict | str) -> None:
     recap_path = landing_dir / "recaps" / f"{slug}.json"
     recap_path.parent.mkdir(parents=True, exist_ok=True)
-    recap_path.write_text("{}", encoding="utf-8")
+    recap_path.write_text(payload if isinstance(payload, str) else json.dumps(payload), encoding="utf-8")
+
+
+# The smallest payload that actually validates as a Recap — an empty run, minted and readable.
+# It has to be a real one: retire_fragment asks whether a *loadable* recap survived, not whether
+# a file is there, so a stub would be indistinguishable from the corruption case below.
+VALID_RECAP = {
+    "slug": SLUG,
+    "name": "Autumn 2025",
+    "starts_at": "2025-09-15T00:00:00Z",
+    "freeze_at": "2025-12-01T00:00:00Z",
+    "ended_at": None,
+    "player_count": 0,
+    "total_produced_co2": 0.0,
+    "total_captured_co2": 0.0,
+    "total_net_emissions": 0.0,
+    "rows": [],
+    "tiles": [],
+}
 
 
 def test_retire_fragment_deletes_when_no_recap(configured: Path) -> None:
@@ -500,13 +517,31 @@ def test_retire_fragment_keeps_the_fragment_when_a_recap_exists(configured: Path
     """
     instance_config.publish(InstanceConfig.model_validate(PUBLIC_JSON))
     landing_dir = Path(configured).parent / "landing"
-    _touch_recap(landing_dir, SLUG)
+    _write_recap(landing_dir, SLUG, VALID_RECAP)
 
     assert instance_config.retire_fragment(SLUG) is False
 
     assert (landing_dir / "instances" / f"{SLUG}.json").exists()
     assert instance_config.load_fragment(SLUG) is not None
     assert [entry["slug"] for entry in json.loads((landing_dir / "instances.json").read_text())["instances"]] == [SLUG]
+
+
+@pytest.mark.parametrize("payload", ["{ not valid json", '{"slug": "autumn-2025"}'], ids=["truncated", "wrong-schema"])
+def test_retire_fragment_treats_an_unloadable_recap_as_no_recap(configured: Path, payload: str) -> None:
+    """A recap the lobby cannot render must not hold the fragment open.
+
+    The guard is ``load_recap``, not bare file-existence: keeping the fragment for a truncated or
+    schema-invalid artifact would leave the card advertising "View recap" over a file that never
+    loads — and teardown is precisely when the ability to re-mint it is being destroyed, so the
+    question has to be whether a *usable* recap survived. (``teardown-instance.sh`` refuses to run
+    at all in this state, since the run is still recoverable then; this is the fail-safe beneath it.)
+    """
+    instance_config.publish(InstanceConfig.model_validate(PUBLIC_JSON))
+    landing_dir = Path(configured).parent / "landing"
+    _write_recap(landing_dir, SLUG, payload)
+
+    assert instance_config.retire_fragment(SLUG) is True
+    assert not (landing_dir / "instances" / f"{SLUG}.json").exists()
 
 
 def test_retire_fragment_leaves_sibling_runs_listed(configured: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_instance_config.py
+++ b/tests/unit/test_instance_config.py
@@ -470,3 +470,61 @@ def test_current_phase_broken_config_fails_open_to_active(configured: Path) -> N
     """
     _write_instance_json(configured, "{ not valid json")
     assert instance_config.current_phase(datetime(2026, 4, 1, tzinfo=timezone.utc)) == "active"
+
+
+# --- retire_fragment (teardown, T7) -----------------------------------------------------------
+
+
+def _touch_recap(landing_dir: Path, slug: str) -> None:
+    """Put *something* at recaps/{slug}.json — retire_fragment only asks whether one exists."""
+    recap_path = landing_dir / "recaps" / f"{slug}.json"
+    recap_path.parent.mkdir(parents=True, exist_ok=True)
+    recap_path.write_text("{}", encoding="utf-8")
+
+
+def test_retire_fragment_deletes_when_no_recap(configured: Path) -> None:
+    """A run torn down before it ever froze leaves nothing to point at, so its fragment goes."""
+    instance_config.publish(InstanceConfig.model_validate(PUBLIC_JSON))
+    landing_dir = Path(configured).parent / "landing"
+
+    assert instance_config.retire_fragment(SLUG) is True
+
+    assert not (landing_dir / "instances" / f"{SLUG}.json").exists()
+    assert json.loads((landing_dir / "instances.json").read_text())["instances"] == []
+
+
+def test_retire_fragment_keeps_the_fragment_when_a_recap_exists(configured: Path) -> None:
+    """The headstone rule: the fragment is the *only* pointer the lobby finds a recap by, so a run
+    that minted one keeps its fragment through teardown — otherwise the recap survives on disk and
+    nothing links to it, defeating the reason it was minted.
+    """
+    instance_config.publish(InstanceConfig.model_validate(PUBLIC_JSON))
+    landing_dir = Path(configured).parent / "landing"
+    _touch_recap(landing_dir, SLUG)
+
+    assert instance_config.retire_fragment(SLUG) is False
+
+    assert (landing_dir / "instances" / f"{SLUG}.json").exists()
+    assert instance_config.load_fragment(SLUG) is not None
+    assert [entry["slug"] for entry in json.loads((landing_dir / "instances.json").read_text())["instances"]] == [SLUG]
+
+
+def test_retire_fragment_leaves_sibling_runs_listed(configured: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-aggregation after a retire must drop only the retired run from the manifest."""
+    instance_config.publish(InstanceConfig.model_validate(PUBLIC_JSON))
+    monkeypatch.setenv("ENERGETICA_INSTANCE_SLUG", "spring-2026")
+    instance_config.publish(InstanceConfig.model_validate({**PUBLIC_JSON, "name": "Spring 2026"}))
+
+    instance_config.retire_fragment(SLUG)
+
+    landing_dir = Path(configured).parent / "landing"
+    manifest = json.loads((landing_dir / "instances.json").read_text())
+    assert [entry["slug"] for entry in manifest["instances"]] == ["spring-2026"]
+
+
+def test_retire_fragment_is_idempotent(configured: Path) -> None:
+    """Teardown is re-runnable: retiring an already-retired run is a no-op, not an error."""
+    instance_config.publish(InstanceConfig.model_validate(PUBLIC_JSON))
+
+    assert instance_config.retire_fragment(SLUG) is True
+    assert instance_config.retire_fragment(SLUG) is True


### PR DESCRIPTION
Closes the lifecycle skeleton's last transition (T7 of the [server lifecycle map](https://github.com/felixvonsamson/Energetica/issues/856)). `announced→active` and `active→freeze` are self-driven from each instance's own clock, but a process cannot cleanly stop itself, so `freeze→ended` is the one external step.

## Reap and teardown are two different acts

Kept apart on purpose. Reaping *ends a run*; teardown *removes an instance from the server*. A run is normally reaped and then left alone — teardown may never happen at all.

**Reap (automatic)** — `scripts/infra/reap-instances.sh`, run every 5 minutes by `energetica-reaper.timer` (installed server-wide by `setup-base.sh`). For any run whose `ended_at` has passed it does exactly two things:

- `systemctl stop` — the run goes dark. Its sim already halted at `freeze_at`, so nothing is lost.
- `systemctl disable` — without this the unit is still `Restart=always` + `WantedBy=multi-user.target`, so the next reboot would resurrect a run the clock has already ended.

Everything else is left standing. The sweep is idempotent (an already-reaped run is skipped, a half-reaped one is completed) and re-reads every config each tick, so an admin editing `ended_at` — pulling it in to end a run early, pushing it out to extend one — is obeyed on the next sweep with nothing to re-arm. That is the same "re-read the config, no restart" contract as the freeze clock and the whitelist. `ended_at: null` is never reaped.

A periodic sweep rather than a per-instance timer armed at `ended_at`: no per-instance systemd state to leak at teardown, and admin edits need no re-arming. Five minutes is coarse on purpose — `ended_at` is a wind-down boundary, not a starting gun.

**Teardown (manual)** — `scripts/infra/teardown-instance.sh <slug> --domain <apex>`, confirm-gated on typing the slug back. Removes the unit, the vhost, the app and config dirs, releases the cert, archives the pickle (`--archive-to`). Never touches the recap.

## Three fixes needed to make "the recap survives the reap" actually true

The ticket asked to validate this end-to-end. It did not hold:

- **The lobby vhost served no `/recaps` at all.** `frontend/src/lib/recap.ts` fetches `/recaps/{slug}.json` and its comment says "Apache-aliased in prod", but no vhost had the alias — the recap page T6 shipped would have 404'd in production. Now aliased from the shared landing dir, with `FallbackResource disabled` so an unfrozen run still 404s instead of being answered with `index.html` as a 200 (which `fetchRecap` would then fail to parse, turning "this run hasn't frozen yet" into an unexplained error).
- **`deploy-landing.sh` rsyncs with `--delete` and did not exclude `recaps/`.** A landing deploy would have destroyed every recap. A recap is minted once and is un-recomputable after the run is reaped.
- **`setup-landing.sh` never created `recaps/`.** It was left to the mint's own `mkdir`, which takes the service umask and sets no setgid bit — so a recap could land in a group the lobby's Apache cannot traverse. Now created with the same ownership as `instances/`.

Serving recaps from the *lobby* vhost off the shared landing dir is what lets a recap outlive its run. Serving it from the instance's own vhost would have tied the tombstone to the corpse.

## The fragment rule the deferred design got backwards

`docs/architecture/static-serving-and-deployment.md` specified that teardown "deletes the fragment and re-runs the aggregation". Following that would strand the recap.

The fragment is not only the "run on offer" billboard — it is the **only** pointer by which either lobby surface finds a run at all: `my-runs` joins membership rows against it (`load_fragment`), and the picker reads it through `instances.json`. Delete it and the recap sits on disk, served, and linked from nowhere.

> **A recap promotes the fragment from billboard to headstone.** Teardown keeps the fragment whenever a *loadable* recap exists; only a run that never froze — and so left nothing worth pointing at — loses it.

The rule lives in `instance_config.retire_fragment` with unit tests; the shell script is a thin wrapper over it, the same split as `whitelist-instance.sh` over `jq`.

Nothing new was needed to make the kept fragment read as finished: `ended_at` has passed, so the phase derives to `ended` and the lobby card turns itself from "Join" into "View recap" — which it now does as the card's **only** action, since the reap has made the cross-origin link into a dead subdomain.

### "Loadable", not "present" (Greptile P1, 7f5da869)

The first cut guarded on `recap_exists` — bare file existence — while `mint_recap_if_needed` right beside it guards on `load_recap` **specifically** so a malformed artifact self-heals on the next freeze tick. That gap mattered at exactly the wrong moment: a truncated or schema-invalid recap kept its fragment, the lobby went on advertising "View recap" over a file that never renders, and teardown then deleted the service, venv and pickle that re-minting depends on — making it permanent.

`retire_fragment` now asks whether a *usable* recap survived, so a corrupt artifact counts as no recap and the run doesn't linger as a broken card.

Beneath that, `teardown-instance.sh` **refuses to run at all** in this state. It is the last moment the run is recoverable — the instance and its player state are untouched, and the documented regenerate path still works — so the preflight aborts and names the recovery rather than quietly retiring the fragment. There is no `--force`: the escape hatch is the same `rm` either way. Delete the corrupt file and re-run, and the run either keeps a freshly minted recap or retires as one that never froze. Both beat a flag whose meaning is "yes, strand it". `retire_fragment` itself stays total and fails safe, so a caller that skips the preflight still cannot produce the permanent state.

### "Cannot check" must never read as "checked, fine" (Greptile P1, 106e4d92)

The preflight above was written as `[ -x "$VENV_PYTHON" ] && ! validate` — so a missing venv falsified the whole condition, the check was *skipped*, and the script then logged that the recap loads. The one preflight whose job is to prevent permanent stranding could be bypassed by a half-finished earlier teardown.

Now a single `CODE_ROOT` is resolved up front as a hard precondition. Both steps that need Python — validating the recap and retiring the fragment — call landing-dir logic that reads nothing but the landing dir and knows nothing about the game domain, so any deployed copy on the box answers identically: this instance's venv, else the lobby's, else a sibling instance's. If none exists the script refuses to start rather than degrading, because its next act is to delete the state that would let anyone repair the outcome. The fragment step had the same shape and now aborts instead of warning.

Two more faults surfaced while testing that preflight end to end:

- **The exit code conflated "does not parse" with "the check failed."** A broken interpreter or an import error was reported as a corrupt recap — a false verdict pointing at the wrong fix. Parse failure is now exit `3` specifically; anything else aborts as "could not verify", saying explicitly that it is not a verdict on the recap.
- **Importing `energetica` constructs the dormant `GameEngine`, whose `__init__` does `Path("instance").mkdir()` — relative to cwd.** Run from `/root` or a home dir that would either litter an empty `instance/` there or, where the service user cannot write, fail the import and surface as a corrupt recap. The snippet now runs from a throwaway service-user-owned cwd.

### Never report a reap that did not happen (Greptile, fb9f3cc0)

Both previous rounds landed in the teardown script; this one is in the reaper, which neither had touched. It piped `systemctl stop` **and** `disable` failures into a log line and then unconditionally printed "reaped" and incremented the count — so a run that failed to stop was recorded as reaped, and the oneshot still exited 0.

Nobody watches this sweep. The journal is the entire signal, and it was emitting `✗ stop failed` immediately followed by `✓ reaped`, with `systemctl --failed` clean. An ended instance could stay live indefinitely while the system reported success.

Both commands are still attempted — disabling is worth doing even when the stop failed, since it at least stops a reboot resurrecting the run — but the reap is only *claimed* when both succeed. A partial reap is recorded as a failure and picked up by the next sweep, since a still-running or still-enabled unit fails the already-reaped guard.

The same defect sat in the two skip branches: a config that cannot be read, or an unparseable `ended_at`, means a run that may never be reaped at all — and the same broken file defeats the instance's own `current_phase()`, which fails open to active and leaves the game running. Those now count as failures too.

The sweep exits non-zero when anything was left undone, so systemd marks the activation failed and it surfaces in `systemctl --failed`. That does not stop the schedule: a failed activation still counts as an activation, so the timer fires the next sweep as usual and retries. The no-op `SuccessExitStatus=0` is gone from the unit, with a comment on why failing is the point.

## Verification

- `retire_fragment` covered by six unit tests: deletes when no recap, keeps when a loadable recap exists, treats a truncated **and** a schema-invalid recap as no recap (parametrized), leaves sibling runs listed, idempotent. The "keeps" case now writes a genuinely valid `Recap` rather than a `{}` stub — which is precisely what let the weaker `recap_exists` guard pass. Full suite: 239 passed.
- The repo has no shell test harness, so both scripts were exercised against faked trees.
  - **Reaper**, against a fixture config root with stubbed `systemctl`/`date`: a past `ended_at` reaps; a future one and `ended_at: null` do not; a malformed config is skipped without aborting the sweep; `server.json` is not mistaken for a slug; an already-reaped run is silent; a half-reaped run (stopped by hand, still enabled) is completed. Failure reporting: a failing `stop` and a failing `disable` each report **NOT reaped** and exit 1; a clean sweep reaps and exits 0; a sweep with nothing to do stays silent and exits 0; a broken config alone exits 1.
  - **Teardown**, against a faked server tree with stubbed `systemctl`/`apache`/`certbot` and a real interpreter: a corrupt recap aborts; a corrupt recap **with the venv gone** aborts (previously proceeded); a broken interpreter aborts blaming the check, leaving the app dir intact; a valid recap tears down with recap and fragment kept; no recap tears down with the fragment deleted and the manifest re-aggregated to `{"instances": []}`. This also exercised the full teardown path for the first time.
- `bash -n` clean on all new/changed scripts. `bun run typecheck` / `lint` / `format`, `ruff`, `pyright` all clean.

Not verified: `apache2ctl configtest` and `certbot` are unavailable in the dev sandbox, so the vhost change and teardown's cert release are unexercised — same bar as the existing infra scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds automatic lifecycle reaping, manual instance teardown, and durable lobby-hosted recaps.
- Installs a server-wide systemd timer that stops and disables runs after `ended_at`.
- Adds confirm-gated teardown with recap validation, optional state archival, fragment retirement, vhost removal, and certificate cleanup.
- Preserves valid recap headstones and serves them through the lobby after the game instance is gone.
- Protects recap artifacts during landing deployment and creates the shared recap directory with appropriate permissions.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until teardown stops the instance before retiring its fragment, preventing the running process from recreating a stale lobby entry.

Fragment retirement currently precedes service shutdown, while authenticated entry can republish the fragment during that window; because teardown performs no later cleanup, the lobby can continue advertising a fully removed instance.

**Files Needing Attention:** scripts/infra/teardown-instance.sh

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/infra/teardown-instance.sh | Adds comprehensive manual teardown and recovery checks, but fragment retirement can race with publication by the still-running service. |
| scripts/infra/reap-instances.sh | Adds an idempotent ended-at sweep with correct partial-failure accounting and retry behavior. |
| energetica/instance_config.py | Adds recap-aware fragment retirement that retains only fragments backed by a loadable recap. |
| scripts/infra/apache-lobby.conf | Serves recap JSON from shared storage with directory listing disabled and SPA fallback suppressed. |
| frontend/src/components/lobby/run-cards.tsx | Makes the recap the sole action for ended runs whose backend has been reaped. |
| tests/unit/test_instance_config.py | Covers valid, absent, malformed, sibling, and idempotent fragment-retirement behavior. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Instance reaches freeze_at] --> B[Mint recap]
  B --> C[Recap and fragment in shared landing directory]
  C --> D[Reaper observes ended_at]
  D --> E[Stop and disable instance service]
  E --> F{Manual teardown}
  F -->|Valid recap| G[Keep recap and fragment headstone]
  F -->|No recap| H[Retire fragment]
  G --> I[Lobby continues serving recap]
  H --> J[Stop service and remove instance resources]
```

<sub>Reviews (4): Last reviewed commit: ["fix(reaper): never report a reap that di..."](https://github.com/felixvonsamson/energetica/commit/fb9f3cc050004c0a2263cbdab2a33c5a8cc6c0d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50994213)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Recap: Freeze-Time Snapshot and Publish Flow](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/recap-flow.md)
- Knowledge Base — [Game Config and Balance](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/game-config-and-balance.md)
- Knowledge Base — [Frontend App](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/frontend-app.md)
</details>

<!-- /greptile_comment -->