### PR TITLE
Improvement pass on the join page for token link

### DIFF
--- a/energetica/routers/join.py
+++ b/energetica/routers/join.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from energetica import accounts, instance_config
 from energetica.accounts import Account
 from energetica.game_error import GameError, GameExceptionType
-from energetica.schemas.join import JoinLinkOut
+from energetica.schemas.join import JoinLinkOut, Viewer
 from energetica.utils.auth import get_current_account
 from energetica.utils.misc import record_join_reconciling_settlement
 
@@ -51,11 +51,18 @@ def _resolve(token: str) -> tuple[str, instance_config.PrivateAccess]:
 def get_join_link(token: str, account: Annotated[Account | None, Depends(get_current_account)]) -> JoinLinkOut:
     """What this join link offers, and whether the visitor already has a session to join with."""
     instance_name, access = _resolve(token)
-    return JoinLinkOut(
-        instance_name=instance_name,
-        join_open=access.join_open,
-        viewer_username=account.username if account is not None else None,
-    )
+    viewer = None
+    if account is not None:
+        slug = instance_config.instance_slug()
+        assert slug is not None  # _resolve() only succeeds for a slug-configured, privately-set-up instance
+        if accounts.is_facilitator(account_id=account.account_id, slug=slug):
+            membership = "facilitator"
+        elif accounts.has_joined(account_id=account.account_id, slug=slug):
+            membership = "player"
+        else:
+            membership = None
+        viewer = Viewer(username=account.username, membership=membership)
+    return JoinLinkOut(instance_name=instance_name, join_open=access.join_open, viewer=viewer)
 
 
 @router.post("/{token}", status_code=204)

--- a/energetica/schemas/join.py
+++ b/energetica/schemas/join.py
@@ -2,18 +2,32 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
+class Viewer(BaseModel):
+    """The signed-in visitor's identity and standing relative to this instance."""
+
+    username: str
+    membership: Literal["player", "facilitator"] | None = Field(
+        description="'player' if the visitor is already a member, 'facilitator' if they hold a "
+        "facilitator/moderator grant covering this instance (and so can't also join it as a player, "
+        "per ADR-0004), or `null` if they haven't joined yet."
+    )
+
+
 class JoinLinkOut(BaseModel):
-    """What a join link resolves to — enough for the confirmation screen, and nothing that
-    requires the visitor to already be admitted onto this instance.
+    """
+    What a join link resolves to.
+
+    Contains all the information needed for the confirmation screen.
     """
 
     instance_name: str = Field(description="This instance's display name, for the 'Join <name>?' prompt.")
     join_open: bool = Field(description="Whether the join link currently admits new accounts.")
-    viewer_username: str | None = Field(
-        description="The visitor's username if they already have a valid SSO session, else null "
-        "— null means the frontend must send them through login/signup before showing the "
-        "confirmation screen."
+    viewer: Viewer | None = Field(
+        description="The visitor's identity and membership state, or `null` if they don't have a valid "
+        "SSO session yet — `null` means they must first log in/sign up before joining."
     )

--- a/frontend/src/routes/app/join/$token.tsx
+++ b/frontend/src/routes/app/join/$token.tsx
@@ -1,21 +1,23 @@
 /**
  * Public join flow (#1021): link → confirm → enter.
  *
- * The visitor-facing counterpart to #1020's facilitator page. Reachable by
- * anyone holding the link — `staticData.routeConfig` is `{ requiredRole: null
- * }` so `__root.tsx`'s guard leaves it alone regardless of auth state, which
- * matters here: a visitor mid-join has a valid SSO session but isn't
- * access-allowed yet, a state `fetchCurrentUser` deliberately reads as
- * "unauthenticated" (see `contexts/auth-context.tsx`) — this page renders its
- * own state off `useJoinLink` instead of `useAuth()`.
+ * The visitor-facing counterpart to #1020's facilitator page. Anyone with the
+ * link (with the token) can access this page. anyone holding the link —
+ * `staticData.routeConfig` is `{ requiredRole: null }` so `__root.tsx`'s guard
+ * leaves it alone regardless of auth state, which matters here: a visitor
+ * mid-join has a valid SSO session but isn't access-allowed yet, a state
+ * `fetchCurrentUser` deliberately reads as "unauthenticated" (see
+ * `contexts/auth-context.tsx`) — this page renders its own state off
+ * `useJoinLink` instead of `useAuth()`.
  *
  * Doesn't use `GameLayout`/`AppSidebar` (same reasoning as the facilitator page
  * — no settled player to render chrome around) or `GameLayout`'s sibling admin
- * shell (no "Log out" affordance makes sense for someone who may not even have
- * an account yet).
+ * shell. `JoinHeader` shows "Signed in as X" + a "Log out" link only once the
+ * visitor has a session (`viewer` is non-null) — before that, no identity
+ * exists yet to log out of.
  */
 
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import Logo from "@/assets/simplified_logo.svg?react";
@@ -34,6 +36,9 @@ import { useConfirmJoin, useJoinLink } from "@/hooks/use-join";
 import { getUserFriendlyError } from "@/lib/error-utils";
 import { lobbyLoginHref } from "@/lib/instances";
 import { rememberPendingJoinToken } from "@/lib/join";
+import type { ApiSchema } from "@/types/api-helpers";
+
+type Viewer = ApiSchema<"Viewer">;
 
 function JoinHelp() {
     return (
@@ -54,22 +59,40 @@ export const Route = createFileRoute("/app/join/$token")({
     },
 });
 
-function JoinHeader() {
+function JoinHeader({ viewer }: { viewer?: Viewer | null }) {
     return (
         <header className="shrink-0 flex h-(--topbar-height) items-center justify-between border-b border-border-brand bg-topbar px-4">
             <div className="flex items-center gap-1.5">
                 <Logo className="size-10 fill-foreground" />
                 <span className="font-titles text-lg">Energetica</span>
             </div>
-            <ThemeToggle variant="icon-only" />
+            <div className="flex items-center gap-3">
+                {viewer && (
+                    <>
+                        <span className="text-sm text-muted-foreground">
+                            Signed in as{" "}
+                            <span className="font-medium text-foreground">
+                                {viewer.username}
+                            </span>
+                        </span>
+                        <Button variant="outline" size="sm" asChild>
+                            <Link to="/app/logout">Log out</Link>
+                        </Button>
+                    </>
+                )}
+                <ThemeToggle variant="icon-only" />
+            </div>
         </header>
     );
 }
 
 function JoinPage() {
+    const { token } = Route.useParams();
+    const { data } = useJoinLink(token);
+
     return (
         <div className="flex min-h-svh flex-col">
-            <JoinHeader />
+            <JoinHeader viewer={data?.viewer} />
             <main className="flex-1 overflow-auto p-4 md:p-8">
                 <div className="max-w-xl mx-auto">
                     <JoinCard />
@@ -108,10 +131,18 @@ function JoinCard() {
         );
     }
 
-    if (data.viewer_username === null) {
+    if (data.viewer === null) {
         return (
             <LogInToJoinCard instanceName={data.instance_name} token={token} />
         );
+    }
+
+    if (data.viewer.membership === "facilitator") {
+        return <AlreadyFacilitatorCard instanceName={data.instance_name} />;
+    }
+
+    if (data.viewer.membership === "player") {
+        return <AlreadyMemberCard instanceName={data.instance_name} />;
     }
 
     return <ConfirmJoinCard instanceName={data.instance_name} token={token} />;
@@ -182,8 +213,7 @@ function ConfirmJoinCard({
                     <TypographyH2>Join {instanceName}?</TypographyH2>
                 </CardTitle>
                 <TypographyMuted>
-                    You're signed in. Confirming adds your account to this
-                    instance so you can play.
+                    Join this instance to start playing.
                 </TypographyMuted>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -200,6 +230,51 @@ function ConfirmJoinCard({
                 >
                     {(isPending || isSuccess) && <Spinner />}
                     Join {instanceName}
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}
+
+function AlreadyMemberCard({ instanceName }: { instanceName: string }) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>
+                    <TypographyH2>
+                        You're already in {instanceName}
+                    </TypographyH2>
+                </CardTitle>
+                <TypographyMuted>
+                    You have already joined this instance.
+                </TypographyMuted>
+            </CardHeader>
+            <CardContent>
+                <Button asChild className="w-full" size="lg">
+                    <Link to="/app">Go to instance</Link>
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}
+
+function AlreadyFacilitatorCard({ instanceName }: { instanceName: string }) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>
+                    <TypographyH2>Join link for {instanceName}</TypographyH2>
+                </CardTitle>
+                <TypographyMuted>
+                    The join link for this instance is currently enabled. Share
+                    this page's URL to players so they can join this instance.
+                </TypographyMuted>
+            </CardHeader>
+            <CardContent>
+                <Button asChild className="w-full" size="lg">
+                    <Link to="/app/facilitator">
+                        Back to moderator dashboard
+                    </Link>
                 </Button>
             </CardContent>
         </Card>

--- a/frontend/src/routes/app/join/$token.tsx
+++ b/frontend/src/routes/app/join/$token.tsx
@@ -122,6 +122,16 @@ function JoinCard() {
         );
     }
 
+    // Show show facilitators and players who have already joined the same thing
+    // irrespective of if the join link is still active or not
+    if (data.viewer?.membership === "facilitator") {
+        return <AlreadyFacilitatorCard instanceName={data.instance_name} />;
+    }
+
+    if (data.viewer?.membership === "player") {
+        return <AlreadyMemberCard instanceName={data.instance_name} />;
+    }
+
     if (!data.join_open) {
         return (
             <InfoBanner variant="warning">
@@ -135,14 +145,6 @@ function JoinCard() {
         return (
             <LogInToJoinCard instanceName={data.instance_name} token={token} />
         );
-    }
-
-    if (data.viewer.membership === "facilitator") {
-        return <AlreadyFacilitatorCard instanceName={data.instance_name} />;
-    }
-
-    if (data.viewer.membership === "player") {
-        return <AlreadyMemberCard instanceName={data.instance_name} />;
     }
 
     return <ConfirmJoinCard instanceName={data.instance_name} token={token} />;

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -2855,8 +2855,9 @@ export interface components {
         HydroFacilityType: "watermill" | "small_water_dam" | "large_water_dam";
         /**
          * JoinLinkOut
-         * @description What a join link resolves to — enough for the confirmation screen, and nothing that
-         *     requires the visitor to already be admitted onto this instance.
+         * @description What a join link resolves to.
+         *
+         *     Contains all the information needed for the confirmation screen.
          */
         JoinLinkOut: {
             /**
@@ -2869,11 +2870,8 @@ export interface components {
              * @description Whether the join link currently admits new accounts.
              */
             join_open: boolean;
-            /**
-             * Viewer Username
-             * @description The visitor's username if they already have a valid SSO session, else null — null means the frontend must send them through login/signup before showing the confirmation screen.
-             */
-            viewer_username: string | null;
+            /** @description The visitor's identity and membership state, or `null` if they don't have a valid SSO session yet — `null` means they must first log in/sign up before joining. */
+            viewer: components["schemas"]["Viewer"] | null;
         };
         /** LeaderboardsOut */
         LeaderboardsOut: {
@@ -4444,6 +4442,19 @@ export interface components {
         VapidPublicKey: {
             /** Public Key */
             public_key: string;
+        };
+        /**
+         * Viewer
+         * @description The signed-in visitor's identity and standing relative to this instance.
+         */
+        Viewer: {
+            /** Username */
+            username: string;
+            /**
+             * Membership
+             * @description 'player' if the visitor is already a member, 'facilitator' if they hold a facilitator/moderator grant covering this instance (and so can't also join it as a player, per ADR-0004), or `null` if they haven't joined yet.
+             */
+            membership: ("player" | "facilitator") | null;
         };
         /** WeatherOut */
         WeatherOut: {

--- a/tests/integration/test_join_router.py
+++ b/tests/integration/test_join_router.py
@@ -117,7 +117,7 @@ def test_get_with_a_valid_token_reports_the_instance_name_and_open_state(instanc
     body = response.json()
     assert body["instance_name"] == "ETHZ Spring 2026"
     assert body["join_open"] is True
-    assert body["viewer_username"] is None
+    assert body["viewer"] is None
 
 
 def test_get_reports_join_open_false(instance_json: Path) -> None:
@@ -131,7 +131,7 @@ def test_get_reports_join_open_false(instance_json: Path) -> None:
     assert response.json()["join_open"] is False
 
 
-def test_get_reports_the_viewer_username_for_a_signed_in_visitor_with_no_player(instance_json: Path) -> None:
+def test_get_reports_the_viewer_for_a_signed_in_visitor_with_no_player(instance_json: Path) -> None:
     """The crux of #1021: a visitor with a valid SSO session but no Player yet (not
     access-allowed, so they've never settled) must still be identified here.
     """
@@ -144,10 +144,38 @@ def test_get_reports_the_viewer_username_for_a_signed_in_visitor_with_no_player(
     response = client.get(_join_url(TOKEN))
 
     assert response.status_code == 200
-    assert response.json()["viewer_username"] == "carol"
+    assert response.json()["viewer"] == {"username": "carol", "membership": None}
     # Merely resolving the link must not itself grant or create anything.
     assert next(Player.filter_by(account_id=account_id), None) is None
     assert "carol" not in _joined_usernames()
+
+
+def test_get_reports_player_membership_for_a_visitor_who_already_joined(instance_json: Path) -> None:
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+    account_id = make_account("carol", "pw")
+    accounts.record_join(account_id=account_id, slug=SLUG, joined_at="2026-01-01T00:00:00Z")
+    authenticate(client, account_id)
+
+    response = client.get(_join_url(TOKEN))
+
+    assert response.status_code == 200
+    assert response.json()["viewer"] == {"username": "carol", "membership": "player"}
+
+
+def test_get_reports_facilitator_membership_for_a_visitor_who_administers_this_run(
+    instance_json: Path,
+) -> None:
+    _write(instance_json, PRIVATE_JSON)
+    client = _client()
+    account_id = make_account("carol", "pw")
+    accounts.grant_facilitator(account_id=account_id, slug=SLUG)
+    authenticate(client, account_id)
+
+    response = client.get(_join_url(TOKEN))
+
+    assert response.status_code == 200
+    assert response.json()["viewer"] == {"username": "carol", "membership": "facilitator"}
 
 
 # --- POST: confirming -----------------------------------------------------------------------


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enriches join-link responses with the signed-in viewer's instance membership and adds tailored join-page states and navigation for players and facilitators.
- Replaces `viewer_username` with a structured `viewer` API object.
- Derives player or facilitator membership for the resolved instance.
- Adds signed-in identity and logout controls to the join header.
- Adds terminal cards for accounts that already joined or administer the instance.
- Extends integration coverage for each membership response.

<h3>Confidence Score: 4/5</h3>

The membership-aware API is consistent, but the join page should be fixed so closed admission does not strand existing players and facilitators on the closed-state card.

The membership branches are placed after an unconditional closed-admission return, making the new navigation unavailable for authenticated accounts that already have instance access whenever joining is disabled.

**Files Needing Attention:** frontend/src/routes/app/join/$token.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| energetica/routers/join.py | Extends join-link resolution with viewer identity and membership derived using the same instance-scoped predicates as existing access checks. |
| energetica/schemas/join.py | Replaces the nullable username field with a structured viewer schema and constrained membership values. |
| frontend/src/routes/app/join/$token.tsx | Adds identity and membership-specific UI, but the earlier join-open return prevents existing members and facilitators from reaching their navigation cards when admission is closed. |
| frontend/src/types/api.generated.ts | Updates the generated frontend contract consistently with the backend Viewer and JoinLinkOut schemas. |
| tests/integration/test_join_router.py | Updates the response assertions and covers unaffiliated, player, and facilitator viewer states. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Link[Open token link] --> Resolve[Resolve join link and viewer]
  Resolve --> Open{join_open?}
  Open -->|No| Closed[Show joining closed]
  Open -->|Yes| Session{Signed in?}
  Session -->|No| Login[Log in or sign up]
  Session -->|Yes| Membership{Membership}
  Membership -->|Player| Player[Go to instance]
  Membership -->|Facilitator| Facilitator[Go to moderator dashboard]
  Membership -->|None| Confirm[Confirm joining]
```

<sub>Reviews (1): Last reviewed commit: ["Improvement pass on the join page for to..."](https://github.com/felixvonsamson/energetica/commit/2336b6854834f5acab93bc28a36fb04f11cb5ea8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59659998)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Quality and contract validation](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/quality-and-contract-validation.md)

<!-- /greptile_comment -->