### PR TITLE
hotfix: update scripts and docs so that the lobby runs on port 8002 by default (which is what it's been running on this whole time anyway)

### DIFF
--- a/docs/backend/deployment.md
+++ b/docs/backend/deployment.md
@@ -19,7 +19,7 @@ sudo bash scripts/infra/setup-base.sh --deploy-user deploy   # Apache, Python, c
                                                              # shared secret + server.json
 sudo bash scripts/infra/setup-landing.sh --domain energetica-game.org   # apex vhost + TLS
 sudo bash scripts/infra/setup-lobby.sh --domain energetica-game.org     # lobby vhost+TLS+unit
-sudo bash scripts/infra/setup-instance.sh autumn-2025 8002 --domain energetica-game.org  # vhost+TLS+unit
+sudo bash scripts/infra/setup-instance.sh autumn-2025 8004 --domain energetica-game.org  # vhost+TLS+unit
 ```
 
 `setup-instance.sh` provisions the box (directory, venv, `/etc/energetica/{slug}/instance.json`,
@@ -27,7 +27,7 @@ vhost+TLS, enabled-but-unstarted unit) but ships **no** code and does **not** st
 service. The first deploy is what ships the backend and starts it. `setup-lobby.sh` works
 the same way for the lobby service.
 
-Every service needs its own uvicorn port: the lobby defaults to **8001** (`--port`
+Every service needs its own uvicorn port: the lobby defaults to **8002** (`--port`
 overrides), so give each instance a different one. `setup-lobby.sh` refuses a port
 already claimed by another `energetica-*` unit.
 

--- a/main_lobby.py
+++ b/main_lobby.py
@@ -6,7 +6,7 @@ separate from any game instance. In production the systemd unit ``energetica-lob
 ``ENERGETICA_APEX_DOMAIN``, the shared-secret path, the accounts-DB path and the landing dir, and
 Apache (``apache-lobby.conf``) proxies ``/api/v1`` and ``/logout`` to this process.
 
-    python main_lobby.py --port 8001
+    python main_lobby.py --port 8002
 """
 
 import argparse
@@ -18,7 +18,7 @@ from lobby import create_lobby_app
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the Energetica lobby service.")
     parser.add_argument("--host", default="127.0.0.1", help="Interface to bind (default: 127.0.0.1)")
-    parser.add_argument("--port", type=int, default=8001, help="Port to listen on (default: 8001)")
+    parser.add_argument("--port", type=int, default=8002, help="Port to listen on (default: 8002)")
     args = parser.parse_args()
 
     uvicorn.run(create_lobby_app(), host=args.host, port=args.port)

--- a/scripts/infra/setup-lobby.sh
+++ b/scripts/infra/setup-lobby.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # per VPS, as root, AFTER setup-base.sh and setup-landing.sh.
 #
 #   sudo bash scripts/infra/setup-lobby.sh --domain <apex-domain> \
-#        [--port 8001] [--deploy-user <user>] [--yes]
+#        [--port 8002] [--deploy-user <user>] [--yes]
 #
 # Creates the lobby dir + venv, the Apache vhost (lobby.{apex}) + TLS, and the
 # energetica-lobby.service unit (enabled, NOT started). Like setup-instance.sh it ships
@@ -18,7 +18,7 @@ set -euo pipefail
 
 DOMAIN="${ENERGETICA_DOMAIN:-}"
 DEPLOY_USER="${DEPLOY_USER:-deploy}"
-PORT=8001
+PORT=8002
 AUTO_CONFIRM=false
 APP_DIR=/var/www/energetica-lobby
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
         --port) PORT="$2"; shift 2 ;;
         --deploy-user) DEPLOY_USER="$2"; shift 2 ;;
         --yes) AUTO_CONFIRM=true; shift ;;
-        *) echo "Unknown option: $1"; echo "Usage: sudo bash setup-lobby.sh --domain <apex-domain> [--port 8001] [--deploy-user <user>] [--yes]"; exit 1 ;;
+        *) echo "Unknown option: $1"; echo "Usage: sudo bash setup-lobby.sh --domain <apex-domain> [--port 8002] [--deploy-user <user>] [--yes]"; exit 1 ;;
     esac
 done
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the production lobby’s default port from 8001 to 8002 and keeps the deployment instructions consistent.
- Changes the lobby CLI and provisioning-script defaults to port 8002.
- Moves the documented game-instance example to port 8004 to avoid a collision.
- Updates command examples and usage text.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the production service and proxy configuration remaining aligned on the new default.

The provisioning script renders the same selected port into the lobby’s systemd unit and Apache proxy, the documented instance uses a distinct port, and existing local launchers explicitly retain their local port configuration.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| main_lobby.py | Changes the standalone CLI default and example to port 8002; repository launchers continue to pass their intended ports explicitly. |
| scripts/infra/setup-lobby.sh | Changes the provisioned lobby default to 8002 while consistently rendering that value into both systemd and Apache configuration. |
| docs/backend/deployment.md | Documents the new lobby default and assigns the example game instance a distinct port. |

<sub>Reviews (1): Last reviewed commit: ["hotfix: update scripts and docs so that ..."](https://github.com/felixvonsamson/energetica/commit/e49c0eebed9a5353d74538dc4ece966302b85fbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58450999)</sub>

<!-- /greptile_comment -->