### PR TITLE
feat(facilitator): roster page — view, manual add, ban (#1022)

### DIFF
--- a/energetica/accounts/__init__.py
+++ b/energetica/accounts/__init__.py
@@ -19,6 +19,7 @@ from energetica.accounts.db import (
     get_or_create_account_id,
     init_db,
     record_membership,
+    search_accounts,
     update_password,
     verify_password,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "get_or_create_account_id",
     "init_db",
     "record_membership",
+    "search_accounts",
     "update_password",
     "verify_password",
 ]

--- a/energetica/accounts/db.py
+++ b/energetica/accounts/db.py
@@ -168,6 +168,19 @@ def verify_password(*, username: str, password: str) -> bool:
     return check_password_hash(plain_password=password, hashed_password=account.pwhash)
 
 
+def _row_to_account(row: sqlite3.Row) -> Account:
+    """Map one ``accounts`` row to an :class:`Account`. The shared row shape every read query
+    below selects, so the column list and field-by-field construction live in exactly one place.
+    """
+    return Account(
+        account_id=row["account_id"],
+        username=row["username"],
+        pwhash=row["pwhash"],
+        email=row["email"],
+        created_at=row["created_at"],
+    )
+
+
 def get_account_by_id(account_id: int) -> Account | None:
     """Look up an account by its immutable id. The lobby resolves the session cookie's
     ``account_id`` payload through here (ADR-0002).
@@ -177,15 +190,7 @@ def get_account_by_id(account_id: int) -> Account | None:
             "SELECT account_id, username, pwhash, email, created_at FROM accounts WHERE account_id = ?",
             (account_id,),
         ).fetchone()
-    if row is None:
-        return None
-    return Account(
-        account_id=row["account_id"],
-        username=row["username"],
-        pwhash=row["pwhash"],
-        email=row["email"],
-        created_at=row["created_at"],
-    )
+    return _row_to_account(row) if row is not None else None
 
 
 def search_accounts(*, prefix: str, limit: int = 20) -> list[Account]:
@@ -208,16 +213,7 @@ def search_accounts(*, prefix: str, limit: int = 20) -> list[Account]:
             "WHERE username LIKE ? ESCAPE '\\' ORDER BY username LIMIT ?",
             (f"{escaped}%", limit),
         ).fetchall()
-    return [
-        Account(
-            account_id=row["account_id"],
-            username=row["username"],
-            pwhash=row["pwhash"],
-            email=row["email"],
-            created_at=row["created_at"],
-        )
-        for row in rows
-    ]
+    return [_row_to_account(row) for row in rows]
 
 
 def get_account_by_username(username: str) -> Account | None:
@@ -226,15 +222,7 @@ def get_account_by_username(username: str) -> Account | None:
             "SELECT account_id, username, pwhash, email, created_at FROM accounts WHERE username = ?",
             (username,),
         ).fetchone()
-    if row is None:
-        return None
-    return Account(
-        account_id=row["account_id"],
-        username=row["username"],
-        pwhash=row["pwhash"],
-        email=row["email"],
-        created_at=row["created_at"],
-    )
+    return _row_to_account(row) if row is not None else None
 
 
 def record_membership(*, account_id: int, slug: str, settled_at: str) -> None:

--- a/energetica/accounts/db.py
+++ b/energetica/accounts/db.py
@@ -188,6 +188,38 @@ def get_account_by_id(account_id: int) -> Account | None:
     )
 
 
+def search_accounts(*, prefix: str, limit: int = 20) -> list[Account]:
+    """Accounts whose username starts with ``prefix``, alphabetical, capped at ``limit``.
+
+    Backs the facilitator roster's add control (#1022): the facilitator can only add an account
+    that actually exists, so the frontend looks one up by prefix here rather than accepting a
+    freeform username string. Matching is an exact-case prefix, same as :func:`get_account_by_username`'s
+    exact-case equality — neither normalises case. ``prefix``'s own ``%``/``_`` characters are
+    escaped so a username containing either can't accidentally act as a wildcard.
+    """
+    escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    with _connect() as conn:
+        # SQLite's LIKE is case-insensitive for ASCII by default; case_sensitive_like matches
+        # get_account_by_username's exact-case equality instead of surprising callers with
+        # case-folded matches nowhere else in this module.
+        conn.execute("PRAGMA case_sensitive_like = ON")
+        rows = conn.execute(
+            "SELECT account_id, username, pwhash, email, created_at FROM accounts "
+            "WHERE username LIKE ? ESCAPE '\\' ORDER BY username LIMIT ?",
+            (f"{escaped}%", limit),
+        ).fetchall()
+    return [
+        Account(
+            account_id=row["account_id"],
+            username=row["username"],
+            pwhash=row["pwhash"],
+            email=row["email"],
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+
 def get_account_by_username(username: str) -> Account | None:
     with _connect() as conn:
         row = conn.execute(

--- a/energetica/routers/facilitator.py
+++ b/energetica/routers/facilitator.py
@@ -6,7 +6,7 @@ here is instance-wide, not tied to *which* admin is calling, so the auth gate is
 dependency rather than a per-route parameter each handler would otherwise ignore.
 """
 
-from typing import Annotated
+from typing import Annotated, Callable, TypeVar
 
 from fastapi import APIRouter, Depends, Query
 
@@ -24,18 +24,26 @@ from energetica.utils.auth import get_admin_user
 
 router = APIRouter(prefix="/facilitator", tags=["Facilitator"], dependencies=[Depends(get_admin_user)])
 
+_T = TypeVar("_T")
 
-def _access_out() -> FacilitatorAccessOut:
-    """The current join-link settings, generating the token on first call (never rotated after).
+
+def _or_not_private(mutate: Callable[[], _T]) -> _T:
+    """Run a private-access write, translating ``InstanceNotPrivateError`` into the same
+    ``GameError`` (400) every facilitator route surfaces instead of the 500 it would otherwise be.
 
     A facilitator route only makes sense on a privately-configured instance — a public one has no
-    allowlist/join-token to show — so ``InstanceNotPrivateError`` is translated into a ``GameError``
-    (400) rather than the 500 it would otherwise surface as.
+    allowlist/join-token to mutate — and every ``instance_config`` write below raises the same
+    error for that case, so this is the one place that translation happens.
     """
     try:
-        join_token = instance_config.get_or_create_join_token()
+        return mutate()
     except instance_config.InstanceNotPrivateError as exc:
         raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE) from exc
+
+
+def _access_out() -> FacilitatorAccessOut:
+    """The current join-link settings, generating the token on first call (never rotated after)."""
+    join_token = _or_not_private(instance_config.get_or_create_join_token)
     config = instance_config.load_instance_config()
     # get_or_create_join_token() just succeeded, which only happens for a privately-configured
     # instance, so re-reading here always finds the same PrivateAccess block.
@@ -52,10 +60,7 @@ def get_access() -> FacilitatorAccessOut:
 @router.patch("/access", status_code=204)
 def update_access(access_patch: FacilitatorAccessPatch) -> None:
     """Flip whether the join link currently admits new accounts."""
-    try:
-        instance_config.set_join_open(access_patch.join_open)
-    except instance_config.InstanceNotPrivateError as exc:
-        raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE) from exc
+    _or_not_private(lambda: instance_config.set_join_open(access_patch.join_open))
 
 
 def _private_access() -> instance_config.PrivateAccess:
@@ -107,10 +112,7 @@ def add_to_roster(body: RosterAddIn) -> None:
     """
     if accounts.get_account_by_username(body.username) is None:
         raise GameError(GameExceptionType.USER_NOT_FOUND)
-    try:
-        instance_config.add_allowed_username(body.username)
-    except instance_config.InstanceNotPrivateError as exc:
-        raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE) from exc
+    _or_not_private(lambda: instance_config.add_allowed_username(body.username))
 
 
 @router.delete("/roster/{username}", status_code=204)
@@ -122,7 +124,4 @@ def remove_from_roster(username: str) -> None:
     ``username`` wasn't on the allowlist, matching :func:`instance_config.remove_allowed_username`'s
     own idempotency.
     """
-    try:
-        instance_config.remove_allowed_username(username)
-    except instance_config.InstanceNotPrivateError as exc:
-        raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE) from exc
+    _or_not_private(lambda: instance_config.remove_allowed_username(username))

--- a/energetica/routers/facilitator.py
+++ b/energetica/routers/facilitator.py
@@ -1,16 +1,25 @@
-"""Facilitator instance-admin surface: join link and the open/closed toggle (#1020).
+"""Facilitator instance-admin surface: join link/toggle (#1020) and the roster page (#1022).
 
 Exposes #1019's private-access write path (``instance_config``'s ``get_or_create_join_token`` /
-``set_join_open``) over HTTP for the facilitator settings page. Every route here is instance-wide,
-not tied to *which* admin is calling, so the auth gate is a router-level dependency rather than a
-per-route parameter each handler would otherwise ignore.
+``set_join_open`` / ``add_allowed_username`` / ``remove_allowed_username``) over HTTP. Every route
+here is instance-wide, not tied to *which* admin is calling, so the auth gate is a router-level
+dependency rather than a per-route parameter each handler would otherwise ignore.
 """
 
-from fastapi import APIRouter, Depends
+from typing import Annotated
 
-from energetica import instance_config
+from fastapi import APIRouter, Depends, Query
+
+from energetica import accounts, instance_config
+from energetica.database.user import User
 from energetica.game_error import GameError, GameExceptionType
-from energetica.schemas.facilitator import FacilitatorAccessOut, FacilitatorAccessPatch
+from energetica.schemas.facilitator import (
+    FacilitatorAccessOut,
+    FacilitatorAccessPatch,
+    FacilitatorRosterOut,
+    RosterAddIn,
+    RosterCandidatesOut,
+)
 from energetica.utils.auth import get_admin_user
 
 router = APIRouter(prefix="/facilitator", tags=["Facilitator"], dependencies=[Depends(get_admin_user)])
@@ -45,5 +54,75 @@ def update_access(access_patch: FacilitatorAccessPatch) -> None:
     """Flip whether the join link currently admits new accounts."""
     try:
         instance_config.set_join_open(access_patch.join_open)
+    except instance_config.InstanceNotPrivateError as exc:
+        raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE) from exc
+
+
+def _private_access() -> instance_config.PrivateAccess:
+    """This instance's private-access block, translating "not private" into the same
+    ``GameError`` every facilitator route uses.
+    """
+    try:
+        config = instance_config.load_instance_config()
+    except instance_config.InstanceConfigError as exc:
+        raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE) from exc
+    if config is None or not isinstance(config.access, instance_config.PrivateAccess):
+        raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE)
+    return config.access
+
+
+@router.get("/roster")
+def get_roster() -> FacilitatorRosterOut:
+    """This instance's roster, split into joined (an auto-provisioned local ``User`` already
+    exists) vs invited (allowlisted, no entry yet).
+    """
+    access = _private_access()
+    joined: list[str] = []
+    invited: list[str] = []
+    for username in access.allowed_usernames:
+        bucket = joined if next(User.filter_by(username=username), None) is not None else invited
+        bucket.append(username)
+    return FacilitatorRosterOut(joined=joined, invited=invited)
+
+
+@router.get("/roster/candidates")
+def search_roster_candidates(prefix: Annotated[str, Query(min_length=1)]) -> RosterCandidatesOut:
+    """Existing accounts whose username starts with ``prefix`` — the add control's lookup.
+
+    Doesn't require this instance to be private (searching the server-wide account store doesn't
+    touch its allowlist), so it skips :func:`_private_access` — the add-control's own POST is
+    where "this instance isn't private" would actually matter.
+    """
+    matches = accounts.search_accounts(prefix=prefix)
+    return RosterCandidatesOut(usernames=[account.username for account in matches])
+
+
+@router.post("/roster", status_code=204)
+def add_to_roster(body: RosterAddIn) -> None:
+    """Add an existing account to the roster.
+
+    No freeform username strings: an account must already exist server-wide (a facilitator can
+    only invite someone with an account, not conjure a name into the allowlist), which reuses the
+    same ``USER_NOT_FOUND`` a login rejects an unknown username with.
+    """
+    if accounts.get_account_by_username(body.username) is None:
+        raise GameError(GameExceptionType.USER_NOT_FOUND)
+    try:
+        instance_config.add_allowed_username(body.username)
+    except instance_config.InstanceNotPrivateError as exc:
+        raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE) from exc
+
+
+@router.delete("/roster/{username}", status_code=204)
+def remove_from_roster(username: str) -> None:
+    """Ban/remove: drop ``username`` from the allowlist.
+
+    Revocation is eventual — it takes effect on the account's next entry check, not an instant
+    kick of a live session (out of scope here, #677 if ever built). A no-op (still 204) if
+    ``username`` wasn't on the allowlist, matching :func:`instance_config.remove_allowed_username`'s
+    own idempotency.
+    """
+    try:
+        instance_config.remove_allowed_username(username)
     except instance_config.InstanceNotPrivateError as exc:
         raise GameError(GameExceptionType.INSTANCE_NOT_PRIVATE) from exc

--- a/energetica/schemas/facilitator.py
+++ b/energetica/schemas/facilitator.py
@@ -16,3 +16,24 @@ class FacilitatorAccessPatch(BaseModel):
     """Request body to flip whether the join link currently admits new accounts."""
 
     join_open: bool
+
+
+class FacilitatorRosterOut(BaseModel):
+    """The private instance's roster (#1022), split by whether the account has touched this
+    instance yet.
+    """
+
+    joined: list[str] = Field(description="Allowlisted usernames that already have a User on this instance.")
+    invited: list[str] = Field(description="Allowlisted usernames with no User here yet.")
+
+
+class RosterCandidatesOut(BaseModel):
+    """Existing accounts matching a roster-search prefix — the add control's lookup."""
+
+    usernames: list[str] = Field(description="Existing accounts' usernames starting with the search prefix.")
+
+
+class RosterAddIn(BaseModel):
+    """Request body to add an existing account to the roster."""
+
+    username: str = Field(description="An existing account's username to add to the private allowlist.")

--- a/frontend/src/components/facilitator/facilitator-header.tsx
+++ b/frontend/src/components/facilitator/facilitator-header.tsx
@@ -1,0 +1,62 @@
+/**
+ * Shared shell for the facilitator surfaces (#1020 join link, #1022 roster):
+ * the topbar plus a small nav between the two pages.
+ *
+ * Deliberately doesn't use `GameLayout`/`AppSidebar` — those assume a settled
+ * player (capability flags, money, workers), none of which an admin account
+ * has.
+ */
+
+import { Link, useLocation } from "@tanstack/react-router";
+
+import Logo from "@/assets/simplified_logo.svg?react";
+import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { cn } from "@/lib/utils";
+
+const NAV_LINKS = [
+    { to: "/app/facilitator", label: "Join link" },
+    { to: "/app/facilitator/roster", label: "Roster" },
+] as const;
+
+export function FacilitatorHeader() {
+    const location = useLocation();
+
+    return (
+        <header className="shrink-0 flex flex-col border-b border-border-brand bg-topbar">
+            <div className="flex h-(--topbar-height) items-center justify-between px-4">
+                <Link to="/app" className="flex items-center gap-1.5">
+                    <Logo className="size-10 fill-foreground" />
+                    <span className="font-titles text-lg">
+                        Energetica — Facilitator
+                    </span>
+                </Link>
+                <div className="flex items-center gap-2">
+                    <ThemeToggle variant="icon-only" />
+                    <Button variant="outline" asChild>
+                        <Link to="/app/logout">Log out</Link>
+                    </Button>
+                </div>
+            </div>
+            <nav className="flex gap-4 px-4">
+                {NAV_LINKS.map((link) => {
+                    const isActive = location.pathname === link.to;
+                    return (
+                        <Link
+                            key={link.to}
+                            to={link.to}
+                            className={cn(
+                                "border-b-2 px-1 pb-2 text-sm font-medium transition-colors",
+                                isActive
+                                    ? "border-foreground text-foreground"
+                                    : "border-transparent text-muted-foreground hover:text-foreground",
+                            )}
+                        >
+                            {link.label}
+                        </Link>
+                    );
+                })}
+            </nav>
+        </header>
+    );
+}

--- a/frontend/src/hooks/use-facilitator-roster.ts
+++ b/frontend/src/hooks/use-facilitator-roster.ts
@@ -24,7 +24,7 @@ export function useFacilitatorRoster() {
  */
 export function useRosterCandidates(prefix: string) {
     return useQuery({
-        queryKey: [...queryKeys.facilitator.roster, "candidates", prefix],
+        queryKey: queryKeys.facilitator.rosterCandidates(prefix),
         queryFn: () => facilitatorApi.searchRosterCandidates(prefix),
         enabled: prefix.length > 0,
     });

--- a/frontend/src/hooks/use-facilitator-roster.ts
+++ b/frontend/src/hooks/use-facilitator-roster.ts
@@ -1,0 +1,74 @@
+/**
+ * Hooks for the facilitator roster page (#1022): the joined/invited split, the
+ * add-control's account search, and the add/ban mutations.
+ */
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { facilitatorApi } from "@/lib/api/facilitator";
+import { queryClient, queryKeys } from "@/lib/query-client";
+
+/** This instance's roster, split into joined vs invited-not-yet-joined. */
+export function useFacilitatorRoster() {
+    return useQuery({
+        queryKey: queryKeys.facilitator.roster,
+        queryFn: facilitatorApi.getRoster,
+    });
+}
+
+/**
+ * Existing accounts whose username starts with `prefix` — the add control's
+ * lookup. Disabled while `prefix` is empty, matching the backend's
+ * `min_length=1` on the same query.
+ */
+export function useRosterCandidates(prefix: string) {
+    return useQuery({
+        queryKey: [...queryKeys.facilitator.roster, "candidates", prefix],
+        queryFn: () => facilitatorApi.searchRosterCandidates(prefix),
+        enabled: prefix.length > 0,
+    });
+}
+
+/**
+ * Add an existing account to the roster; it shows up under "Invited" until the
+ * account's own next entry provisions its local `User`.
+ *
+ * @example
+ *     const { mutate: addToRoster } = useAddToRoster();
+ *     addToRoster("carol");
+ */
+export function useAddToRoster() {
+    return useMutation({
+        mutationFn: (username: string) =>
+            facilitatorApi.addToRoster({ username }),
+        onSuccess: (_data, username) => {
+            toast.success(`${username} added to the roster`);
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.facilitator.roster,
+            });
+        },
+    });
+}
+
+/**
+ * Ban/remove a username from the roster. Revocation is eventual — it takes
+ * effect on the account's next entry check, not an instant kick of a live
+ * session (#677 if that's ever built).
+ *
+ * @example
+ *     const { mutate: removeFromRoster } = useRemoveFromRoster();
+ *     removeFromRoster("carol");
+ */
+export function useRemoveFromRoster() {
+    return useMutation({
+        mutationFn: (username: string) =>
+            facilitatorApi.removeFromRoster(username),
+        onSuccess: (_data, username) => {
+            toast.success(`${username} removed from the roster`);
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.facilitator.roster,
+            });
+        },
+    });
+}

--- a/frontend/src/lib/api/facilitator.ts
+++ b/frontend/src/lib/api/facilitator.ts
@@ -1,4 +1,4 @@
-/** Facilitator instance-admin API calls (#1020). */
+/** Facilitator instance-admin API calls (#1020, #1022). */
 
 import { apiClient } from "@/lib/api-client";
 import type { ApiRequestBody, ApiResponse } from "@/types/api-helpers";
@@ -17,4 +17,29 @@ export const facilitatorApi = {
     updateAccess: (
         data: ApiRequestBody<"/api/v1/facilitator/access", "patch">,
     ) => apiClient.patch<void>("/facilitator/access", data),
+
+    /** This instance's roster, split into joined vs invited-not-yet-joined. */
+    getRoster: () =>
+        apiClient.get<ApiResponse<"/api/v1/facilitator/roster", "get">>(
+            "/facilitator/roster",
+        ),
+
+    /**
+     * Existing accounts whose username starts with `prefix` — the add control's
+     * lookup.
+     */
+    searchRosterCandidates: (prefix: string) =>
+        apiClient.get<
+            ApiResponse<"/api/v1/facilitator/roster/candidates", "get">
+        >("/facilitator/roster/candidates", { params: { prefix } }),
+
+    /** Add an existing account to the roster. */
+    addToRoster: (data: ApiRequestBody<"/api/v1/facilitator/roster", "post">) =>
+        apiClient.post<void>("/facilitator/roster", data),
+
+    /** Ban/remove a username from the roster. */
+    removeFromRoster: (username: string) =>
+        apiClient.delete<void>(
+            `/facilitator/roster/${encodeURIComponent(username)}`,
+        ),
 };

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -289,6 +289,7 @@ export const queryKeys = {
     },
     facilitator: {
         access: ["facilitator", "access"] as const,
+        roster: ["facilitator", "roster"] as const,
     },
     join: {
         link: (token: string) => ["join", "link", token] as const,

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -290,6 +290,8 @@ export const queryKeys = {
     facilitator: {
         access: ["facilitator", "access"] as const,
         roster: ["facilitator", "roster"] as const,
+        rosterCandidates: (prefix: string) =>
+            ["facilitator", "roster", "candidates", prefix] as const,
     },
     join: {
         link: (token: string) => ["join", "link", token] as const,

--- a/frontend/src/lib/route-guard.test.ts
+++ b/frontend/src/lib/route-guard.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { ApiSchema } from "@/types/api-helpers";
 import type { PlayerCapabilities } from "@/types/capabilities";
 
-import { computeRedirect } from "./route-guard";
+import { computeRedirect, isAnnouncedTakeover } from "./route-guard";
 
 type User = ApiSchema<"UserOut">;
 
@@ -118,5 +118,51 @@ describe("computeRedirect", () => {
                 CAPABILITIES,
             ),
         ).toBe("/app/dashboard");
+    });
+});
+
+describe("isAnnouncedTakeover", () => {
+    // --- facilitator exemption (#1028) --------------------------------------------------------
+
+    it("exempts an admin-required route from the announced takeover", () => {
+        expect(
+            isAnnouncedTakeover({ requiredRole: "admin" }, "announced"),
+        ).toBe(false);
+    });
+
+    it("still gates a player route during the announced phase", () => {
+        expect(
+            isAnnouncedTakeover(
+                { requiredRole: "player", requiresSettledTile: true },
+                "announced",
+            ),
+        ).toBe(true);
+    });
+
+    it("still gates a public route (requiredRole: null) during the announced phase", () => {
+        expect(isAnnouncedTakeover({ requiredRole: null }, "announced")).toBe(
+            true,
+        );
+    });
+
+    it("does not take over outside the announced phase", () => {
+        expect(
+            isAnnouncedTakeover(
+                { requiredRole: "player", requiresSettledTile: true },
+                "active",
+            ),
+        ).toBe(false);
+        expect(isAnnouncedTakeover({ requiredRole: "admin" }, "active")).toBe(
+            false,
+        );
+    });
+
+    it("does not take over while the phase is unresolved", () => {
+        expect(
+            isAnnouncedTakeover(
+                { requiredRole: "player", requiresSettledTile: true },
+                undefined,
+            ),
+        ).toBe(false);
     });
 });

--- a/frontend/src/lib/route-guard.ts
+++ b/frontend/src/lib/route-guard.ts
@@ -12,10 +12,25 @@
 
 import type { StaticDataRouteOption } from "@tanstack/react-router";
 
+import type { Phase } from "@/lib/instances";
 import type { ApiSchema } from "@/types/api-helpers";
 import type { PlayerCapabilities } from "@/types/capabilities";
 
 type User = ApiSchema<"UserOut">;
+
+/**
+ * Whether the announced-phase waiting screen (`__root.tsx`, #862) takes over
+ * rendering instead of the requested route. A facilitator route (`requiredRole:
+ * "admin"`) has no in-game session to wait on — inviting and managing the
+ * roster (#1022) is exactly what a facilitator needs to do _before_ the run
+ * starts — so it's exempt.
+ */
+export function isAnnouncedTakeover(
+    routeConfig: StaticDataRouteOption["routeConfig"],
+    phase: Phase | undefined,
+): boolean {
+    return phase === "announced" && routeConfig?.requiredRole !== "admin";
+}
 
 export function computeRedirect(
     routeConfig: StaticDataRouteOption["routeConfig"],

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -37,6 +37,7 @@ import { Route as AppFacilitiesPowerRouteImport } from './routes/app/facilities/
 import { Route as AppFacilitiesManageRouteImport } from './routes/app/facilities/manage'
 import { Route as AppFacilitiesFunctionalRouteImport } from './routes/app/facilities/functional'
 import { Route as AppFacilitiesExtractionRouteImport } from './routes/app/facilities/extraction'
+import { Route as AppFacilitatorRosterRouteImport } from './routes/app/facilitator/roster'
 import { Route as AppDashboardQuizRouteImport } from './routes/app/dashboard/quiz'
 import { Route as AppCommunityResourceMarketRouteImport } from './routes/app/community/resource-market'
 import { Route as AppCommunityMessagesRouteImport } from './routes/app/community/messages'
@@ -186,6 +187,11 @@ const AppFacilitiesExtractionRoute = AppFacilitiesExtractionRouteImport.update({
   path: '/app/facilities/extraction',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AppFacilitatorRosterRoute = AppFacilitatorRosterRouteImport.update({
+  id: '/app/facilitator/roster',
+  path: '/app/facilitator/roster',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AppDashboardQuizRoute = AppDashboardQuizRouteImport.update({
   id: '/quiz',
   path: '/quiz',
@@ -233,6 +239,7 @@ export interface FileRoutesByFullPath {
   '/app/community/messages': typeof AppCommunityMessagesRoute
   '/app/community/resource-market': typeof AppCommunityResourceMarketRoute
   '/app/dashboard/quiz': typeof AppDashboardQuizRoute
+  '/app/facilitator/roster': typeof AppFacilitatorRosterRoute
   '/app/facilities/extraction': typeof AppFacilitiesExtractionRoute
   '/app/facilities/functional': typeof AppFacilitiesFunctionalRoute
   '/app/facilities/manage': typeof AppFacilitiesManageRoute
@@ -269,6 +276,7 @@ export interface FileRoutesByTo {
   '/app/community/messages': typeof AppCommunityMessagesRoute
   '/app/community/resource-market': typeof AppCommunityResourceMarketRoute
   '/app/dashboard/quiz': typeof AppDashboardQuizRoute
+  '/app/facilitator/roster': typeof AppFacilitatorRosterRoute
   '/app/facilities/extraction': typeof AppFacilitiesExtractionRoute
   '/app/facilities/functional': typeof AppFacilitiesFunctionalRoute
   '/app/facilities/manage': typeof AppFacilitiesManageRoute
@@ -306,6 +314,7 @@ export interface FileRoutesById {
   '/app/community/messages': typeof AppCommunityMessagesRoute
   '/app/community/resource-market': typeof AppCommunityResourceMarketRoute
   '/app/dashboard/quiz': typeof AppDashboardQuizRoute
+  '/app/facilitator/roster': typeof AppFacilitatorRosterRoute
   '/app/facilities/extraction': typeof AppFacilitiesExtractionRoute
   '/app/facilities/functional': typeof AppFacilitiesFunctionalRoute
   '/app/facilities/manage': typeof AppFacilitiesManageRoute
@@ -344,6 +353,7 @@ export interface FileRouteTypes {
     | '/app/community/messages'
     | '/app/community/resource-market'
     | '/app/dashboard/quiz'
+    | '/app/facilitator/roster'
     | '/app/facilities/extraction'
     | '/app/facilities/functional'
     | '/app/facilities/manage'
@@ -380,6 +390,7 @@ export interface FileRouteTypes {
     | '/app/community/messages'
     | '/app/community/resource-market'
     | '/app/dashboard/quiz'
+    | '/app/facilitator/roster'
     | '/app/facilities/extraction'
     | '/app/facilities/functional'
     | '/app/facilities/manage'
@@ -416,6 +427,7 @@ export interface FileRouteTypes {
     | '/app/community/messages'
     | '/app/community/resource-market'
     | '/app/dashboard/quiz'
+    | '/app/facilitator/roster'
     | '/app/facilities/extraction'
     | '/app/facilities/functional'
     | '/app/facilities/manage'
@@ -452,6 +464,7 @@ export interface RootRouteChildren {
   AppCommunityMapRoute: typeof AppCommunityMapRoute
   AppCommunityMessagesRoute: typeof AppCommunityMessagesRoute
   AppCommunityResourceMarketRoute: typeof AppCommunityResourceMarketRoute
+  AppFacilitatorRosterRoute: typeof AppFacilitatorRosterRoute
   AppFacilitiesExtractionRoute: typeof AppFacilitiesExtractionRoute
   AppFacilitiesFunctionalRoute: typeof AppFacilitiesFunctionalRoute
   AppFacilitiesManageRoute: typeof AppFacilitiesManageRoute
@@ -674,6 +687,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppFacilitiesExtractionRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/app/facilitator/roster': {
+      id: '/app/facilitator/roster'
+      path: '/app/facilitator/roster'
+      fullPath: '/app/facilitator/roster'
+      preLoaderRoute: typeof AppFacilitatorRosterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/app/dashboard/quiz': {
       id: '/app/dashboard/quiz'
       path: '/quiz'
@@ -743,6 +763,7 @@ const rootRouteChildren: RootRouteChildren = {
   AppCommunityMapRoute: AppCommunityMapRoute,
   AppCommunityMessagesRoute: AppCommunityMessagesRoute,
   AppCommunityResourceMarketRoute: AppCommunityResourceMarketRoute,
+  AppFacilitatorRosterRoute: AppFacilitatorRosterRoute,
   AppFacilitiesExtractionRoute: AppFacilitiesExtractionRoute,
   AppFacilitiesFunctionalRoute: AppFacilitiesFunctionalRoute,
   AppFacilitiesManageRoute: AppFacilitiesManageRoute,

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -13,7 +13,7 @@ import { useCapabilities } from "@/hooks/use-capabilities";
 import { useGameEngine } from "@/hooks/use-game";
 import { usePhase } from "@/hooks/use-phase";
 import { lobbyLoginHref } from "@/lib/instances";
-import { computeRedirect } from "@/lib/route-guard";
+import { computeRedirect, isAnnouncedTakeover } from "@/lib/route-guard";
 
 export const Route = createRootRoute({
     staticData: { title: "", routeConfig: { requiredRole: null } },
@@ -53,10 +53,16 @@ function RootComponent() {
     // `undefined` while the engine config loads or on an unconfigured/open-ended run — mirroring the
     // backend's fail-open-to-active phase read (#861). Freeze/ended stay ungated here (that in-game
     // read-only surface is T8, #866).
+    // Facilitator (`requiredRole: "admin"`) routes are exempt (#1028): a facilitator manages the
+    // roster and join link precisely during this pre-start window, and the backend imposes no
+    // phase gate on those endpoints.
     // `phase === "announced"` already implies `engine.starts_at` is set (usePhase returns undefined
     // otherwise); the render branch below narrows it for the prop.
     const announced =
-        authResolved && isAuthenticated && !!user && phase === "announced";
+        authResolved &&
+        isAuthenticated &&
+        !!user &&
+        isAnnouncedTakeover(routeConfig, phase);
     const redirectTo =
         !announced && authResolved && isAuthenticated && user
             ? computeRedirect(routeConfig, user, capabilities)

--- a/frontend/src/routes/app/facilitator/index.tsx
+++ b/frontend/src/routes/app/facilitator/index.tsx
@@ -7,11 +7,11 @@
  * has. This page is a small, self-contained shell instead.
  */
 
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { Check, Copy } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import Logo from "@/assets/simplified_logo.svg?react";
+import { FacilitatorHeader } from "@/components/facilitator/facilitator-header";
 import { JoinQrCode } from "@/components/facilitator/join-qr-code";
 import {
     Card,
@@ -26,7 +26,6 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { TypographyH2, TypographyMuted } from "@/components/ui/typography";
 import {
     useFacilitatorAccess,
@@ -56,25 +55,6 @@ export const Route = createFileRoute("/app/facilitator/")({
         infoDialog: { contents: <FacilitatorHelp /> },
     },
 });
-
-function FacilitatorHeader() {
-    return (
-        <header className="shrink-0 flex h-(--topbar-height) items-center justify-between border-b border-border-brand bg-topbar px-4">
-            <Link to="/app" className="flex items-center gap-1.5">
-                <Logo className="size-10 fill-foreground" />
-                <span className="font-titles text-lg">
-                    Energetica — Facilitator
-                </span>
-            </Link>
-            <div className="flex items-center gap-2">
-                <ThemeToggle variant="icon-only" />
-                <Button variant="outline" asChild>
-                    <Link to="/app/logout">Log out</Link>
-                </Button>
-            </div>
-        </header>
-    );
-}
 
 function FacilitatorPage() {
     return (

--- a/frontend/src/routes/app/facilitator/roster.tsx
+++ b/frontend/src/routes/app/facilitator/roster.tsx
@@ -1,0 +1,251 @@
+/**
+ * Facilitator roster page (#1022): the private instance's allowlist, split into
+ * joined vs invited-not-yet-joined, plus a search-and-add control and a
+ * ban/remove action per row.
+ */
+
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+import { FacilitatorHeader } from "@/components/facilitator/facilitator-header";
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    InfoBanner,
+} from "@/components/ui";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyH2, TypographyMuted } from "@/components/ui/typography";
+import {
+    useAddToRoster,
+    useFacilitatorRoster,
+    useRemoveFromRoster,
+    useRosterCandidates,
+} from "@/hooks/use-facilitator-roster";
+import { getUserFriendlyError } from "@/lib/error-utils";
+
+function RosterHelp() {
+    return (
+        <div className="space-y-3">
+            <p>
+                <strong>Joined</strong> accounts have already entered this
+                instance. <strong>Invited</strong> accounts are allowlisted but
+                haven't shown up yet.
+            </p>
+            <p>
+                Banning removes an account from the allowlist — its next entry
+                attempt is denied. It doesn't interrupt a session already in
+                progress.
+            </p>
+        </div>
+    );
+}
+
+export const Route = createFileRoute("/app/facilitator/roster")({
+    component: RosterPage,
+    staticData: {
+        title: "Roster",
+        routeConfig: { requiredRole: "admin" },
+        infoDialog: { contents: <RosterHelp /> },
+    },
+});
+
+function RosterPage() {
+    return (
+        <div className="flex min-h-svh flex-col">
+            <FacilitatorHeader />
+            <main className="flex-1 overflow-auto p-4 md:p-8">
+                <div className="max-w-2xl mx-auto space-y-6">
+                    <AddAccountCard />
+                    <RosterCard />
+                </div>
+            </main>
+        </div>
+    );
+}
+
+function AddAccountCard() {
+    const [query, setQuery] = useState("");
+    const [debouncedQuery, setDebouncedQuery] = useState("");
+
+    // Debounce the search-as-you-type prefix so every keystroke doesn't fire a request.
+    useEffect(() => {
+        const timeout = setTimeout(() => setDebouncedQuery(query.trim()), 300);
+        return () => clearTimeout(timeout);
+    }, [query]);
+
+    const { data, isFetching } = useRosterCandidates(debouncedQuery);
+    const {
+        mutate: addToRoster,
+        isPending,
+        variables: pendingUsername,
+    } = useAddToRoster();
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>
+                    <TypographyH2>Add to roster</TypographyH2>
+                </CardTitle>
+                <TypographyMuted>
+                    Search for an existing account by username and add it to
+                    this instance's allowlist.
+                </TypographyMuted>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                <Input
+                    placeholder="Search by username…"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                />
+                {debouncedQuery.length > 0 && (
+                    <div className="divide-y rounded-md border">
+                        {isFetching && !data ? (
+                            <div className="flex justify-center p-3">
+                                <Spinner />
+                            </div>
+                        ) : data && data.usernames.length > 0 ? (
+                            data.usernames.map((username) => (
+                                <div
+                                    key={username}
+                                    className="flex items-center justify-between px-3 py-2"
+                                >
+                                    <span className="text-sm">{username}</span>
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        disabled={
+                                            isPending &&
+                                            pendingUsername === username
+                                        }
+                                        onClick={() => addToRoster(username)}
+                                    >
+                                        {isPending &&
+                                        pendingUsername === username ? (
+                                            <Spinner />
+                                        ) : (
+                                            "Add"
+                                        )}
+                                    </Button>
+                                </div>
+                            ))
+                        ) : (
+                            <p className="px-3 py-2 text-sm text-muted-foreground">
+                                No matching accounts.
+                            </p>
+                        )}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function RosterCard() {
+    const { data, isLoading, isError, error } = useFacilitatorRoster();
+    const {
+        mutate: removeFromRoster,
+        isPending,
+        variables: pendingUsername,
+    } = useRemoveFromRoster();
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-12">
+                <Spinner />
+            </div>
+        );
+    }
+
+    if (isError || !data) {
+        return (
+            <InfoBanner variant="error">
+                {getUserFriendlyError(error)}
+            </InfoBanner>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <RosterSection
+                title="Joined"
+                usernames={data.joined}
+                emptyLabel="No one has joined yet."
+                onBan={removeFromRoster}
+                pendingUsername={isPending ? pendingUsername : null}
+            />
+            <RosterSection
+                title="Invited"
+                usernames={data.invited}
+                emptyLabel="No pending invites."
+                onBan={removeFromRoster}
+                pendingUsername={isPending ? pendingUsername : null}
+            />
+        </div>
+    );
+}
+
+function RosterSection({
+    title,
+    usernames,
+    emptyLabel,
+    onBan,
+    pendingUsername,
+}: {
+    title: string;
+    usernames: string[];
+    emptyLabel: string;
+    onBan: (username: string) => void;
+    pendingUsername: string | null;
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>
+                    <TypographyH2>
+                        {title} ({usernames.length})
+                    </TypographyH2>
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {usernames.length === 0 ? (
+                    <TypographyMuted>{emptyLabel}</TypographyMuted>
+                ) : (
+                    <ul className="divide-y">
+                        {usernames.map((username) => (
+                            <li
+                                key={username}
+                                className="flex items-center justify-between py-2"
+                            >
+                                <span className="text-sm">{username}</span>
+                                <ConfirmDialog
+                                    trigger={
+                                        <Button
+                                            size="sm"
+                                            variant="destructive"
+                                            disabled={
+                                                pendingUsername === username
+                                            }
+                                        >
+                                            Ban
+                                        </Button>
+                                    }
+                                    title={`Ban ${username}?`}
+                                    description={`This removes ${username} from the allowlist. Their next entry attempt is denied — a session already in progress isn't interrupted.`}
+                                    confirmLabel="Ban"
+                                    variant="danger"
+                                    isPending={pendingUsername === username}
+                                    onConfirm={() => onBan(username)}
+                                />
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -839,6 +839,84 @@ export interface paths {
         patch: operations["update_access_api_v1_facilitator_access_patch"];
         trace?: never;
     };
+    "/api/v1/facilitator/roster": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Roster
+         * @description This instance's roster, split into joined (an auto-provisioned local ``User`` already
+         *     exists) vs invited (allowlisted, no entry yet).
+         */
+        get: operations["get_roster_api_v1_facilitator_roster_get"];
+        put?: never;
+        /**
+         * Add To Roster
+         * @description Add an existing account to the roster.
+         *
+         *     No freeform username strings: an account must already exist server-wide (a facilitator can
+         *     only invite someone with an account, not conjure a name into the allowlist), which reuses the
+         *     same ``USER_NOT_FOUND`` a login rejects an unknown username with.
+         */
+        post: operations["add_to_roster_api_v1_facilitator_roster_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/facilitator/roster/candidates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search Roster Candidates
+         * @description Existing accounts whose username starts with ``prefix`` — the add control's lookup.
+         *
+         *     Doesn't require this instance to be private (searching the server-wide account store doesn't
+         *     touch its allowlist), so it skips :func:`_private_access` — the add-control's own POST is
+         *     where "this instance isn't private" would actually matter.
+         */
+        get: operations["search_roster_candidates_api_v1_facilitator_roster_candidates_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/facilitator/roster/{username}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Remove From Roster
+         * @description Ban/remove: drop ``username`` from the allowlist.
+         *
+         *     Revocation is eventual — it takes effect on the account's next entry check, not an instant
+         *     kick of a live session (out of scope here, #677 if ever built). A no-op (still 204) if
+         *     ``username`` wasn't on the allowlist, matching :func:`instance_config.remove_allowed_username`'s
+         *     own idempotency.
+         */
+        delete: operations["remove_from_roster_api_v1_facilitator_roster__username__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/facilities": {
         parameters: {
             query?: never;
@@ -1006,9 +1084,11 @@ export interface paths {
          *     Requires an SSO session (``get_current_account``, not ``get_settled_player`` — the whole point
          *     is this runs *before* the visitor is access-allowed, so no local ``User`` need exist yet) but
          *     deliberately does not go through ``_enforce_instance_access``: granting access is this
-         *     endpoint's job, not a precondition for reaching it. Re-checks ``join_open`` server-side (not
-         *     just trusted from the page's last ``GET``) so a facilitator flipping the toggle mid-visit is
-         *     the outcome that wins, not a stale client.
+         *     endpoint's job, not a precondition for reaching it. Checks identity before instance state
+         *     (mirrors ``get_admin_user``/``get_settled_player``'s "who, then what" order elsewhere in this
+         *     codebase) and re-checks ``join_open`` server-side rather than trusting the page's last
+         *     ``GET``, so a facilitator flipping the toggle mid-visit is the outcome that wins, not a stale
+         *     client.
          */
         post: operations["confirm_join_api_v1_join__token__post"];
         delete?: never;
@@ -2455,6 +2535,23 @@ export interface components {
             /** Join Open */
             join_open: boolean;
         };
+        /**
+         * FacilitatorRosterOut
+         * @description The private instance's roster (#1022), split by whether the account has touched this
+         *     instance yet.
+         */
+        FacilitatorRosterOut: {
+            /**
+             * Joined
+             * @description Allowlisted usernames that already have a User on this instance.
+             */
+            joined: string[];
+            /**
+             * Invited
+             * @description Allowlisted usernames with no User here yet.
+             */
+            invited: string[];
+        };
         /** FacilitiesListOut */
         FacilitiesListOut: {
             /** Power Facilities */
@@ -3689,6 +3786,28 @@ export interface components {
             series: {
                 [key: string]: number[];
             };
+        };
+        /**
+         * RosterAddIn
+         * @description Request body to add an existing account to the roster.
+         */
+        RosterAddIn: {
+            /**
+             * Username
+             * @description An existing account's username to add to the private allowlist.
+             */
+            username: string;
+        };
+        /**
+         * RosterCandidatesOut
+         * @description Existing accounts matching a roster-search prefix — the add control's lookup.
+         */
+        RosterCandidatesOut: {
+            /**
+             * Usernames
+             * @description Existing accounts' usernames starting with the search prefix.
+             */
+            usernames: string[];
         };
         /**
          * SettingsOut
@@ -5548,6 +5667,117 @@ export interface operations {
                 "application/json": components["schemas"]["FacilitatorAccessPatch"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_roster_api_v1_facilitator_roster_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FacilitatorRosterOut"];
+                };
+            };
+        };
+    };
+    add_to_roster_api_v1_facilitator_roster_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RosterAddIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    search_roster_candidates_api_v1_facilitator_roster_candidates_get: {
+        parameters: {
+            query: {
+                prefix: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RosterCandidatesOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_from_roster_api_v1_facilitator_roster__username__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             204: {

--- a/frontend/src/types/app-routes.ts
+++ b/frontend/src/types/app-routes.ts
@@ -13,6 +13,7 @@ export type AppRoute =
     | "/app/community/messages"
     | "/app/community/resource-market"
     | "/app/dashboard/quiz"
+    | "/app/facilitator/roster"
     | "/app/facilities/extraction"
     | "/app/facilities/functional"
     | "/app/facilities/manage"

--- a/tests/integration/test_facilitator_router.py
+++ b/tests/integration/test_facilitator_router.py
@@ -139,3 +139,165 @@ def test_get_on_a_public_instance_fails_with_a_game_error(instance_json: Path) -
     response = client.get(ACCESS_URL)
     assert response.status_code == 400
     assert response.json()["game_exception_type"] == "INSTANCE_NOT_PRIVATE"
+
+
+# --- Roster: view, manual add, ban (#1022) -------------------------------------------------------
+
+ROSTER_URL = f"http://localhost:{PORT}/api/v1/facilitator/roster"
+
+
+def _candidates_url(prefix: str) -> str:
+    return f"{ROSTER_URL}/candidates?prefix={prefix}"
+
+
+def test_roster_rejects_a_non_admin(instance_json: Path) -> None:
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+    account_id = make_account("alice", "pw")
+    User(username="alice", pwhash="unused", role="player", account_id=account_id)
+    authenticate(client, account_id)
+
+    assert client.get(ROSTER_URL).status_code == 403
+    assert client.get(_candidates_url("a")).status_code == 403
+    assert client.post(ROSTER_URL, json={"username": "alice"}).status_code == 403
+    assert client.delete(f"{ROSTER_URL}/alice").status_code == 403
+
+
+def test_roster_splits_joined_and_invited(instance_json: Path) -> None:
+    """"alice" is allowlisted (by ``PRIVATE_JSON``) and has a local User (joined); "bob" is
+    allowlisted via the add endpoint but has never touched this instance (invited).
+    """
+    client = _admin_client(instance_json)  # PRIVATE_JSON allowlists "alice"
+    alice_id = make_account("alice", "pw")
+    User(username="alice", pwhash="unused", role="player", account_id=alice_id)
+    make_account("bob", "pw")  # server-wide account exists, but no local User yet
+    assert client.post(ROSTER_URL, json={"username": "bob"}).status_code == 204
+
+    response = client.get(ROSTER_URL)
+
+    assert response.status_code == 200
+    assert response.json() == {"joined": ["alice"], "invited": ["bob"]}
+
+
+def test_roster_get_on_a_public_instance_fails_with_a_game_error(instance_json: Path) -> None:
+    _write(instance_json, PUBLIC_JSON)
+    client = _client()
+    account_id = make_account("prof", "pw")
+    User(username="prof", pwhash="unused", role="admin", account_id=account_id)
+    authenticate(client, account_id)
+
+    response = client.get(ROSTER_URL)
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "INSTANCE_NOT_PRIVATE"
+
+
+def test_roster_candidates_returns_matching_accounts(instance_json: Path) -> None:
+    client = _admin_client(instance_json)
+    make_account("carol", "pw")
+    make_account("caroline", "pw")
+    make_account("dave", "pw")
+
+    response = client.get(_candidates_url("car"))
+
+    assert response.status_code == 200
+    # Alphabetical: "carol" sorts before "caroline" (it's a prefix of it).
+    assert response.json() == {"usernames": ["carol", "caroline"]}
+
+
+def test_roster_candidates_does_not_require_a_private_instance(instance_json: Path) -> None:
+    """Searching the server-wide account store doesn't touch this instance's allowlist, so it
+    works even before/without a private config — unlike every other roster route.
+    """
+    _write(instance_json, PUBLIC_JSON)
+    client = _client()
+    account_id = make_account("prof", "pw")
+    User(username="prof", pwhash="unused", role="admin", account_id=account_id)
+    authenticate(client, account_id)
+    make_account("carol", "pw")
+
+    response = client.get(_candidates_url("car"))
+
+    assert response.status_code == 200
+    assert response.json() == {"usernames": ["carol"]}
+
+
+def test_roster_post_adds_an_existing_account_and_it_appears_as_invited(instance_json: Path) -> None:
+    client = _admin_client(instance_json)
+    make_account("carol", "pw")
+
+    response = client.post(ROSTER_URL, json={"username": "carol"})
+
+    assert response.status_code == 204
+    on_disk = json.loads(instance_json.read_text())
+    assert "carol" in on_disk["access"]["allowed_usernames"]
+    assert client.get(ROSTER_URL).json()["invited"] == ["alice", "carol"]
+
+
+def test_roster_post_rejects_a_username_with_no_matching_account(instance_json: Path) -> None:
+    """No freeform username strings — only an existing account can be added."""
+    client = _admin_client(instance_json)
+
+    response = client.post(ROSTER_URL, json={"username": "ghost"})
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "USER_NOT_FOUND"
+    on_disk = json.loads(instance_json.read_text())
+    assert "ghost" not in on_disk["access"]["allowed_usernames"]
+
+
+def test_roster_post_on_a_public_instance_fails_with_a_game_error(instance_json: Path) -> None:
+    _write(instance_json, PUBLIC_JSON)
+    client = _client()
+    account_id = make_account("prof", "pw")
+    User(username="prof", pwhash="unused", role="admin", account_id=account_id)
+    authenticate(client, account_id)
+    make_account("carol", "pw")
+
+    response = client.post(ROSTER_URL, json={"username": "carol"})
+
+    assert response.status_code == 400
+    assert response.json()["game_exception_type"] == "INSTANCE_NOT_PRIVATE"
+
+
+def test_roster_delete_removes_from_the_allowlist(instance_json: Path) -> None:
+    client = _admin_client(instance_json)  # "alice" is already allowlisted
+
+    response = client.delete(f"{ROSTER_URL}/alice")
+
+    assert response.status_code == 204
+    on_disk = json.loads(instance_json.read_text())
+    assert "alice" not in on_disk["access"]["allowed_usernames"]
+
+
+def test_roster_delete_denies_the_banned_account_on_its_next_entry_attempt(instance_json: Path) -> None:
+    """One shared client, swapping which account's cookie is set — a second ``_client()`` would
+    spin up a second engine and lose the first's state (see the module docstring's single-app
+    convention followed throughout this file and ``test_join_router.py``).
+    """
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+    admin_id = make_account("prof", "pw")
+    User(username="prof", pwhash="unused", role="admin", account_id=admin_id)
+    carol_id = make_account("carol", "pw")
+
+    authenticate(client, admin_id)
+    assert client.post(ROSTER_URL, json={"username": "carol"}).status_code == 204
+
+    authenticate(client, carol_id)
+    assert client.get(f"http://localhost:{PORT}/api/v1/auth/me").status_code == 200
+
+    authenticate(client, admin_id)
+    response = client.delete(f"{ROSTER_URL}/carol")
+    assert response.status_code == 204
+
+    authenticate(client, carol_id)
+    assert client.get(f"http://localhost:{PORT}/api/v1/auth/me").status_code == 403
+
+
+def test_roster_delete_is_a_noop_for_an_unlisted_username(instance_json: Path) -> None:
+    client = _admin_client(instance_json)
+
+    response = client.delete(f"{ROSTER_URL}/never-invited")
+
+    assert response.status_code == 204

--- a/tests/unit/test_accounts_db.py
+++ b/tests/unit/test_accounts_db.py
@@ -85,3 +85,52 @@ def test_update_password_changes_stored_hash(accounts_db: Path) -> None:
 
     assert accounts.verify_password(username="alice", password="old-pw") is False
     assert accounts.verify_password(username="alice", password="new-pw") is True
+
+
+# --- search_accounts (#1022) --------------------------------------------------------------------
+#
+# Backs the facilitator roster's add control: looking up an existing account by username prefix
+# so the facilitator can only add an account that actually exists (no freeform username strings).
+
+
+def test_search_accounts_matches_by_prefix(accounts_db: Path) -> None:
+    accounts.create_account(username="alice", pwhash="hash")
+    accounts.create_account(username="alicia", pwhash="hash")
+    accounts.create_account(username="bob", pwhash="hash")
+
+    matches = accounts.search_accounts(prefix="ali")
+
+    assert [account.username for account in matches] == ["alice", "alicia"]
+
+
+def test_search_accounts_is_case_sensitive_like_the_rest_of_the_store(accounts_db: Path) -> None:
+    """Matches ``get_account_by_username``'s exact-match convention: no case folding."""
+    accounts.create_account(username="Alice", pwhash="hash")
+
+    assert accounts.search_accounts(prefix="ali") == []
+    assert [account.username for account in accounts.search_accounts(prefix="Ali")] == ["Alice"]
+
+
+def test_search_accounts_no_match_returns_empty_list(accounts_db: Path) -> None:
+    accounts.create_account(username="alice", pwhash="hash")
+
+    assert accounts.search_accounts(prefix="zzz") == []
+
+
+def test_search_accounts_treats_percent_and_underscore_as_literal(accounts_db: Path) -> None:
+    """A prefix containing SQL ``LIKE`` wildcards must not match unrelated usernames."""
+    accounts.create_account(username="a_b", pwhash="hash")
+    accounts.create_account(username="axb", pwhash="hash")
+
+    matches = accounts.search_accounts(prefix="a_")
+
+    assert [account.username for account in matches] == ["a_b"]
+
+
+def test_search_accounts_caps_results_at_limit(accounts_db: Path) -> None:
+    for i in range(5):
+        accounts.create_account(username=f"player{i}", pwhash="hash")
+
+    matches = accounts.search_accounts(prefix="player", limit=3)
+
+    assert len(matches) == 3


### PR DESCRIPTION
Closes #1022.

Stacked on #1027 (#1021), which is stacked on #1026 (#1020), which is stacked on #1025 (#1019).

## What

The facilitator-only roster page on top of #1019's private-access write path and #1020's facilitator router:

- `GET /facilitator/roster` splits the private instance's allowlist into **Joined** (a local `User` already exists) and **Invited** (allowlisted, no entry yet).
- `GET /facilitator/roster/candidates?prefix=` looks up existing accounts by username prefix (`accounts.search_accounts`, new in `accounts/db.py`) so the add control can only add an account that actually exists — no freeform username strings.
- `POST /facilitator/roster` adds an existing account to the allowlist; rejects a username with no matching account (`USER_NOT_FOUND`).
- `DELETE /facilitator/roster/{username}` bans/removes it. Revocation is eventual — it denies the account's next entry attempt, without kicking an already-live session (#677 if that's ever built).

Frontend: a new `/app/facilitator/roster` page (search-and-add card + Joined/Invited lists with a ban confirmation dialog), a small nav shared with the existing join-link page via a new `FacilitatorHeader` component, and the matching API client/hooks.

## Testing

- Backend: new integration tests in `tests/integration/test_facilitator_router.py` (roster split, candidate search, add, ban, non-admin/non-private rejections) and unit tests in `tests/unit/test_accounts_db.py` for `search_accounts`. Full suite: 286 passed.
- Frontend: `bun run typecheck`, `bun run lint`, `bun run test` all clean.
- Ran through `/code-review` (Standards + Spec axes) — findings fixed in a follow-up commit (dedupe row mapping, error translation, query key convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds facilitator roster management for private instances, backed by server-wide account lookup and typed frontend APIs.
- Adds authenticated roster view, candidate search, allowlist addition, and removal endpoints.
- Adds a facilitator roster page with debounced account search, joined/invited sections, and ban confirmation.
- Refactors the facilitator shell into shared navigation and updates generated API and route contracts.

<h3>Confidence Score: 4/5</h3>

The pre-start route takeover should be fixed before merging because it prevents facilitators from managing the new roster during the primary invitation window.

The backend roster operations are consistently gated and synchronized, but the frontend root replaces the new admin route with the announced waiting screen before the game begins.

**Files Needing Attention:** frontend/src/routes/app/facilitator/roster.tsx and frontend/src/routes/__root.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| energetica/accounts/db.py | Adds escaped, case-sensitive prefix account search and consolidates account-row mapping without an accepted defect. |
| energetica/routers/facilitator.py | Adds admin-gated roster reads and allowlist mutations with private-instance error translation. |
| frontend/src/routes/app/facilitator/roster.tsx | Adds the complete roster interface, but its route is replaced by the global waiting screen before the game starts. |
| frontend/src/hooks/use-facilitator-roster.ts | Adds roster queries and mutations with correctly aligned query keys and roster invalidation. |
| frontend/src/components/facilitator/facilitator-header.tsx | Extracts shared facilitator navigation and preserves role-aware navigation through `/app`. |
| tests/integration/test_facilitator_router.py | Covers backend authorization, private-instance behavior, roster splitting, candidate search, addition, and removal, but not the frontend pre-start route gate. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant F as Facilitator
    participant UI as Roster page
    participant API as Facilitator API
    participant Accounts as Account store
    participant Config as Instance access config
    F->>UI: Search username prefix
    UI->>API: GET /facilitator/roster/candidates
    API->>Accounts: Search existing accounts
    Accounts-->>UI: Matching usernames
    F->>UI: Add selected account
    UI->>API: POST /facilitator/roster
    API->>Accounts: Verify exact account
    API->>Config: Add allowed username
    Config-->>UI: 204
    UI->>API: GET /facilitator/roster
    API-->>UI: Joined and invited usernames
    F->>UI: Confirm ban
    UI->>API: "DELETE /facilitator/roster/{username}"
    API->>Config: Remove allowed username
```

<sub>Reviews (1): Last reviewed commit: ["review(facilitator): dedupe row mapping,..."](https://github.com/felixvonsamson/energetica/commit/ea65b815d2c4c3c1a2105fd0d22189c4fd46a689) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57279851)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Game API routing](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/game-api-routing.md)
- Knowledge Base — [Identity and account persistence](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/identity-and-account-persistence.md)
- Knowledge Base — [Game web client](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/game-web-client.md)
</details>


<!-- /greptile_comment -->