### PR TITLE
feat(join): public join flow — link, confirm, enter (#1021)

### DIFF
--- a/energetica/game_error.py
+++ b/energetica/game_error.py
@@ -40,6 +40,8 @@ class GameExceptionType(StrEnum):
     OLD_PASSWORD_INCORRECT = "OLD_PASSWORD_INCORRECT"
     INSTANCE_ACCESS_DENIED = "INSTANCE_ACCESS_DENIED"
     INSTANCE_NOT_PRIVATE = "INSTANCE_NOT_PRIVATE"
+    JOIN_LINK_INVALID = "JOIN_LINK_INVALID"
+    JOIN_LINK_CLOSED = "JOIN_LINK_CLOSED"
     # Lifecycle
     INSTANCE_FROZEN = "Instance is frozen; the game is read-only."
     # Technology effects

--- a/energetica/routers/__init__.py
+++ b/energetica/routers/__init__.py
@@ -25,6 +25,7 @@ from .electricity_markets import router as electricity_markets_router
 from .facilitator import router as facilitator_router
 from .facilities import router as facilities_router
 from .game import router as game_router
+from .join import router as join_router
 from .map import router as map_router
 from .notifications import router as notifications_router
 from .players import router as player_router
@@ -48,6 +49,7 @@ api_routers = [
     facilitator_router,
     facilities_router,
     game_router,
+    join_router,
     lobby_router,
     map_router,
     notifications_router,

--- a/energetica/routers/join.py
+++ b/energetica/routers/join.py
@@ -11,10 +11,12 @@ gate reads.
 """
 
 import secrets
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from energetica import instance_config
+from energetica.accounts import Account
 from energetica.game_error import GameError, GameExceptionType
 from energetica.schemas.join import JoinLinkOut
 from energetica.utils.auth import get_current_account
@@ -43,10 +45,9 @@ def _resolve(token: str) -> tuple[str, instance_config.PrivateAccess]:
 
 
 @router.get("/{token}")
-def get_join_link(token: str, request: Request) -> JoinLinkOut:
+def get_join_link(token: str, account: Annotated[Account | None, Depends(get_current_account)]) -> JoinLinkOut:
     """What this join link offers, and whether the visitor already has a session to join with."""
     instance_name, access = _resolve(token)
-    account = get_current_account(request)
     return JoinLinkOut(
         instance_name=instance_name,
         join_open=access.join_open,
@@ -55,22 +56,23 @@ def get_join_link(token: str, request: Request) -> JoinLinkOut:
 
 
 @router.post("/{token}", status_code=204)
-def confirm_join(token: str, request: Request) -> None:
+def confirm_join(token: str, account: Annotated[Account | None, Depends(get_current_account)]) -> None:
     """Confirm joining: append the signed-in visitor's username to the allowlist.
 
     Requires an SSO session (``get_current_account``, not ``get_settled_player`` — the whole point
     is this runs *before* the visitor is access-allowed, so no local ``User`` need exist yet) but
     deliberately does not go through ``_enforce_instance_access``: granting access is this
-    endpoint's job, not a precondition for reaching it. Re-checks ``join_open`` server-side (not
-    just trusted from the page's last ``GET``) so a facilitator flipping the toggle mid-visit is
-    the outcome that wins, not a stale client.
+    endpoint's job, not a precondition for reaching it. Checks identity before instance state
+    (mirrors ``get_admin_user``/``get_settled_player``'s "who, then what" order elsewhere in this
+    codebase) and re-checks ``join_open`` server-side rather than trusting the page's last
+    ``GET``, so a facilitator flipping the toggle mid-visit is the outcome that wins, not a stale
+    client.
     """
-    _, access = _resolve(token)
-    if not access.join_open:
-        raise GameError(GameExceptionType.JOIN_LINK_CLOSED)
-    account = get_current_account(request)
     if account is None:
         # Matches resolve_entry_user's convention: no/invalid session is a 401, not a 400
         # GameError — this is a plain auth failure, not a game-domain rejection.
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, GameExceptionType.NOT_AUTHENTICATED)
+    _, access = _resolve(token)
+    if not access.join_open:
+        raise GameError(GameExceptionType.JOIN_LINK_CLOSED)
     instance_config.add_allowed_username(account.username)

--- a/energetica/routers/join.py
+++ b/energetica/routers/join.py
@@ -1,0 +1,76 @@
+"""Public join-link surface (#1021): the visitor-facing counterpart to #1020's facilitator page.
+
+Reachable by anyone holding a valid token — no ``get_admin_user``/``get_settled_player`` gate here,
+the unguessable token in the URL *is* the authorization. Resolves a token to this instance's name
+and open/closed state (``GET``, safe to call before the visitor is access-allowed or even signed
+in), and lets an already-signed-in visitor confirm joining (``POST``), which appends their
+username to the private instance's allowlist via #1019's write path. Entry into the game itself
+still goes through the existing, unmodified entry gate (``/auth/me`` → ``resolve_entry_user`` /
+``_enforce_instance_access`` in ``routers.auth``) — this router only ever grows the allowlist that
+gate reads.
+"""
+
+import secrets
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from energetica import instance_config
+from energetica.game_error import GameError, GameExceptionType
+from energetica.schemas.join import JoinLinkOut
+from energetica.utils.auth import get_current_account
+
+router = APIRouter(prefix="/join", tags=["Join"])
+
+
+def _resolve(token: str) -> tuple[str, instance_config.PrivateAccess]:
+    """This instance's name and private-access block, if ``token`` is its current join token.
+
+    A wrong token, an unconfigured/public instance, or an instance with no join token generated
+    yet all collapse to the same ``JOIN_LINK_INVALID`` — there is nothing case-specific a visitor
+    could act on, and distinguishing them would only help someone probing for a valid link.
+    ``compare_digest`` avoids a timing oracle on the comparison.
+    """
+    try:
+        config = instance_config.load_instance_config()
+    except instance_config.InstanceConfigError as exc:
+        raise GameError(GameExceptionType.JOIN_LINK_INVALID) from exc
+    if config is None or not isinstance(config.access, instance_config.PrivateAccess):
+        raise GameError(GameExceptionType.JOIN_LINK_INVALID)
+    access = config.access
+    if access.join_token is None or not secrets.compare_digest(access.join_token, token):
+        raise GameError(GameExceptionType.JOIN_LINK_INVALID)
+    return config.name, access
+
+
+@router.get("/{token}")
+def get_join_link(token: str, request: Request) -> JoinLinkOut:
+    """What this join link offers, and whether the visitor already has a session to join with."""
+    instance_name, access = _resolve(token)
+    account = get_current_account(request)
+    return JoinLinkOut(
+        instance_name=instance_name,
+        join_open=access.join_open,
+        viewer_username=account.username if account is not None else None,
+    )
+
+
+@router.post("/{token}", status_code=204)
+def confirm_join(token: str, request: Request) -> None:
+    """Confirm joining: append the signed-in visitor's username to the allowlist.
+
+    Requires an SSO session (``get_current_account``, not ``get_settled_player`` — the whole point
+    is this runs *before* the visitor is access-allowed, so no local ``User`` need exist yet) but
+    deliberately does not go through ``_enforce_instance_access``: granting access is this
+    endpoint's job, not a precondition for reaching it. Re-checks ``join_open`` server-side (not
+    just trusted from the page's last ``GET``) so a facilitator flipping the toggle mid-visit is
+    the outcome that wins, not a stale client.
+    """
+    _, access = _resolve(token)
+    if not access.join_open:
+        raise GameError(GameExceptionType.JOIN_LINK_CLOSED)
+    account = get_current_account(request)
+    if account is None:
+        # Matches resolve_entry_user's convention: no/invalid session is a 401, not a 400
+        # GameError — this is a plain auth failure, not a game-domain rejection.
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, GameExceptionType.NOT_AUTHENTICATED)
+    instance_config.add_allowed_username(account.username)

--- a/energetica/schemas/join.py
+++ b/energetica/schemas/join.py
@@ -1,0 +1,19 @@
+"""Schema for the public join-link surface (#1021)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class JoinLinkOut(BaseModel):
+    """What a join link resolves to — enough for the confirmation screen, and nothing that
+    requires the visitor to already be admitted onto this instance.
+    """
+
+    instance_name: str = Field(description="This instance's display name, for the 'Join <name>?' prompt.")
+    join_open: bool = Field(description="Whether the join link currently admits new accounts.")
+    viewer_username: str | None = Field(
+        description="The visitor's username if they already have a valid SSO session, else null "
+        "— null means the frontend must send them through login/signup before showing the "
+        "confirmation screen."
+    )

--- a/energetica/utils/auth.py
+++ b/energetica/utils/auth.py
@@ -12,7 +12,8 @@ from datetime import datetime, timezone
 
 from fastapi import HTTPException, Request, status
 
-from energetica import instance_config
+from energetica import accounts, instance_config
+from energetica.accounts import Account
 from energetica.database.player import Player
 from energetica.database.user import User
 from energetica.game_error import GameExceptionType
@@ -44,6 +45,7 @@ __all__ = [
     "generate_password_hash",
     "get_or_create_secret_key",
     "serializer",
+    "get_current_account",
     "get_user_from_token",
     "get_user",
     "get_playing_user",
@@ -79,6 +81,25 @@ def reject_when_frozen() -> None:
     """
     if instance_config.current_phase() in ("freeze", "ended"):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=GameExceptionType.INSTANCE_FROZEN)
+
+
+def get_current_account(request: Request) -> Account | None:
+    """Resolve the SSO cookie to a server-wide :class:`Account`, or ``None``.
+
+    Unlike :func:`get_user`, this never touches this instance's local ``User``/access-policy
+    layer — it is the identity check the join flow (#1021) needs *before* a visitor is
+    access-allowed, when no local ``User`` can exist yet and :func:`get_user` would read as
+    ``None`` regardless of whether they have a valid session. A missing/invalid cookie, or a
+    cookie for an account since deleted from the server-wide store, both read as ``None`` here —
+    identical to :func:`resolve_entry_user`'s 401 cases in ``routers.auth``, just without raising.
+    """
+    token = request.cookies.get(SESSION_COOKIE_NAME)
+    if not token:
+        return None
+    account_id = account_id_from_token(token)
+    if account_id is None:
+        return None
+    return accounts.get_account_by_id(account_id)
 
 
 def get_user_from_token(token: str) -> User | None:

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -8,6 +8,7 @@ import { createContext, type ReactNode } from "react";
 
 import { authApi } from "@/lib/api/auth";
 import { ApiClientError } from "@/lib/api-client";
+import { isErrorType } from "@/lib/error-utils";
 import { queryKeys } from "@/lib/query-client";
 import type { ApiSchema } from "@/types/api-helpers";
 
@@ -46,6 +47,14 @@ export async function fetchCurrentUser(): Promise<User | null> {
     } catch (err) {
         if (err instanceof ApiClientError && err.status === 401) {
             // Not authenticated - return null instead of throwing
+            return null;
+        }
+        if (isErrorType(err, "INSTANCE_ACCESS_DENIED")) {
+            // A valid SSO session for an account this private instance hasn't allowlisted yet
+            // (#1021's join flow puts a visitor in exactly this state between logging in and
+            // confirming). The SPA has as little use for this account here as for no session at
+            // all — treating it as authenticated would just point every role guard at a user with
+            // no access — so this collapses to the same "unauthenticated" outcome as a 401.
             return null;
         }
         throw err;

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -52,9 +52,15 @@ export async function fetchCurrentUser(): Promise<User | null> {
         if (isErrorType(err, "INSTANCE_ACCESS_DENIED")) {
             // A valid SSO session for an account this private instance hasn't allowlisted yet
             // (#1021's join flow puts a visitor in exactly this state between logging in and
-            // confirming). The SPA has as little use for this account here as for no session at
-            // all — treating it as authenticated would just point every role guard at a user with
-            // no access — so this collapses to the same "unauthenticated" outcome as a 401.
+            // confirming). This doesn't change any *route guard's* behaviour — `AuthProvider`
+            // already coerced an errored query's `undefined` data to `user: null` /
+            // `isAuthenticated: false` via `user ?? null` below, so `__root.tsx`'s guards already
+            // treated a denied account the same as a logged-out one. What this catch actually
+            // fixes is `/app/`'s root loader: it reads this same query with `ensureQueryData`,
+            // which rejects on an unhandled error and previously crashed the loader outright for
+            // any denied visitor landing on bare `/app` — this makes it resolve to `null` and fall
+            // through to the ordinary redirect instead. (`error` here is unused anywhere in the
+            // app today, so nothing that surfaced `INSTANCE_ACCESS_DENIED`'s message loses it.)
             return null;
         }
         throw err;

--- a/frontend/src/hooks/use-join.ts
+++ b/frontend/src/hooks/use-join.ts
@@ -33,11 +33,11 @@ export function useJoinLink(token: string) {
 export function useConfirmJoin(token: string) {
     return useMutation({
         mutationFn: () => joinApi.confirm(token),
-        onSuccess: () => {
+        onSuccess: async () => {
             void queryClient.invalidateQueries({
                 queryKey: queryKeys.join.link(token),
             });
-            void queryClient.invalidateQueries({ queryKey: queryKeys.auth.me });
+            await queryClient.invalidateQueries({ queryKey: queryKeys.auth.me });
         },
     });
 }

--- a/frontend/src/hooks/use-join.ts
+++ b/frontend/src/hooks/use-join.ts
@@ -1,0 +1,43 @@
+/**
+ * Hooks for the visitor-facing join flow (#1021): resolving a join token and
+ * confirming membership, backing `/app/join/$token`.
+ */
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { joinApi } from "@/lib/api/join";
+import { queryClient, queryKeys } from "@/lib/query-client";
+
+/**
+ * What this join link offers: the instance's name, whether it's currently
+ * accepting new members, and — if the visitor already has an SSO session —
+ * their username.
+ */
+export function useJoinLink(token: string) {
+    return useQuery({
+        queryKey: queryKeys.join.link(token),
+        queryFn: () => joinApi.getLink(token),
+        // Nothing else in this session writes this instance's join settings; the toggle only
+        // ever changes from the facilitator's own page, in a different browser entirely.
+        staleTime: 60 * 1000,
+        refetchOnWindowFocus: false,
+    });
+}
+
+/**
+ * Confirm joining: appends the visitor's username to the instance's allowlist.
+ * Invalidates `auth.me` on success — the entry gate (`GET /auth/me`) now admits
+ * this account, so the SPA's global auth state must re-resolve before the
+ * caller navigates into the app.
+ */
+export function useConfirmJoin(token: string) {
+    return useMutation({
+        mutationFn: () => joinApi.confirm(token),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: queryKeys.join.link(token),
+            });
+            void queryClient.invalidateQueries({ queryKey: queryKeys.auth.me });
+        },
+    });
+}

--- a/frontend/src/lib/api/join.ts
+++ b/frontend/src/lib/api/join.ts
@@ -1,0 +1,25 @@
+/**
+ * Public join-link API calls (#1021) — the visitor-facing counterpart to
+ * `lib/api/facilitator.ts`.
+ */
+
+import { apiClient } from "@/lib/api-client";
+import type { ApiResponse } from "@/types/api-helpers";
+
+export const joinApi = {
+    /**
+     * What this join link offers, and whether the visitor already has a session
+     * to join with.
+     */
+    getLink: (token: string) =>
+        apiClient.get<ApiResponse<"/api/v1/join/{token}", "get">>(
+            `/join/${encodeURIComponent(token)}`,
+        ),
+
+    /**
+     * Confirm joining: append the signed-in visitor's username to the
+     * allowlist.
+     */
+    confirm: (token: string) =>
+        apiClient.post<void>(`/join/${encodeURIComponent(token)}`),
+};

--- a/frontend/src/lib/game-messages.ts
+++ b/frontend/src/lib/game-messages.ts
@@ -41,6 +41,9 @@ export const GAME_ERROR_MESSAGES: Record<GameExceptionType, string> = {
     INSTANCE_ACCESS_DENIED: "Your account is not allowed on this instance.",
     INSTANCE_NOT_PRIVATE:
         "This instance is not configured as private, so it has no join link.",
+    JOIN_LINK_INVALID:
+        "This join link isn't valid. Ask the organizer for a new one.",
+    JOIN_LINK_CLOSED: "This join link isn't accepting new members right now.",
 
     // --- Lifecycle ---
     // 409 backstop when a write reaches a frozen instance (#861). Normally unseen: the client

--- a/frontend/src/lib/join.test.ts
+++ b/frontend/src/lib/join.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { rememberPendingJoinToken, takePendingJoinToken } from "./join";
+
+/**
+ * Minimal in-memory `Storage` stand-in — no DOM environment needed to test the
+ * round trip.
+ */
+function fakeStorage(): Storage {
+    const data = new Map<string, string>();
+    return {
+        getItem: (key) => data.get(key) ?? null,
+        setItem: (key, value) => void data.set(key, value),
+        removeItem: (key) => void data.delete(key),
+        clear: () => data.clear(),
+        key: () => null,
+        get length() {
+            return data.size;
+        },
+    };
+}
+
+describe("pending join token (storage round trip)", () => {
+    it("returns null when nothing was remembered", () => {
+        expect(takePendingJoinToken(fakeStorage())).toBeNull();
+    });
+
+    it("returns a remembered token", () => {
+        const storage = fakeStorage();
+        rememberPendingJoinToken("abc123", storage);
+        expect(takePendingJoinToken(storage)).toBe("abc123");
+    });
+
+    it("clears the token on read, so a second read finds nothing", () => {
+        const storage = fakeStorage();
+        rememberPendingJoinToken("abc123", storage);
+        takePendingJoinToken(storage);
+        expect(takePendingJoinToken(storage)).toBeNull();
+    });
+
+    it("overwrites a previously remembered token", () => {
+        const storage = fakeStorage();
+        rememberPendingJoinToken("first", storage);
+        rememberPendingJoinToken("second", storage);
+        expect(takePendingJoinToken(storage)).toBe("second");
+    });
+
+    it("swallows a storage that throws (e.g. private browsing) rather than crashing", () => {
+        const throwing: Storage = {
+            getItem: () => {
+                throw new Error("blocked");
+            },
+            setItem: () => {
+                throw new Error("blocked");
+            },
+            removeItem: () => {
+                throw new Error("blocked");
+            },
+            clear: () => {},
+            key: () => null,
+            length: 0,
+        };
+        expect(() =>
+            rememberPendingJoinToken("abc123", throwing),
+        ).not.toThrow();
+        expect(takePendingJoinToken(throwing)).toBeNull();
+    });
+
+    it("no-ops when storage is unavailable (undefined)", () => {
+        expect(() =>
+            rememberPendingJoinToken("abc123", undefined),
+        ).not.toThrow();
+        expect(takePendingJoinToken(undefined)).toBeNull();
+    });
+});

--- a/frontend/src/lib/join.ts
+++ b/frontend/src/lib/join.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helpers for the visitor-facing join flow (#1021).
+ *
+ * A visitor with no SSO session yet must go through the lobby's existing,
+ * unmodified login/signup flow before they can confirm joining — but that
+ * flow's `?return=` bounce (`lobbyLoginHref` in `lib/instances.ts`) only ever
+ * lands them back on this run's bare `/app` root, never on the specific
+ * `/app/join/:token` page they started from (the bounce carries a run slug, not
+ * an arbitrary path, and is shared with unrelated login flows the
+ * switcher/picker also use). `sessionStorage` — scoped to this run's own
+ * origin, so it survives the round trip to the lobby's different origin and
+ * back, and is cleared when the tab closes rather than lingering forever — is
+ * what lets `/app/`'s root loader notice "there was a join in progress" and
+ * send the visitor back to the confirm screen instead of the ordinary
+ * role-based landing page.
+ *
+ * The storage takes a `Storage` parameter (defaulting to the real
+ * `sessionStorage`) rather than reading the global directly, so the round-trip
+ * logic is a pure function of its argument and needs no DOM environment to test
+ * (`vitest.config.ts` sticks to the plain `node` environment).
+ */
+
+const PENDING_JOIN_TOKEN_KEY = "energetica.pendingJoinToken";
+
+function defaultStorage(): Storage | undefined {
+    return typeof sessionStorage === "undefined" ? undefined : sessionStorage;
+}
+
+/**
+ * Remember `token` before sending an unauthenticated visitor off to log in or
+ * sign up.
+ */
+export function rememberPendingJoinToken(
+    token: string,
+    storage: Storage | undefined = defaultStorage(),
+): void {
+    try {
+        storage?.setItem(PENDING_JOIN_TOKEN_KEY, token);
+    } catch {
+        // Storage can be unavailable (private browsing, disabled) — the visitor simply has to
+        // re-click the join link after logging in instead of resuming automatically.
+    }
+}
+
+/**
+ * Read and clear the pending join token, if one was remembered. Consuming it on
+ * read means a later, unrelated login in the same tab does not resume a stale
+ * join.
+ */
+export function takePendingJoinToken(
+    storage: Storage | undefined = defaultStorage(),
+): string | null {
+    try {
+        const token = storage?.getItem(PENDING_JOIN_TOKEN_KEY) ?? null;
+        if (token !== null) storage?.removeItem(PENDING_JOIN_TOKEN_KEY);
+        return token;
+    } catch {
+        return null;
+    }
+}

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -290,4 +290,7 @@ export const queryKeys = {
     facilitator: {
         access: ["facilitator", "access"] as const,
     },
+    join: {
+        link: (token: string) => ["join", "link", token] as const,
+    },
 } as const;

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as AppOverviewsPowerRouteImport } from './routes/app/overviews/po
 import { Route as AppOverviewsEmissionsRouteImport } from './routes/app/overviews/emissions'
 import { Route as AppOverviewsElectricityMarketsRouteImport } from './routes/app/overviews/electricity-markets'
 import { Route as AppOverviewsCashFlowRouteImport } from './routes/app/overviews/cash-flow'
+import { Route as AppJoinTokenRouteImport } from './routes/app/join/$token'
 import { Route as AppInternalTypographyRouteImport } from './routes/app/internal/typography'
 import { Route as AppInternalIconsRouteImport } from './routes/app/internal/icons'
 import { Route as AppInternalDesignRouteImport } from './routes/app/internal/design'
@@ -122,6 +123,11 @@ const AppOverviewsElectricityMarketsRoute =
 const AppOverviewsCashFlowRoute = AppOverviewsCashFlowRouteImport.update({
   id: '/app/overviews/cash-flow',
   path: '/app/overviews/cash-flow',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AppJoinTokenRoute = AppJoinTokenRouteImport.update({
+  id: '/app/join/$token',
+  path: '/app/join/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AppInternalTypographyRoute = AppInternalTypographyRouteImport.update({
@@ -238,6 +244,7 @@ export interface FileRoutesByFullPath {
   '/app/internal/design': typeof AppInternalDesignRoute
   '/app/internal/icons': typeof AppInternalIconsRoute
   '/app/internal/typography': typeof AppInternalTypographyRoute
+  '/app/join/$token': typeof AppJoinTokenRoute
   '/app/overviews/cash-flow': typeof AppOverviewsCashFlowRoute
   '/app/overviews/electricity-markets': typeof AppOverviewsElectricityMarketsRoute
   '/app/overviews/emissions': typeof AppOverviewsEmissionsRoute
@@ -273,6 +280,7 @@ export interface FileRoutesByTo {
   '/app/internal/design': typeof AppInternalDesignRoute
   '/app/internal/icons': typeof AppInternalIconsRoute
   '/app/internal/typography': typeof AppInternalTypographyRoute
+  '/app/join/$token': typeof AppJoinTokenRoute
   '/app/overviews/cash-flow': typeof AppOverviewsCashFlowRoute
   '/app/overviews/electricity-markets': typeof AppOverviewsElectricityMarketsRoute
   '/app/overviews/emissions': typeof AppOverviewsEmissionsRoute
@@ -309,6 +317,7 @@ export interface FileRoutesById {
   '/app/internal/design': typeof AppInternalDesignRoute
   '/app/internal/icons': typeof AppInternalIconsRoute
   '/app/internal/typography': typeof AppInternalTypographyRoute
+  '/app/join/$token': typeof AppJoinTokenRoute
   '/app/overviews/cash-flow': typeof AppOverviewsCashFlowRoute
   '/app/overviews/electricity-markets': typeof AppOverviewsElectricityMarketsRoute
   '/app/overviews/emissions': typeof AppOverviewsEmissionsRoute
@@ -346,6 +355,7 @@ export interface FileRouteTypes {
     | '/app/internal/design'
     | '/app/internal/icons'
     | '/app/internal/typography'
+    | '/app/join/$token'
     | '/app/overviews/cash-flow'
     | '/app/overviews/electricity-markets'
     | '/app/overviews/emissions'
@@ -381,6 +391,7 @@ export interface FileRouteTypes {
     | '/app/internal/design'
     | '/app/internal/icons'
     | '/app/internal/typography'
+    | '/app/join/$token'
     | '/app/overviews/cash-flow'
     | '/app/overviews/electricity-markets'
     | '/app/overviews/emissions'
@@ -416,6 +427,7 @@ export interface FileRouteTypes {
     | '/app/internal/design'
     | '/app/internal/icons'
     | '/app/internal/typography'
+    | '/app/join/$token'
     | '/app/overviews/cash-flow'
     | '/app/overviews/electricity-markets'
     | '/app/overviews/emissions'
@@ -451,6 +463,7 @@ export interface RootRouteChildren {
   AppInternalDesignRoute: typeof AppInternalDesignRoute
   AppInternalIconsRoute: typeof AppInternalIconsRoute
   AppInternalTypographyRoute: typeof AppInternalTypographyRoute
+  AppJoinTokenRoute: typeof AppJoinTokenRoute
   AppOverviewsCashFlowRoute: typeof AppOverviewsCashFlowRoute
   AppOverviewsElectricityMarketsRoute: typeof AppOverviewsElectricityMarketsRoute
   AppOverviewsEmissionsRoute: typeof AppOverviewsEmissionsRoute
@@ -575,6 +588,13 @@ declare module '@tanstack/react-router' {
       path: '/app/overviews/cash-flow'
       fullPath: '/app/overviews/cash-flow'
       preLoaderRoute: typeof AppOverviewsCashFlowRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/app/join/$token': {
+      id: '/app/join/$token'
+      path: '/app/join/$token'
+      fullPath: '/app/join/$token'
+      preLoaderRoute: typeof AppJoinTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/app/internal/typography': {
@@ -734,6 +754,7 @@ const rootRouteChildren: RootRouteChildren = {
   AppInternalDesignRoute: AppInternalDesignRoute,
   AppInternalIconsRoute: AppInternalIconsRoute,
   AppInternalTypographyRoute: AppInternalTypographyRoute,
+  AppJoinTokenRoute: AppJoinTokenRoute,
   AppOverviewsCashFlowRoute: AppOverviewsCashFlowRoute,
   AppOverviewsElectricityMarketsRoute: AppOverviewsElectricityMarketsRoute,
   AppOverviewsEmissionsRoute: AppOverviewsEmissionsRoute,

--- a/frontend/src/routes/app/index.tsx
+++ b/frontend/src/routes/app/index.tsx
@@ -1,10 +1,27 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { fetchCurrentUser } from "@/contexts/auth-context";
+import { takePendingJoinToken } from "@/lib/join";
 import { queryClient, queryKeys } from "@/lib/query-client";
 
 export const Route = createFileRoute("/app/")({
     loader: async () => {
+        // A join in progress (#1021) wins over the ordinary role-based landing below: a visitor
+        // who followed a join link while signed out was sent off to the lobby to log in/sign up
+        // and is bouncing back here now — `takePendingJoinToken` is how `/app/join/$token`
+        // survives that cross-origin round trip (the lobby's `?return=` bounce only ever lands on
+        // this bare `/app` root, see `lib/join.ts`). Checked, and consumed, before touching
+        // `auth.me`: a visitor in this state is real per the SSO cookie but not yet
+        // access-allowed, and `fetchCurrentUser` reads that as `null` (#1021) — falling through to
+        // the role-based redirect below would bounce them straight back to the lobby and loop.
+        const pendingJoinToken = takePendingJoinToken();
+        if (pendingJoinToken !== null) {
+            throw redirect({
+                to: "/app/join/$token",
+                params: { token: pendingJoinToken },
+            });
+        }
+
         // Role-aware so an admin account lands on its own home (#1020) instead of bouncing
         // through the player-only `/app/dashboard`, which `__root.tsx`'s route guard would then
         // redirect straight to `/app/logout` (a role mismatch on a gated route always logs out —

--- a/frontend/src/routes/app/join/$token.tsx
+++ b/frontend/src/routes/app/join/$token.tsx
@@ -1,0 +1,207 @@
+/**
+ * Public join flow (#1021): link → confirm → enter.
+ *
+ * The visitor-facing counterpart to #1020's facilitator page. Reachable by
+ * anyone holding the link — `staticData.routeConfig` is `{ requiredRole: null
+ * }` so `__root.tsx`'s guard leaves it alone regardless of auth state, which
+ * matters here: a visitor mid-join has a valid SSO session but isn't
+ * access-allowed yet, a state `fetchCurrentUser` deliberately reads as
+ * "unauthenticated" (see `contexts/auth-context.tsx`) — this page renders its
+ * own state off `useJoinLink` instead of `useAuth()`.
+ *
+ * Doesn't use `GameLayout`/`AppSidebar` (same reasoning as the facilitator page
+ * — no settled player to render chrome around) or `GameLayout`'s sibling admin
+ * shell (no "Log out" affordance makes sense for someone who may not even have
+ * an account yet).
+ */
+
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+import Logo from "@/assets/simplified_logo.svg?react";
+import {
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    InfoBanner,
+} from "@/components/ui";
+import { Spinner } from "@/components/ui/spinner";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { TypographyH2, TypographyMuted } from "@/components/ui/typography";
+import { useConfirmJoin, useJoinLink } from "@/hooks/use-join";
+import { getUserFriendlyError } from "@/lib/error-utils";
+import { lobbyLoginHref } from "@/lib/instances";
+import { rememberPendingJoinToken } from "@/lib/join";
+
+function JoinHelp() {
+    return (
+        <p>
+            Someone shared this link (or its QR code) to invite you into a
+            private Energetica instance. Confirming adds your account to that
+            instance — nothing happens until you do.
+        </p>
+    );
+}
+
+export const Route = createFileRoute("/app/join/$token")({
+    component: JoinPage,
+    staticData: {
+        title: "Join",
+        routeConfig: { requiredRole: null },
+        infoDialog: { contents: <JoinHelp /> },
+    },
+});
+
+function JoinHeader() {
+    return (
+        <header className="shrink-0 flex h-(--topbar-height) items-center justify-between border-b border-border-brand bg-topbar px-4">
+            <div className="flex items-center gap-1.5">
+                <Logo className="size-10 fill-foreground" />
+                <span className="font-titles text-lg">Energetica</span>
+            </div>
+            <ThemeToggle variant="icon-only" />
+        </header>
+    );
+}
+
+function JoinPage() {
+    return (
+        <div className="flex min-h-svh flex-col">
+            <JoinHeader />
+            <main className="flex-1 overflow-auto p-4 md:p-8">
+                <div className="max-w-xl mx-auto">
+                    <JoinCard />
+                </div>
+            </main>
+        </div>
+    );
+}
+
+function JoinCard() {
+    const { token } = Route.useParams();
+    const { data, isLoading, isError, error } = useJoinLink(token);
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-12">
+                <Spinner />
+            </div>
+        );
+    }
+
+    if (isError || !data) {
+        return (
+            <InfoBanner variant="error">
+                {getUserFriendlyError(error)}
+            </InfoBanner>
+        );
+    }
+
+    if (!data.join_open) {
+        return (
+            <InfoBanner variant="warning">
+                Joining <strong>{data.instance_name}</strong> is currently
+                closed. Contact the administrator for an invitation.
+            </InfoBanner>
+        );
+    }
+
+    if (data.viewer_username === null) {
+        return (
+            <LogInToJoinCard instanceName={data.instance_name} token={token} />
+        );
+    }
+
+    return <ConfirmJoinCard instanceName={data.instance_name} token={token} />;
+}
+
+function LogInToJoinCard({
+    instanceName,
+    token,
+}: {
+    instanceName: string;
+    token: string;
+}) {
+    const handleLogIn = () => {
+        // Survives the round trip through the lobby's login/signup (a different origin) so
+        // `/app/`'s root loader can send the visitor straight back here afterwards — see `lib/join.ts`.
+        rememberPendingJoinToken(token);
+        window.location.assign(lobbyLoginHref());
+    };
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>
+                    <TypographyH2>Join {instanceName}</TypographyH2>
+                </CardTitle>
+                <TypographyMuted>
+                    Log in or create an account to join this instance.
+                </TypographyMuted>
+            </CardHeader>
+            <CardContent>
+                <Button onClick={handleLogIn} className="w-full" size="lg">
+                    Log in to join
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}
+
+function ConfirmJoinCard({
+    instanceName,
+    token,
+}: {
+    instanceName: string;
+    token: string;
+}) {
+    const navigate = useNavigate();
+    const {
+        mutate: confirmJoin,
+        isPending,
+        isSuccess,
+        isError,
+        error,
+    } = useConfirmJoin(token);
+
+    // Once confirmed, `/app` re-resolves the now-passing entry gate (`auth.me`, invalidated by
+    // the mutation) and lands the visitor on their role-appropriate page — the same redirect any
+    // returning player gets, not a special case for joining.
+    useEffect(() => {
+        if (isSuccess) {
+            void navigate({ to: "/app" });
+        }
+    }, [isSuccess, navigate]);
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>
+                    <TypographyH2>Join {instanceName}?</TypographyH2>
+                </CardTitle>
+                <TypographyMuted>
+                    You're signed in. Confirming adds your account to this
+                    instance so you can play.
+                </TypographyMuted>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {isError && (
+                    <InfoBanner variant="error">
+                        {getUserFriendlyError(error)}
+                    </InfoBanner>
+                )}
+                <Button
+                    onClick={() => confirmJoin()}
+                    disabled={isPending || isSuccess}
+                    className="w-full flex items-center justify-center gap-2"
+                    size="lg"
+                >
+                    {(isPending || isSuccess) && <Spinner />}
+                    Join {instanceName}
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -986,6 +986,37 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/join/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Join Link
+         * @description What this join link offers, and whether the visitor already has a session to join with.
+         */
+        get: operations["get_join_link_api_v1_join__token__get"];
+        put?: never;
+        /**
+         * Confirm Join
+         * @description Confirm joining: append the signed-in visitor's username to the allowlist.
+         *
+         *     Requires an SSO session (``get_current_account``, not ``get_settled_player`` — the whole point
+         *     is this runs *before* the visitor is access-allowed, so no local ``User`` need exist yet) but
+         *     deliberately does not go through ``_enforce_instance_access``: granting access is this
+         *     endpoint's job, not a precondition for reaching it. Re-checks ``join_open`` server-side (not
+         *     just trusted from the page's last ``GET``) so a facilitator flipping the toggle mid-visit is
+         *     the outcome that wins, not a stale client.
+         */
+        post: operations["confirm_join_api_v1_join__token__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/lobby/my-runs": {
         parameters: {
             query?: never;
@@ -2654,6 +2685,28 @@ export interface components {
          * @enum {string}
          */
         HydroFacilityType: "watermill" | "small_water_dam" | "large_water_dam";
+        /**
+         * JoinLinkOut
+         * @description What a join link resolves to — enough for the confirmation screen, and nothing that
+         *     requires the visitor to already be admitted onto this instance.
+         */
+        JoinLinkOut: {
+            /**
+             * Instance Name
+             * @description This instance's display name, for the 'Join <name>?' prompt.
+             */
+            instance_name: string;
+            /**
+             * Join Open
+             * @description Whether the join link currently admits new accounts.
+             */
+            join_open: boolean;
+            /**
+             * Viewer Username
+             * @description The visitor's username if they already have a valid SSO session, else null — null means the frontend must send them through login/signup before showing the confirmation screen.
+             */
+            viewer_username: string | null;
+        };
         /** LeaderboardsOut */
         LeaderboardsOut: {
             /** Rows */
@@ -4277,7 +4330,7 @@ export interface components {
          * GameExceptionType
          * @enum {string}
          */
-        GameExceptionType: "Not enough money" | "TileNotFound" | "noTile" | "noLocation" | "Player has no tile" | "locationOccupied" | "choiceUnmodifiable" | "USERNAME_TAKEN" | "USER_NOT_FOUND" | "INVALID_PASSWORD" | "NOT_AUTHENTICATED" | "USER_IS_NOT_A_PLAYER" | "USER_IS_NOT_AN_ADMIN" | "PLAYER_NOT_SET_UP" | "SIGNUP_DISABLED" | "OLD_PASSWORD_INCORRECT" | "INSTANCE_ACCESS_DENIED" | "INSTANCE_NOT_PRIVATE" | "Instance is frozen; the game is read-only." | "InvalidMultiplier" | "malformedRequest" | "storagePriceInversion" | "Project not found" | "CannotDecreasePriorityOfLastProject" | "CannotIncreasePriorityOfFirstProject" | "requirementsPreventReorder" | "cannotPause" | "cannotResume" | "CannotSwapPausedProject" | "PausedPrerequisitePreventUnpause" | "Requirements not satisfied" | "HasDependents" | "Facility not upgradable" | "FacilityIsDecommissioning" | "Facility not found" | "Cannot remove technologies or functional facilities" | "wrongTitleLength" | "chatAlreadyExist" | "notInChat" | "noMessage" | "messageTooLong" | "quizAlreadyAnswered" | "networkNotUnlocked" | "noSuchNetwork" | "playerAlreadyInNetwork" | "nameAlreadyUsed" | "notInNetwork" | "networkFull" | "notEnoughResource" | "invalidQuantity";
+        GameExceptionType: "Not enough money" | "TileNotFound" | "noTile" | "noLocation" | "Player has no tile" | "locationOccupied" | "choiceUnmodifiable" | "USERNAME_TAKEN" | "USER_NOT_FOUND" | "INVALID_PASSWORD" | "NOT_AUTHENTICATED" | "USER_IS_NOT_A_PLAYER" | "USER_IS_NOT_AN_ADMIN" | "PLAYER_NOT_SET_UP" | "SIGNUP_DISABLED" | "OLD_PASSWORD_INCORRECT" | "INSTANCE_ACCESS_DENIED" | "INSTANCE_NOT_PRIVATE" | "JOIN_LINK_INVALID" | "JOIN_LINK_CLOSED" | "Instance is frozen; the game is read-only." | "InvalidMultiplier" | "malformedRequest" | "storagePriceInversion" | "Project not found" | "CannotDecreasePriorityOfLastProject" | "CannotIncreasePriorityOfFirstProject" | "requirementsPreventReorder" | "cannotPause" | "cannotResume" | "CannotSwapPausedProject" | "PausedPrerequisitePreventUnpause" | "Requirements not satisfied" | "HasDependents" | "Facility not upgradable" | "FacilityIsDecommissioning" | "Facility not found" | "Cannot remove technologies or functional facilities" | "wrongTitleLength" | "chatAlreadyExist" | "notInChat" | "noMessage" | "messageTooLong" | "quizAlreadyAnswered" | "networkNotUnlocked" | "noSuchNetwork" | "playerAlreadyInNetwork" | "nameAlreadyUsed" | "notInNetwork" | "networkFull" | "notEnoughResource" | "invalidQuantity";
     };
     responses: never;
     parameters: never;
@@ -5694,6 +5747,66 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GameEngineOut"];
+                };
+            };
+        };
+    };
+    get_join_link_api_v1_join__token__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JoinLinkOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirm_join_api_v1_join__token__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/src/types/app-routes.ts
+++ b/frontend/src/types/app-routes.ts
@@ -24,6 +24,7 @@ export type AppRoute =
     | "/app/internal/design"
     | "/app/internal/icons"
     | "/app/internal/typography"
+    | "/app/join/$token"
     | "/app/overviews/cash-flow"
     | "/app/overviews/electricity-markets"
     | "/app/overviews/emissions"

--- a/tests/integration/test_join_router.py
+++ b/tests/integration/test_join_router.py
@@ -1,0 +1,235 @@
+"""Integration tests for the public join-link routes (#1021): ``GET/POST /api/v1/join/{token}``.
+
+The visitor-facing counterpart to #1020's facilitator page — reachable by anyone holding the
+token, not just the instance's admin. Builds on #1019's write path (``add_allowed_username``) the
+same way ``test_facilitator_router.py`` builds on ``get_or_create_join_token``/``set_join_open``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from energetica import create_app
+from energetica.database.user import User
+from energetica.globals import engine
+
+from ._session_helpers import authenticate, make_account
+
+PORT = 8000
+SLUG = "autumn-2025"
+TOKEN = "the-real-join-token"
+
+PRIVATE_JSON = {
+    "name": "ETHZ Spring 2026",
+    "advertised": False,
+    "starts_at": "2026-03-01T00:00:00Z",
+    "access": {
+        "policy": "private",
+        "allowed_usernames": ["alice"],
+        "join_token": TOKEN,
+        "join_open": True,
+    },
+}
+PUBLIC_JSON = {
+    "name": "Autumn 2025",
+    "advertised": True,
+    "starts_at": "2025-09-15T00:00:00Z",
+    "access": {"policy": "public"},
+}
+
+
+def _join_url(token: str) -> str:
+    return f"http://localhost:{PORT}/api/v1/join/{token}"
+
+
+@pytest.fixture
+def instance_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``instance_config`` at a per-test config dir and return the path to write to."""
+    config_dir = tmp_path / "etc"
+    monkeypatch.setenv("ENERGETICA_INSTANCE_SLUG", SLUG)
+    monkeypatch.setenv("ENERGETICA_INSTANCE_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ENERGETICA_LANDING_DIR", str(tmp_path / "landing"))
+    path = config_dir / SLUG / "instance.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _client() -> TestClient:
+    app = create_app(rm_instance=True, skip_adding_handlers=True, env="dev", port=PORT)
+    engine.serve_local = False
+    return TestClient(app)
+
+
+def _allowed_usernames(path: Path) -> list[str]:
+    return json.loads(path.read_text())["access"]["allowed_usernames"]
+
+
+# --- GET: resolving the link -------------------------------------------------------------------
+
+
+def test_get_rejects_an_unknown_token(instance_json: Path) -> None:
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+
+    response = client.get(_join_url("wrong-token"))
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "JOIN_LINK_INVALID"
+
+
+def test_get_rejects_a_token_on_a_public_instance(instance_json: Path) -> None:
+    _write(instance_json, PUBLIC_JSON)
+    client = _client()
+
+    response = client.get(_join_url(TOKEN))
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "JOIN_LINK_INVALID"
+
+
+def test_get_rejects_a_token_on_an_unconfigured_instance() -> None:
+    """No ENERGETICA_INSTANCE_SLUG set at all — nothing to resolve against."""
+    client = _client()
+
+    response = client.get(_join_url(TOKEN))
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "JOIN_LINK_INVALID"
+
+
+def test_get_with_a_valid_token_reports_the_instance_name_and_open_state(instance_json: Path) -> None:
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+
+    response = client.get(_join_url(TOKEN))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["instance_name"] == "ETHZ Spring 2026"
+    assert body["join_open"] is True
+    assert body["viewer_username"] is None
+
+
+def test_get_reports_join_open_false(instance_json: Path) -> None:
+    closed = {**PRIVATE_JSON, "access": {**PRIVATE_JSON["access"], "join_open": False}}
+    _write(instance_json, closed)
+    client = _client()
+
+    response = client.get(_join_url(TOKEN))
+
+    assert response.status_code == 200
+    assert response.json()["join_open"] is False
+
+
+def test_get_reports_the_viewer_username_for_a_signed_in_visitor_with_no_local_user(instance_json: Path) -> None:
+    """The crux of #1021: a visitor with a valid SSO session but no User row yet (not
+    access-allowed, so the entry gate has never provisioned one) must still be identified here.
+    """
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+    account_id = make_account("carol", "pw")
+    authenticate(client, account_id)
+    assert next(User.filter_by(account_id=account_id), None) is None
+
+    response = client.get(_join_url(TOKEN))
+
+    assert response.status_code == 200
+    assert response.json()["viewer_username"] == "carol"
+    # Merely resolving the link must not itself grant or provision anything.
+    assert next(User.filter_by(account_id=account_id), None) is None
+    assert "carol" not in _allowed_usernames(instance_json)
+
+
+# --- POST: confirming -----------------------------------------------------------------------
+
+
+def test_post_rejects_an_unauthenticated_visitor(instance_json: Path) -> None:
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+
+    response = client.post(_join_url(TOKEN))
+
+    assert response.status_code == 401
+
+
+def test_post_rejects_an_unknown_token(instance_json: Path) -> None:
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+    account_id = make_account("carol", "pw")
+    authenticate(client, account_id)
+
+    response = client.post(_join_url("wrong-token"))
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "JOIN_LINK_INVALID"
+    assert "carol" not in _allowed_usernames(instance_json)
+
+
+def test_post_rejects_when_join_is_closed_and_does_not_modify_the_allowlist(instance_json: Path) -> None:
+    closed = {**PRIVATE_JSON, "access": {**PRIVATE_JSON["access"], "join_open": False}}
+    _write(instance_json, closed)
+    client = _client()
+    account_id = make_account("carol", "pw")
+    authenticate(client, account_id)
+
+    response = client.post(_join_url(TOKEN))
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "JOIN_LINK_CLOSED"
+    assert "carol" not in _allowed_usernames(instance_json)
+
+
+def test_post_adds_the_visitor_to_the_allowlist_and_the_entry_gate_then_admits_them(instance_json: Path) -> None:
+    """The full acceptance scenario: confirm, then the existing entry gate (unmodified) admits
+    the visitor as a normal player and provisions their local User.
+    """
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+    account_id = make_account("carol", "pw")
+    authenticate(client, account_id)
+
+    # Blocked before confirming, exactly like any other not-yet-allowed account.
+    assert client.get(f"http://localhost:{PORT}/api/v1/auth/me").status_code == 403
+
+    response = client.post(_join_url(TOKEN))
+    assert response.status_code == 204
+    assert "carol" in _allowed_usernames(instance_json)
+
+    me = client.get(f"http://localhost:{PORT}/api/v1/auth/me")
+    assert me.status_code == 200
+    body = me.json()
+    assert body["username"] == "carol"
+    assert body["role"] == "player"
+    assert next(User.filter_by(account_id=account_id), None) is not None
+
+
+def test_post_is_idempotent_for_an_already_allowed_username(instance_json: Path) -> None:
+    _write(instance_json, PRIVATE_JSON)  # "alice" is already allowlisted
+    client = _client()
+    account_id = make_account("alice", "pw")
+    authenticate(client, account_id)
+
+    response = client.post(_join_url(TOKEN))
+
+    assert response.status_code == 204
+    assert _allowed_usernames(instance_json).count("alice") == 1
+
+
+def test_post_rejects_a_token_on_a_public_instance(instance_json: Path) -> None:
+    _write(instance_json, PUBLIC_JSON)
+    client = _client()
+    account_id = make_account("carol", "pw")
+    authenticate(client, account_id)
+
+    response = client.post(_join_url(TOKEN))
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "JOIN_LINK_INVALID"


### PR DESCRIPTION
## Summary

The visitor-facing counterpart to #1020's facilitator page: following a valid join link authenticates the visitor through the existing, unmodified login/signup flow, then shows an explicit "Join **<Instance Name>**?" confirmation before appending their username to `allowed_usernames`.

- Backend: `GET`/`POST /api/v1/join/{token}`, reachable by anyone holding the token (the token itself is the authorization, not `get_admin_user`). `GET` resolves the token to the instance's name, `join_open` state, and — if the visitor already has an SSO session — their username, all without requiring them to be access-allowed yet. `POST` appends the signed-in visitor's username to `allowed_usernames` via #1019's write path, re-checking `join_open` server-side. A new `get_current_account()` (`utils/auth.py`) identifies the visitor from the SSO cookie alone, independent of the local `User`/access-policy layer that `get_user()` depends on — the whole point being to work *before* that layer would admit them.
- Entry into the game itself is unchanged: `/auth/me`'s existing entry gate (`resolve_entry_user` / `_enforce_instance_access`) picks up the now-allowed username on the next check.
- `fetchCurrentUser` (`auth-context.tsx`) now treats `INSTANCE_ACCESS_DENIED` like a 401: a visitor mid-join has a valid SSO session but isn't access-allowed yet, and the SPA's global auth state has no more use for that account than for no session at all. (Verified this doesn't change any route guard's behaviour or hide a currently-displayed message — see review notes below.)
- Frontend: `/app/join/$token`, a self-contained page (same reasoning as #1020's facilitator page — no settled player to render chrome around) showing a login/signup CTA, the closed-link message, or the confirm screen based on the token's resolved state. A signed-out visitor's token survives the cross-origin round trip through the lobby's login/signup via `sessionStorage` (`lib/join.ts`) — the lobby's `?return=` bounce only ever lands back on this run's bare `/app` root, so `/app/`'s root loader checks for a pending join token before its ordinary role-based redirect.

Closes #1021.

## Testing

Backend integration coverage for both routes (unknown/wrong token, public instance, closed link, unauthenticated confirm, the full confirm-then-entry-gate-admits scenario, idempotent re-join); frontend unit tests for the sessionStorage round trip (including storage-unavailable fallback). Full backend suite (270 tests) and frontend suite (83 tests) pass; typecheck, lint, and format clean.

## Review

Ran `/code-review` against this diff (Standards + Spec sub-agents). Spec review found no gaps or scope creep. Standards review flagged two issues, applied in a follow-up commit:
- `join.py` now resolves the account via `Depends(get_current_account)`, matching every other router in the codebase instead of taking a raw `Request`.
- `confirm_join` checks identity before instance state ("who, then what"), matching `get_admin_user`/`get_settled_player`'s order elsewhere.
- The `auth-context.tsx` comment was expanded after verifying the broadened catch doesn't introduce a new redirect loop or hide any currently-rendered error message (nothing in the app renders `useAuth().error` today; `isAuthenticated` was already `?? null`-coerced for any query failure before this change).

## Stacking

Based on #1026 (#1020), which is based on #1025 (#1019) — this PR targets `feat/1020-facilitator-join-link-qr` and should be retargeted to `main` once that chain lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a token-authorized public join flow that resolves instance details, preserves the token across lobby authentication, confirms admission by updating the private allowlist, and then enters through the existing authentication gate.
- Adds public GET and authenticated POST join endpoints with typed responses and domain errors.
- Adds the standalone join confirmation page, login-return token storage, query hooks, and generated route/API contracts.
- Extends integration and frontend unit coverage for token resolution, admission, idempotency, and storage behavior.
- The post-confirm transition currently races authentication-cache refresh, so a successful join can still bounce the visitor back to the lobby.

<h3>Confidence Score: 4/5</h3>

The join endpoints appear sound, but the post-confirm transition should be fixed before merging because a newly admitted visitor can be redirected back to the lobby.

The mutation starts authentication invalidation without awaiting the refreshed entry-gate result, while the destination loader can immediately reuse the cached pre-join null user and trigger the unauthenticated redirect.

**Files Needing Attention:** frontend/src/hooks/use-join.ts, frontend/src/routes/app/join/$token.tsx, frontend/src/routes/app/index.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| energetica/routers/join.py | Adds token resolution and signed-in confirmation endpoints, with server-side open-state validation and allowlist mutation. |
| energetica/utils/auth.py | Adds account resolution directly from the shared SSO cookie without requiring instance-local admission. |
| frontend/src/hooks/use-join.ts | Adds join queries and mutation invalidation, but does not await the authentication refresh before entry navigation. |
| frontend/src/routes/app/join/$token.tsx | Implements the standalone login and confirmation experience; its immediate success navigation exposes the stale-auth race. |
| frontend/src/routes/app/index.tsx | Restores pending join tokens before normal role routing but can consume a cached pre-join auth result after confirmation. |
| tests/integration/test_join_router.py | Thoroughly covers backend token resolution, authentication, closed links, admission, and idempotency, but not the frontend cache/navigation transition. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant V as Visitor
    participant J as Join page
    participant L as Lobby
    participant API as Instance API
    participant Q as Auth query cache
    V->>J: Open /app/join/:token
    J->>API: GET /join/:token
    alt No SSO session
        J->>J: Store pending token
        J->>L: Login/signup with return slug
        L-->>V: Return to /app
        V->>J: Resume stored join token
    end
    V->>J: Confirm join
    J->>API: POST /join/:token
    API->>API: Append username to allowlist
    API-->>J: 204 No Content
    J->>Q: Invalidate auth.me
    J->>V: Navigate to /app
    V->>Q: ensureQueryData(auth.me)
    Q-->>V: May return cached pre-join null
    V-->>L: Protected-route guard redirects to login
```

<sub>Reviews (1): Last reviewed commit: ["review(join): DI-convention consistency,..."](https://github.com/felixvonsamson/energetica/commit/174c638e1d29e64f513c8be09899ad615e389ea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57272767)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Game API routing](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/game-api-routing.md)
- Knowledge Base — [Identity and account persistence](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/identity-and-account-persistence.md)
- Knowledge Base — [Lobby and instance access](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/lobby-and-instance-access.md)
- Knowledge Base — [Game web client](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/game-web-client.md)
</details>


<!-- /greptile_comment -->