### PR TITLE
test(errors): pin the error envelope contract across both apps

### DIFF
--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -9,15 +9,7 @@ The backend produces three distinct error shapes. The API client in `lib/api-cli
 { "detail": "USERNAME_TAKEN" }
 ```
 
-**Game errors** — business logic failures from the `GameError` exception handler. Always 400.
-```json
-{ "game_exception_type": "NOT_ENOUGH_MONEY", "kwargs": { ... } }
-```
-
-**Validation errors** — Pydantic schema failures. Always 422.
-```json
-{ "detail": [{ "loc": ["body", "username"], "msg": "...", "type": "..." }] }
-```
+**Game errors** and **validation errors** come from two exception handlers that the game app and the lobby app each define separately. `tests/integration/test_error_envelope_contract.py` pins both shapes and asserts the two apps agree; read it for the exact status codes and body keys.
 
 `ApiClientError.getErrorMessage()` extracts the meaningful string from whichever format arrived.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,12 @@ The autouse `_isolated_accounts_db` fixture redirects the server-wide accounts S
 per-test temp file. Without it, any test that calls ``create_app`` (or otherwise touches
 ``energetica.accounts``) would write to the dev default ``instance/accounts.db`` in the repo,
 leaking state across tests and into the developer's working tree.
+
+The autouse `_restore_serve_local` fixture puts ``engine.serve_local`` back after every test. The
+engine is a module-scope singleton, so a test that flips the flag changes it for every test that
+runs after it — and the flag is load-bearing in two places: ``log_action`` turns every non-GET into
+a 503 while it is True, and ``/healthz`` reports ``resimulating``. Tests set it explicitly for what
+they need; this makes that setting local instead of permanent.
 """
 
 from __future__ import annotations
@@ -14,6 +20,15 @@ from pathlib import Path
 import pytest
 
 from energetica.accounts.db import _reset_initialised_paths
+from energetica.globals import engine
+
+
+@pytest.fixture(autouse=True)
+def _restore_serve_local() -> Iterator[None]:
+    """Undo any test's change to the process-wide ``engine.serve_local`` flag."""
+    previous = engine.serve_local
+    yield
+    engine.serve_local = previous
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_error_envelope_contract.py
+++ b/tests/integration/test_error_envelope_contract.py
@@ -1,0 +1,106 @@
+"""Contract test: the game app and the lobby app must serialise errors identically.
+
+Two exception handlers produce every non-``HTTPException`` error the frontend sees — one for
+``GameError`` (400) and one for ``RequestValidationError`` (422) — and each is written out twice,
+in ``energetica/routers/__init__.py`` and in ``lobby/app.py``. The duplication is deliberate: the
+lobby is engine-free and imports nothing from the game's router package (ADR-0002). Nothing else
+asserts the two copies agree, and the generated-types freshness check structurally cannot see
+them, because both envelopes are hand-built ``JSONResponse`` bodies rather than declared response
+models, so neither reaches the OpenAPI schema.
+
+Each app is driven through two probe routes registered here, one per envelope shape. Probes rather
+than real endpoints because the game side raises ``GameError`` only from deep in the engine, behind
+a settled player — the handler, not the route that trips it, is what this test is about.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from energetica import create_app
+from energetica.game_error import GameError, GameExceptionType
+from energetica.globals import engine
+from lobby import create_lobby_app
+
+GAME_ERROR_PATH = "/probe/game-error"
+VALIDATION_PATH = "/probe/validation-error"
+
+
+class _ProbeBody(BaseModel):
+    count: int
+
+
+def _add_probe_routes(app: FastAPI) -> None:
+    """Attach one route per envelope shape: a ``GameError`` raiser and a schema that will not
+    validate.
+    """
+
+    @app.get(GAME_ERROR_PATH)
+    def _raise_game_error() -> None:
+        raise GameError(GameExceptionType.NOT_ENOUGH_MONEY, required=10)
+
+    @app.post(VALIDATION_PATH)
+    def _validate(body: _ProbeBody) -> None:
+        return None
+
+
+def _game_client() -> TestClient:
+    # schema_only builds the routed app without the engine, tick loop or instance directory; the
+    # exception handlers and the log_action middleware are registered before that early return.
+    app = create_app(env="dev", schema_only=True)
+    # serve_local defaults True, which makes log_action reject every non-GET as a 503.
+    engine.serve_local = False
+    _add_probe_routes(app)
+    return TestClient(app)
+
+
+def _lobby_client() -> TestClient:
+    app = create_lobby_app()
+    _add_probe_routes(app)
+    return TestClient(app)
+
+
+CLIENT_FACTORIES: dict[str, Callable[[], TestClient]] = {"game": _game_client, "lobby": _lobby_client}
+both_apps = pytest.mark.parametrize("make_client", CLIENT_FACTORIES.values(), ids=CLIENT_FACTORIES.keys())
+
+
+@both_apps
+def test_game_error_envelope(make_client: Callable[[], TestClient]) -> None:
+    """A ``GameError`` is always a 400 carrying the code and its kwargs, and nothing else."""
+    response = make_client().get(GAME_ERROR_PATH)
+
+    assert response.status_code == 400
+    assert response.json() == {"game_exception_type": GameExceptionType.NOT_ENOUGH_MONEY, "kwargs": {"required": 10}}
+
+
+@both_apps
+def test_validation_error_envelope(make_client: Callable[[], TestClient]) -> None:
+    """A schema failure is always a 422 carrying pydantic's own error list plus the ``meta`` tag
+    that tells the frontend which envelope it is holding.
+    """
+    response = make_client().post(VALIDATION_PATH, json={"count": "not-a-number"})
+
+    assert response.status_code == 422
+    body = response.json()
+    assert set(body) == {"detail", "meta"}
+    assert body["meta"] == {"error_type": "request_validation_error"}
+    assert [error["loc"] for error in body["detail"]] == [["body", "count"]]
+
+
+@pytest.mark.parametrize("path, method, payload", [(GAME_ERROR_PATH, "GET", None), (VALIDATION_PATH, "POST", {})])
+def test_both_apps_serialise_the_same_error_identically(path: str, method: str, payload: dict | None) -> None:
+    """The contract itself: byte-for-byte the same status and body from both apps.
+
+    The shape assertions above would still pass if both copies of a handler drifted together; this
+    one fails the moment only one of them is edited.
+    """
+    responses = [factory().request(method, path, json=payload) for factory in CLIENT_FACTORIES.values()]
+    game, lobby = responses
+
+    assert game.status_code == lobby.status_code
+    assert game.json() == lobby.json()

--- a/tests/integration/test_error_envelope_contract.py
+++ b/tests/integration/test_error_envelope_contract.py
@@ -53,7 +53,8 @@ def _game_client() -> TestClient:
     # schema_only builds the routed app without the engine, tick loop or instance directory; the
     # exception handlers and the log_action middleware are registered before that early return.
     app = create_app(env="dev", schema_only=True)
-    # serve_local defaults True, which makes log_action reject every non-GET as a 503.
+    # serve_local defaults True, which makes log_action reject every non-GET as a 503. The autouse
+    # conftest fixture puts it back after the test.
     engine.serve_local = False
     _add_probe_routes(app)
     return TestClient(app)

--- a/tests/integration/test_push_notifications.py
+++ b/tests/integration/test_push_notifications.py
@@ -16,6 +16,7 @@ from energetica.database import player as player_module
 from energetica.database.map.hex_tile import HexTile
 from energetica.database.player import Player
 from energetica.database.user import User
+from energetica.globals import engine
 from energetica.schemas.browser_notifications import Subscription, SubscriptionKeys
 from energetica.schemas.notifications import ChatMessagePayload
 from energetica.utils.auth import generate_password_hash
@@ -24,6 +25,9 @@ from energetica.utils.map_helpers import confirm_location
 
 def _make_player() -> Player:
     create_app(rm_instance=True, skip_adding_handlers=True, env="dev")
+    # push_only() skips delivery entirely while serve_local is True (#701), so these tests would
+    # assert nothing. They used to pass only on an earlier test file leaving the flag False.
+    engine.serve_local = False
     user = User(username="username", pwhash=generate_password_hash("password"), role="player", account_id=1)
     return confirm_location(user, HexTile.getitem(1))
 


### PR DESCRIPTION
Closes #972. Part of #901.

## What

One integration test file, `tests/integration/test_error_envelope_contract.py`, covering the two error envelopes the frontend decodes: `GameError` → 400 `{game_exception_type, kwargs}` and `RequestValidationError` → 422 `{detail, meta.error_type}`.

Both handlers are written out twice — `energetica/routers/__init__.py:69` and `lobby/app.py:31` — because the lobby is engine-free and imports nothing from the game's router package (ADR-0002). Nothing asserted the two copies agree. `api-types-freshness` structurally cannot: both envelopes are hand-built `JSONResponse` bodies rather than declared response models, so neither reaches the OpenAPI schema the generated types come from.

## How

Each app gets two probe routes registered by the test, one per envelope shape. Probes rather than real endpoints because the game side raises `GameError` only from deep in the engine, behind a settled player — the handler, not the route that trips it, is what is under test. The game app is built with `create_app(schema_only=True)`, which registers the handlers and the `log_action` middleware without the engine or the tick loop.

Six cases: each shape against each app, plus a direct "both apps return the same status and body" assertion. That last one is the contract; the shape assertions alone would still pass if both copies drifted together.

Verified to have teeth — flipping the lobby's 400 to a 409 and its `meta.error_type` string fails four of the six.

`pytest` already runs unconditionally in CI, so this needs no workflow change and does not wait on #953.

## Docs

`docs/architecture/error-handling.md` claimed the 422 body was Pydantic's error list alone, omitting the `meta` key the frontend reads. Per #904, the two now-checked shapes point at the test instead of restating it. The rest of that file, which #941 disposed for deletion, is left to #946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds integration coverage that pins the game and lobby applications to identical `GameError` and validation-error envelopes, and updates related documentation and test isolation.
- Adds probe-route contract tests for both FastAPI applications.
- Restores the process-wide `engine.serve_local` flag after every test.
- Makes push-notification tests explicitly enable delivery rather than relying on test order.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/conftest.py | Adds an autouse fixture that safely restores the shared `engine.serve_local` value after each test. |
| tests/integration/test_error_envelope_contract.py | Adds cross-application tests for the status codes and response bodies of game and request-validation errors. |
| tests/integration/test_push_notifications.py | Explicitly disables local-serving mode so push-delivery tests no longer depend on earlier tests mutating shared state. |
| docs/architecture/error-handling.md | Directs readers to the executable integration contract for the duplicated error-envelope formats. |

<sub>Reviews (2): Last reviewed commit: ["test(engine): restore engine.serve\_local..."](https://github.com/felixvonsamson/energetica/commit/45f6c5efd85c42555a244e4544c4b6194e7dbaea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51654175)</sub>

<!-- /greptile_comment -->