### PR TITLE
hotfix(lobby): proxy /healthz through the lobby Apache vhost

### DIFF
--- a/docs/architecture/lobby.md
+++ b/docs/architecture/lobby.md
@@ -118,6 +118,7 @@ lobby.energetica-game.org
 ├── /api/auth/*    → ProxyPass → uvicorn (lobby)
 ├── /api/lobby/*   → ProxyPass → uvicorn (lobby)   (my-runs)
 ├── /logout        → ProxyPass → uvicorn (lobby)
+├── /healthz       → ProxyPass → uvicorn (lobby)   (version/status; see docs/backend/deployment.md)
 ├── /instances.json → Alias → the shared landing dir  (the picker's manifest)
 ├── /recaps/*.json → Alias → the shared landing dir  (published recaps)
 ├── /static/*      → Apache serves the lobby bundle

--- a/scripts/deploy-lobby.sh
+++ b/scripts/deploy-lobby.sh
@@ -169,7 +169,9 @@ fi
 log_success "Service is running"
 
 # --- 8. Health check ------------------------------------------------------------------
-# The lobby exposes no /healthz, so four probes cover the chain:
+# /healthz exists (and is now proxied — see apache-lobby.conf) but only reports the
+# already-stamped commit, not whether the just-deployed code is actually serving
+# correctly, so four probes cover that chain instead:
 #   - SPA shell 200 → Apache serves the bundle;
 #   - unauthenticated my-runs 401 → vhost → proxy → uvicorn wiring is up;
 #   - login with a nonexistent user → 401 USER_NOT_FOUND proves the accounts.db READ

--- a/scripts/infra/apache-lobby.conf
+++ b/scripts/infra/apache-lobby.conf
@@ -128,10 +128,16 @@
     # The lobby has no Socket.IO and no bare /logout route (logout is POST under /api).
     ProxyPass        /api http://127.0.0.1:@PORT@/api
     ProxyPassReverse /api http://127.0.0.1:@PORT@/api
+    # /healthz is mounted at the uvicorn root (no /api/v1 prefix), so it needs its own rule —
+    # same reasoning as apache-instance.conf. Without it, the SPA fallback below answers with
+    # index.html (200) instead of the real health/version JSON.
+    ProxyPass        /healthz http://127.0.0.1:@PORT@/healthz
+    ProxyPassReverse /healthz http://127.0.0.1:@PORT@/healthz
 
     # --- SPA routing --------------------------------------------------------------
     # /login, /signup and the picker (/) are client-side routes; real files (assets,
-    # the aliased instances.json) and the proxied /api are matched before the fallback.
+    # the aliased instances.json) and the proxied /api + /healthz are matched before the
+    # fallback.
     FallbackResource /index.html
 
     ErrorLog ${APACHE_LOG_DIR}/energetica-lobby-error.log


### PR DESCRIPTION
## Problem

`scripts/infra/apache-lobby.conf` proxied only `/api` to the lobby's uvicorn process. `/healthz` is mounted at the uvicorn root (no `/api/v1` prefix), so a public request to `lobby.{apex}/healthz` fell through Apache's SPA `FallbackResource` and got back `index.html` (200) instead of health/version JSON.

`apache-instance.conf` already has the equivalent rule for exactly this reason (see its comment: *"/healthz is mounted at the uvicorn root ... so it needs its own rule"*) — the lobby vhost was just missing it. This is also why `docs/backend/deployment.md`'s claim that "the lobby now serves `/healthz` too" and `scripts/deployed-versions.sh` didn't actually work against the lobby in production.

Found while checking whether the deployed lobby matched `main` — it did not (6 commits behind, including the port-collision hotfix), and confirming that required SSHing in and curling uvicorn directly, since the public endpoint was silently returning the SPA shell.

## Fix

- `scripts/infra/apache-lobby.conf`: add `ProxyPass`/`ProxyPassReverse /healthz`, mirroring the instance vhost.
- `docs/architecture/lobby.md`: add `/healthz` to the request-routing diagram.
- `scripts/deploy-lobby.sh`: fix a stale comment claiming the lobby has no `/healthz` (its four-probe health check is otherwise unchanged — `/healthz` only reports the stamped commit, not whether the just-deployed code is serving correctly).

## Deployed

- Ran `./scripts/deploy-lobby.sh` to bring the live lobby up to `main` (`c38e1d7b`, clean).
- Manually re-rendered `/etc/apache2/sites-available/energetica-lobby.conf` on the server from the fixed template (backed up the old file first), `apache2ctl configtest` passed, reloaded Apache.
- Verified: `curl https://lobby.energetica-game.org/healthz` now returns real JSON; SPA/`my-runs`/`instances.json` all still 200/401/200 as before; `scripts/deployed-versions.sh` now reports the lobby row as `up-to-date` instead of failing to parse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a lobby Apache proxy rule so public `/healthz` requests reach uvicorn, updates the routing documentation, and corrects the deployment health-check commentary.
- Mirrors the instance vhost’s root-level `/healthz` proxy configuration.
- Documents `/healthz` in the lobby request-routing diagram.
- Clarifies why the lobby deployment still uses its existing four functional probes.

<h3>Confidence Score: 4/5</h3>

The proxy rule itself is correct, but the hotfix should not be merged as complete until existing lobby installations have a documented or automated way to install the changed vhost and reload Apache.

The normal lobby deployment updates application artifacts and restarts uvicorn but never applies the changed Apache template, leaving the original public `/healthz` failure intact on existing installations.

**Files Needing Attention:** scripts/infra/apache-lobby.conf, scripts/deploy-lobby.sh

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/infra/apache-lobby.conf | Adds the correct backend route, but the provisioning-only template change is not propagated by the normal deployment workflow. |
| scripts/deploy-lobby.sh | Corrects a stale comment but leaves existing vhosts unchanged when deploying this hotfix. |
| docs/architecture/lobby.md | Accurately adds the public `/healthz` route to the lobby routing diagram. |

<sub>Reviews (1): Last reviewed commit: ["hotfix(lobby): proxy /healthz through th..."](https://github.com/felixvonsamson/energetica/commit/3666cbdf0062cdf650d61e3dd2eb537c74665d97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59448287)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->