### PR TITLE
hotfix: permissions issue for moderators for configuring instances

### DIFF
--- a/scripts/infra/setup-instance.sh
+++ b/scripts/infra/setup-instance.sh
@@ -163,7 +163,11 @@ fi
 
 # --- 3. Admin-owned instance.json ----------------------------------------------
 log_section "INSTANCE CONFIG"
-install -d -o root -g energetica -m 0750 "$CONFIG_DIR"
+# 0770: the running service (group energetica) needs to *write* here too — a private
+# instance's facilitator surface persists join tokens/allowlist changes back to
+# instance.json via energetica/instance_config.py's atomic write (mkstemp + rename into
+# this directory), not just read it. See #1019.
+install -d -o root -g energetica -m 0770 "$CONFIG_DIR"
 if [ -f "$CONFIG_DIR/instance.json" ]; then
     log_success "$CONFIG_DIR/instance.json already exists — leaving admin's copy untouched"
 else
@@ -174,8 +178,9 @@ else
         -e "s/@ENDED_AT@/$ENDED_AT_JSON/g" \
         "$SCRIPT_DIR/instance.json.tmpl" > "$CONFIG_DIR/instance.json"
     chown root:energetica "$CONFIG_DIR/instance.json"
-    # 0640: service (group) reads; only root (admin, via sudo) edits. Edit later for a
-    # private/unadvertised instance — changes take effect on the instance's next login.
+    # 0640: service (group) reads; only root (admin, via sudo) edits by hand. The service
+    # itself writes back through instance_config.py's atomic write path (private-access
+    # mutations only), which re-asserts 0640 on every write — see _atomic_write_json.
     chmod 0640 "$CONFIG_DIR/instance.json"
     log_success "Rendered $CONFIG_DIR/instance.json (public, advertised=$ADVERTISED)"
 fi


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix changes newly provisioned instance configuration directories from mode 0750 to 0770 so the game service can atomically persist facilitator access settings.
- Grants the shared energetica group write permission on each instance configuration directory.
- Documents why atomic replacement requires directory write access and retains mode 0640 for `instance.json`.
- Does not migrate the permissions of existing instances through the normal deployment path.

<h3>Confidence Score: 4/5</h3>

This needs a migration or deployment-time permission repair before merging because existing affected instances will continue returning errors for facilitator access updates.

The new mode enables atomic configuration writes only when setup-instance.sh runs, while ordinary deployments leave existing root-owned 0750 configuration directories unchanged.

**Files Needing Attention:** scripts/infra/setup-instance.sh

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/infra/setup-instance.sh | Corrects permissions during provisioning, but leaves existing deployed instances at the old mode unless setup is explicitly rerun. |

<sub>Reviews (1): Last reviewed commit: ["hotfix: permissions issue for moderators..."](https://github.com/felixvonsamson/energetica/commit/80260b860b62a8d3261cbef6d44b29230932c5e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59118913)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Deployment and environment operations](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/deployment-and-environment-operations.md)

<!-- /greptile_comment -->