### PR TITLE
fix(facilitator): poll the roster query so it self-refreshes

### DIFF
--- a/frontend/src/hooks/use-facilitator-roster.ts
+++ b/frontend/src/hooks/use-facilitator-roster.ts
@@ -9,11 +9,23 @@ import { toast } from "sonner";
 import { facilitatorApi } from "@/lib/api/facilitator";
 import { queryClient, queryKeys } from "@/lib/query-client";
 
-/** This instance's roster, split into joined vs invited-not-yet-joined. */
+/**
+ * This instance's roster, split into joined vs invited-not-yet-joined.
+ *
+ * Polls on a real `refetchInterval` (#1033), not just a `staleTime` like most
+ * other list-y hooks in this codebase — those rely on the query client's global
+ * refetch-on-focus/mount to catch up, which never fires for a facilitator tab
+ * that's sitting open and in the foreground while a roster change (another
+ * facilitator's tab, or an invited account settling in) happens elsewhere. A
+ * short interval is this page's own backstop until it moves onto push-based
+ * updates (see the issue for why that's a bigger change than this hook alone).
+ */
 export function useFacilitatorRoster() {
     return useQuery({
         queryKey: queryKeys.facilitator.roster,
         queryFn: facilitatorApi.getRoster,
+        staleTime: 5 * 1000, // 5 seconds, matched to refetchInterval below
+        refetchInterval: 5 * 1000,
     });
 }
 


### PR DESCRIPTION
## What's wrong

`useFacilitatorRoster` had no `staleTime`/`refetchInterval`, and nothing else
invalidated its query key except this browser's own add/ban mutations. So the
roster only updated on this tab's own writes — an account settling in, or a
second facilitator tab/device adding or banning someone, wasn't reflected
until a manual reload.

## Fix

Give the query a real 5s `refetchInterval`, not just a `staleTime` like most
other list-y hooks in this codebase use. That convention relies on the query
client's global refetch-on-focus/mount defaults, which never fire for a tab
that's sitting open and in the foreground the whole time — exactly the
scenario that exposed this bug (two facilitator tabs open side by side).

`staleTime` is matched to the same 5s so a focus/mount refetch mid-cycle
doesn't add a redundant extra request. `refetchIntervalInBackground` is left
at its default (polling pauses while the tab is hidden, resumes on
visibility). The existing add/remove mutations' immediate
`invalidateQueries` calls are untouched — they still give instant feedback to
the tab that acted; the poll is just the backstop for everyone else.

## Not in scope

Push-based updates over the existing Socket.IO channel would be the more
"real" fix, but that connection is scoped to authenticated players only
today (`docs/architecture/real-time-sync.md`) — extending it to facilitators
is a bigger change than this hook alone (new connection-policy decision,
facilitator socket tracking, invalidate call sites at every roster-mutating
site). Left as a documented follow-up in the issue rather than done here.

Fixes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds five-second polling to the facilitator roster query so externally initiated roster changes appear without a manual reload.
- Matches the query's stale time to the polling interval.
- Preserves immediate invalidation after local add and remove mutations.
- Leaves background polling disabled by default.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the polling behavior directly addresses stale foreground roster data without changing mutation, authorization, or data-shaping behavior.

The roster query now refreshes every five seconds while its sole route-scoped consumer is mounted, pauses under the intended background-tab default, and retains immediate invalidation for local mutations.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/hooks/use-facilitator-roster.ts | Adds a route-scoped five-second roster refresh interval with matching cache staleness; no actionable correctness issue was identified. |

<sub>Reviews (1): Last reviewed commit: ["fix(facilitator): poll the roster query ..."](https://github.com/felixvonsamson/energetica/commit/4e541f499de61496999766444e0a0eaabf694a1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58423861)</sub>

<!-- /greptile_comment -->