### PR TITLE
Add scripts/shift_start_date.py to pause an instance over a break

### DIFF
--- a/docs/backend/incident-recovery.md
+++ b/docs/backend/incident-recovery.md
@@ -100,3 +100,16 @@ Persistence runs at two cadences (see `utils/tick_execution.py`):
 - **`save_checkpoint()` — every 6 hours.** Writes `checkpoints/last_checkpoint.tar.gz`, a tarball of the entire `instance/` directory (including a fresh `engine_data.pck` and all data files) at a consistent point in time. This is the unit of disaster recovery.
 
 Check `ls -la checkpoints/` to see the current checkpoint's age. Because the checkpoint is only every 6 h, recovery relies on replaying the actions log forward from the checkpoint tick — which is why the log must never be truncated below a tick you might need to restore from (see `docs/adr/0001-action-log-stays-complete-fix-oom-on-read.md`).
+
+## Pausing an instance without simulating downtime
+
+There's no built-in pause/resume: `announced → active → freeze → ended` is one-directional, and `freeze` mints the recap rather than allowing a resumable pause. If an instance needs to stop for a real-world break (e.g. a holiday) and resume afterwards without simulating that gap as elapsed game time, shift the persisted epoch forward by the downtime instead (issue #1024):
+
+```bash
+cd /var/www/energetica-{slug}
+sudo systemctl stop energetica-{slug}
+sudo -u energetica .venv/bin/python scripts/shift_start_date.py --pickle instance/engine_data.pck --days <N>
+sudo systemctl start energetica-{slug}
+```
+
+`<N>` is the real downtime in whole days (or any other whole multiple of the instance's `clock_time` — every supported `clock_time` divides a day evenly, so whole days are always safe). The script refuses to run against an instance it can still see running, backs up the pickle before writing, and prints the old/new `start_date`; pass `--dry-run` first to check the math. Editing `start_date` in the instance's config file does **not** work here — it's read only by `init_instance()`, never by `engine.load()`, which is the path a restart of an already-running instance always takes.

--- a/scripts/shift_start_date.py
+++ b/scripts/shift_start_date.py
@@ -7,10 +7,7 @@ tick, the scheduler computes how many ticks *should* have run by now as
 ``(time.time() - engine.start_date.timestamp()) / engine.clock_time``. If an instance is simply
 stopped and restarted after a break (holiday, maintenance window, ...) with nothing else changed,
 it sees the full real-world gap since ``start_date`` and rapid-fires every missed tick to catch
-up — i.e. it simulates the whole break. Editing ``start_date`` in the instance's *config* file
-does not help: config's ``start_date`` is only ever read by ``init_instance()``, which runs once
-for a brand-new instance. An instance already in progress always restores ``start_date`` straight
-from the pickle on restart (``GameEngine.load()``), ignoring the config entirely.
+up — i.e. it simulates the whole break.
 
 This script shifts the persisted ``start_date`` forward (or back) by a whole number of days, so
 the instance resumes as if no time had passed — no catch-up burst. Shifting by a whole day (or
@@ -43,6 +40,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import pickle
 import shutil
 import sys
@@ -157,8 +155,13 @@ def main() -> int:
         shutil.copy2(args.pickle, backup_path)
         print(f"Backed up original pickle to {backup_path}")
 
-    with args.pickle.open("wb") as f:
+    # Write to a temp sibling and atomically replace the live pickle, rather than truncating it
+    # in place: if the process is interrupted or hits an I/O error mid-dump, the original file
+    # must stay intact instead of being left half-written and unreadable on next startup.
+    tmp_path = args.pickle.with_name(f"{args.pickle.name}.tmp-{os.getpid()}")
+    with tmp_path.open("wb") as f:
         pickle.dump(engine_state, f)
+    tmp_path.replace(args.pickle)
     print(f"Saved {args.pickle}")
     return 0
 

--- a/scripts/shift_start_date.py
+++ b/scripts/shift_start_date.py
@@ -9,11 +9,15 @@ stopped and restarted after a break (holiday, maintenance window, ...) with noth
 it sees the full real-world gap since ``start_date`` and rapid-fires every missed tick to catch
 up — i.e. it simulates the whole break.
 
-This script shifts the persisted ``start_date`` forward (or back) by a whole number of days, so
-the instance resumes as if no time had passed — no catch-up burst. Shifting by a whole day (or
-any other multiple of the instance's ``clock_time``) keeps tick alignment intact — in particular
-the daily-quiz trigger (``utils/tick_execution.py``, ``% 86400 == 9*3600``), which depends on
-``start_date`` landing on the same second-of-day it did before the shift.
+This script shifts the persisted ``start_date`` forward (or back), so the instance resumes as if
+no time had passed — no catch-up burst. The shift can be given as a whole number of days
+(``--days``) or as a whole number of ticks (``--ticks``, each ``clock_time`` seconds long); either
+way, it must be a whole multiple of the instance's ``clock_time`` to keep tick alignment intact —
+in particular the daily-quiz trigger (``utils/tick_execution.py``, ``% 86400 == 9*3600``), which
+depends on ``start_date`` landing on the same second-of-day it did before the shift. A ``--days``
+shift always satisfies that for every ``clock_time`` game_engine.py actually allows (they all
+divide 86400 evenly); ``--ticks`` satisfies it by construction, and additionally lets the shift
+match a real-world gap exactly instead of rounding to a whole day.
 
 Only affects tick catch-up pacing, nothing else — see issue #1024 for the full trace of every
 ``total_t``/wall-clock consumer. All gameplay state is keyed off simulated ticks, not
@@ -31,10 +35,12 @@ override.
 
 Usage:
     python scripts/shift_start_date.py --pickle instance/engine_data.pck --days <N> [--dry-run]
+    python scripts/shift_start_date.py --pickle instance/engine_data.pck --ticks <N> [--dry-run]
 
-    N is the number of whole days to shift start_date forward; pass a negative number to shift
-    it back. A backup of the pickle (``<pickle>.bak-<timestamp>``) is written before overwriting
-    it, unless --no-backup is passed.
+    Pass exactly one of --days or --ticks: N is the number of whole days, or of clock_time-second
+    ticks, to shift start_date forward; pass a negative number to shift it back. A backup of the
+    pickle (``<pickle>.bak-<timestamp>``) is written before overwriting it, unless --no-backup is
+    passed.
 """
 
 from __future__ import annotations
@@ -78,23 +84,35 @@ def find_running_instance_pid(working_dir: Path, *, proc_root: Path = Path("/pro
     return None
 
 
-def shift_start_date(engine_state: dict[str, Any], days: int) -> tuple[datetime, datetime]:
-    """Shift ``engine_state["start_date"]`` by ``days`` whole days, in place.
+def shift_start_date(
+    engine_state: dict[str, Any], *, days: int | None = None, ticks: int | None = None
+) -> tuple[datetime, datetime]:
+    """Shift ``engine_state["start_date"]`` by a whole number of days or ticks, in place.
 
-    Returns (old_start_date, new_start_date). Raises ValueError if ``days`` is zero, or if the
-    resulting shift isn't a whole multiple of this instance's clock_time — that would desync the
-    daily-quiz trigger's tick alignment (see module docstring).
+    Exactly one of ``days`` or ``ticks`` must be given (a tick is ``clock_time`` seconds).
+    Returns (old_start_date, new_start_date). Raises ValueError if the shift amount is zero, if
+    neither or both of ``days``/``ticks`` were given, or if the resulting shift isn't a whole
+    multiple of this instance's clock_time — that would desync the daily-quiz trigger's tick
+    alignment (see module docstring). A ``ticks`` shift can't fail that last check — it's already
+    expressed in units of clock_time.
     """
-    if days == 0:
-        raise ValueError("--days must be nonzero")
+    if (days is None) == (ticks is None):
+        raise ValueError("specify exactly one of days or ticks")
     clock_time = engine_state["clock_time"]
-    shift = timedelta(days=days)
-    shift_seconds = shift.total_seconds()
-    if shift_seconds % clock_time != 0:
-        raise ValueError(
-            f"a {days}-day shift ({shift_seconds:.0f}s) is not a whole multiple of this "
-            f"instance's clock_time ({clock_time}s) — would desync tick alignment"
-        )
+    if days is not None:
+        if days == 0:
+            raise ValueError("--days must be nonzero")
+        shift = timedelta(days=days)
+        shift_seconds = shift.total_seconds()
+        if shift_seconds % clock_time != 0:
+            raise ValueError(
+                f"a {days}-day shift ({shift_seconds:.0f}s) is not a whole multiple of this "
+                f"instance's clock_time ({clock_time}s) — would desync tick alignment"
+            )
+    else:
+        if ticks == 0:
+            raise ValueError("--ticks must be nonzero")
+        shift = timedelta(seconds=ticks * clock_time)
     old_start_date = engine_state["start_date"]
     new_start_date = old_start_date + shift
     engine_state["start_date"] = new_start_date
@@ -104,8 +122,15 @@ def shift_start_date(engine_state: dict[str, Any], days: int) -> tuple[datetime,
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--pickle", required=True, type=Path, help="Path to engine_data.pck")
-    parser.add_argument(
-        "--days", required=True, type=int, help="Whole days to shift start_date forward (negative to shift back)."
+    shift_group = parser.add_mutually_exclusive_group(required=True)
+    shift_group.add_argument(
+        "--days", type=int, help="Whole days to shift start_date forward (negative to shift back)."
+    )
+    shift_group.add_argument(
+        "--ticks",
+        type=int,
+        help="Whole ticks (clock_time seconds each) to shift start_date forward (negative to shift "
+        "back). Use this instead of --days to match a real-world gap exactly.",
     )
     parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing.")
     parser.add_argument(
@@ -139,12 +164,13 @@ def main() -> int:
         engine_state = pickle.load(f)
 
     try:
-        old_start_date, new_start_date = shift_start_date(engine_state, args.days)
+        old_start_date, new_start_date = shift_start_date(engine_state, days=args.days, ticks=args.ticks)
     except ValueError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         return 1
 
-    print(f"start_date: {old_start_date.isoformat()} -> {new_start_date.isoformat()} ({args.days:+d} day(s))")
+    amount = f"{args.days:+d} day(s)" if args.days is not None else f"{args.ticks:+d} tick(s)"
+    print(f"start_date: {old_start_date.isoformat()} -> {new_start_date.isoformat()} ({amount})")
 
     if args.dry_run:
         print("DRY RUN: no changes written.")

--- a/scripts/shift_start_date.py
+++ b/scripts/shift_start_date.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Shift a stopped instance's simulated epoch so a real-world gap isn't simulated as elapsed
+game time (issue #1024).
+
+The sim's "epoch" is ``engine.start_date``, persisted in ``instance/engine_data.pck``. Every
+tick, the scheduler computes how many ticks *should* have run by now as
+``(time.time() - engine.start_date.timestamp()) / engine.clock_time``. If an instance is simply
+stopped and restarted after a break (holiday, maintenance window, ...) with nothing else changed,
+it sees the full real-world gap since ``start_date`` and rapid-fires every missed tick to catch
+up — i.e. it simulates the whole break. Editing ``start_date`` in the instance's *config* file
+does not help: config's ``start_date`` is only ever read by ``init_instance()``, which runs once
+for a brand-new instance. An instance already in progress always restores ``start_date`` straight
+from the pickle on restart (``GameEngine.load()``), ignoring the config entirely.
+
+This script shifts the persisted ``start_date`` forward (or back) by a whole number of days, so
+the instance resumes as if no time had passed — no catch-up burst. Shifting by a whole day (or
+any other multiple of the instance's ``clock_time``) keeps tick alignment intact — in particular
+the daily-quiz trigger (``utils/tick_execution.py``, ``% 86400 == 9*3600``), which depends on
+``start_date`` landing on the same second-of-day it did before the shift.
+
+Only affects tick catch-up pacing, nothing else — see issue #1024 for the full trace of every
+``total_t``/wall-clock consumer. All gameplay state is keyed off simulated ticks, not
+``start_date``; wall-clock-anchored things (chat timestamps, account bookkeeping) are meant to
+keep advancing through the gap and are untouched by this edit.
+
+Run this only while the instance is fully stopped: ``engine.load()`` raises if any file under
+``instance/data/**`` looks newer than ``engine_data.pck``, and editing the pickle bumps its mtime
+(which is what we want — it must stay the newest file), but concurrent writes from a live
+``engine.save()`` could otherwise race this script's own read-modify-write. The script refuses to
+run if it finds a ``main.py`` process whose working directory matches the instance (best-effort:
+only works on Linux, and only when run as the same user as the service — e.g. via
+``sudo -u energetica``, matching ``docs/backend/incident-recovery.md``); pass ``--force`` to
+override.
+
+Usage:
+    python scripts/shift_start_date.py --pickle instance/engine_data.pck --days <N> [--dry-run]
+
+    N is the number of whole days to shift start_date forward; pass a negative number to shift
+    it back. A backup of the pickle (``<pickle>.bak-<timestamp>``) is written before overwriting
+    it, unless --no-backup is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+import shutil
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def find_running_instance_pid(working_dir: Path, *, proc_root: Path = Path("/proc")) -> int | None:
+    """Best-effort scan of /proc for a running ``main.py`` process whose cwd is ``working_dir``.
+
+    Returns the PID if one is found, else None. This is a safety net, not a guarantee: it
+    silently returns None if ``proc_root`` doesn't exist (non-Linux) or a process's /proc entries
+    aren't readable (different user) — callers should still treat "stop the service first" as
+    the real contract and offer --force for when the check can't see a process it should.
+    """
+    if not proc_root.is_dir():
+        return None
+    try:
+        working_dir = working_dir.resolve()
+    except OSError:
+        return None
+    for entry in proc_root.iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            cwd = (entry / "cwd").resolve()
+            if cwd != working_dir:
+                continue
+            cmdline = (entry / "cmdline").read_bytes()
+        except OSError:
+            continue
+        if b"main.py" in cmdline:
+            return int(entry.name)
+    return None
+
+
+def shift_start_date(engine_state: dict[str, Any], days: int) -> tuple[datetime, datetime]:
+    """Shift ``engine_state["start_date"]`` by ``days`` whole days, in place.
+
+    Returns (old_start_date, new_start_date). Raises ValueError if ``days`` is zero, or if the
+    resulting shift isn't a whole multiple of this instance's clock_time — that would desync the
+    daily-quiz trigger's tick alignment (see module docstring).
+    """
+    if days == 0:
+        raise ValueError("--days must be nonzero")
+    clock_time = engine_state["clock_time"]
+    shift = timedelta(days=days)
+    shift_seconds = shift.total_seconds()
+    if shift_seconds % clock_time != 0:
+        raise ValueError(
+            f"a {days}-day shift ({shift_seconds:.0f}s) is not a whole multiple of this "
+            f"instance's clock_time ({clock_time}s) — would desync tick alignment"
+        )
+    old_start_date = engine_state["start_date"]
+    new_start_date = old_start_date + shift
+    engine_state["start_date"] = new_start_date
+    return old_start_date, new_start_date
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--pickle", required=True, type=Path, help="Path to engine_data.pck")
+    parser.add_argument(
+        "--days", required=True, type=int, help="Whole days to shift start_date forward (negative to shift back)."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing.")
+    parser.add_argument(
+        "--force", action="store_true", help="Proceed even if the instance looks like it's still running."
+    )
+    parser.add_argument(
+        "--no-backup", action="store_true", help="Skip writing a .bak copy of the pickle before overwriting it."
+    )
+    args = parser.parse_args()
+
+    if not args.pickle.exists():
+        print(f"ERROR: pickle not found at {args.pickle}", file=sys.stderr)
+        return 1
+
+    # game_engine.py's save()/load() always use the path "instance/engine_data.pck" relative to
+    # the instance's working directory — walk back up from the pickle to that directory to look
+    # for a live process there.
+    working_dir = args.pickle.resolve().parent.parent
+    pid = find_running_instance_pid(working_dir)
+    if pid is not None and not args.force:
+        print(
+            f"ERROR: instance looks like it's still running (pid {pid}, cwd matches {working_dir}). "
+            "Stop the service first — editing the pickle while it's live races the next "
+            "engine.save() and can corrupt it. Pass --force if you're certain it's safe.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Loading pickle from {args.pickle}")
+    with args.pickle.open("rb") as f:
+        engine_state = pickle.load(f)
+
+    try:
+        old_start_date, new_start_date = shift_start_date(engine_state, args.days)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    print(f"start_date: {old_start_date.isoformat()} -> {new_start_date.isoformat()} ({args.days:+d} day(s))")
+
+    if args.dry_run:
+        print("DRY RUN: no changes written.")
+        return 0
+
+    if not args.no_backup:
+        backup_path = args.pickle.with_name(f"{args.pickle.name}.bak-{datetime.now():%Y%m%d%H%M%S}")
+        shutil.copy2(args.pickle, backup_path)
+        print(f"Backed up original pickle to {backup_path}")
+
+    with args.pickle.open("wb") as f:
+        pickle.dump(engine_state, f)
+    print(f"Saved {args.pickle}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_shift_start_date.py
+++ b/tests/unit/test_shift_start_date.py
@@ -39,7 +39,7 @@ def test_shift_start_date_moves_it_forward_by_whole_days() -> None:
     module = _load_script()
     engine_state = _engine_state(start_date=datetime(2026, 1, 1, tzinfo=timezone.utc))
 
-    old, new = module.shift_start_date(engine_state, 14)
+    old, new = module.shift_start_date(engine_state, days=14)
 
     assert old == datetime(2026, 1, 1, tzinfo=timezone.utc)
     assert new == datetime(2026, 1, 15, tzinfo=timezone.utc)
@@ -50,19 +50,19 @@ def test_shift_start_date_accepts_negative_days() -> None:
     module = _load_script()
     engine_state = _engine_state(start_date=datetime(2026, 1, 15, tzinfo=timezone.utc))
 
-    old, new = module.shift_start_date(engine_state, -14)
+    old, new = module.shift_start_date(engine_state, days=-14)
 
     assert old == datetime(2026, 1, 15, tzinfo=timezone.utc)
     assert new == datetime(2026, 1, 1, tzinfo=timezone.utc)
 
 
-def test_shift_start_date_rejects_a_zero_shift() -> None:
+def test_shift_start_date_rejects_a_zero_day_shift() -> None:
     module = _load_script()
     engine_state = _engine_state()
     original_start_date = engine_state["start_date"]
 
     with pytest.raises(ValueError, match="nonzero"):
-        module.shift_start_date(engine_state, 0)
+        module.shift_start_date(engine_state, days=0)
 
     assert engine_state["start_date"] == original_start_date  # untouched on rejection
 
@@ -75,7 +75,7 @@ def test_shift_start_date_rejects_a_shift_not_aligned_to_clock_time() -> None:
     engine_state = _engine_state(clock_time=7)
 
     with pytest.raises(ValueError, match="clock_time"):
-        module.shift_start_date(engine_state, 1)
+        module.shift_start_date(engine_state, days=1)
 
 
 @pytest.mark.parametrize("clock_time", [60, 30, 20, 15, 12, 10, 6, 5, 4, 3, 2, 1])
@@ -86,7 +86,68 @@ def test_shift_start_date_accepts_every_supported_clock_time(clock_time: int) ->
     module = _load_script()
     engine_state = _engine_state(clock_time=clock_time)
 
-    module.shift_start_date(engine_state, 3)  # must not raise
+    module.shift_start_date(engine_state, days=3)  # must not raise
+
+
+def test_shift_start_date_moves_it_forward_by_whole_ticks() -> None:
+    module = _load_script()
+    # A 1-day-10h15m real-world gap at clock_time=30 is exactly 4110 ticks — no whole day rounds
+    # to that, which is the whole point of offering --ticks.
+    engine_state = _engine_state(clock_time=30, start_date=datetime(2026, 1, 1, 8, 15, tzinfo=timezone.utc))
+
+    old, new = module.shift_start_date(engine_state, ticks=4110)
+
+    assert old == datetime(2026, 1, 1, 8, 15, tzinfo=timezone.utc)
+    assert new == datetime(2026, 1, 2, 18, 30, tzinfo=timezone.utc)
+    assert engine_state["start_date"] == new
+
+
+def test_shift_start_date_accepts_negative_ticks() -> None:
+    module = _load_script()
+    engine_state = _engine_state(clock_time=30, start_date=datetime(2026, 1, 2, 18, 30, tzinfo=timezone.utc))
+
+    old, new = module.shift_start_date(engine_state, ticks=-4110)
+
+    assert old == datetime(2026, 1, 2, 18, 30, tzinfo=timezone.utc)
+    assert new == datetime(2026, 1, 1, 8, 15, tzinfo=timezone.utc)
+
+
+def test_shift_start_date_rejects_a_zero_tick_shift() -> None:
+    module = _load_script()
+    engine_state = _engine_state()
+    original_start_date = engine_state["start_date"]
+
+    with pytest.raises(ValueError, match="nonzero"):
+        module.shift_start_date(engine_state, ticks=0)
+
+    assert engine_state["start_date"] == original_start_date  # untouched on rejection
+
+
+@pytest.mark.parametrize("clock_time", [7, 60, 30, 1])
+def test_shift_start_date_accepts_any_clock_time_for_a_tick_shift(clock_time: int) -> None:
+    """A ticks shift is expressed in units of clock_time already, so it can never fail the
+    alignment check that a days shift can — including for a clock_time --days would reject.
+    """
+    module = _load_script()
+    engine_state = _engine_state(clock_time=clock_time)
+
+    module.shift_start_date(engine_state, ticks=3)  # must not raise
+
+
+def test_shift_start_date_rejects_neither_days_nor_ticks() -> None:
+    module = _load_script()
+    engine_state = _engine_state()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        module.shift_start_date(engine_state)
+
+
+def test_shift_start_date_rejects_both_days_and_ticks() -> None:
+    module = _load_script()
+    engine_state = _engine_state()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        module.shift_start_date(engine_state, days=1, ticks=1)
 
 
 def test_find_running_instance_pid_returns_none_without_a_proc_dir(tmp_path: Path) -> None:

--- a/tests/unit/test_shift_start_date.py
+++ b/tests/unit/test_shift_start_date.py
@@ -1,0 +1,155 @@
+"""Unit tests for the start_date shift script (issue #1024).
+
+Covers the two pure-logic seams `main()` wires together: `shift_start_date` (the actual pickle
+field edit and its tick-alignment validation) and `find_running_instance_pid` (the best-effort
+"instance is still running" guard). Pickle I/O and CLI parsing live in `main()` and aren't
+exercised here, matching the other scripts/*.py tests in this suite.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "shift_start_date.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("shift_start_date", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _engine_state(*, clock_time: int = 30, start_date: datetime | None = None) -> dict:
+    return {
+        "clock_time": clock_time,
+        "start_date": start_date or datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "total_t": 1234,
+    }
+
+
+def test_shift_start_date_moves_it_forward_by_whole_days() -> None:
+    module = _load_script()
+    engine_state = _engine_state(start_date=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    old, new = module.shift_start_date(engine_state, 14)
+
+    assert old == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert new == datetime(2026, 1, 15, tzinfo=timezone.utc)
+    assert engine_state["start_date"] == new
+
+
+def test_shift_start_date_accepts_negative_days() -> None:
+    module = _load_script()
+    engine_state = _engine_state(start_date=datetime(2026, 1, 15, tzinfo=timezone.utc))
+
+    old, new = module.shift_start_date(engine_state, -14)
+
+    assert old == datetime(2026, 1, 15, tzinfo=timezone.utc)
+    assert new == datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def test_shift_start_date_rejects_a_zero_shift() -> None:
+    module = _load_script()
+    engine_state = _engine_state()
+    original_start_date = engine_state["start_date"]
+
+    with pytest.raises(ValueError, match="nonzero"):
+        module.shift_start_date(engine_state, 0)
+
+    assert engine_state["start_date"] == original_start_date  # untouched on rejection
+
+
+def test_shift_start_date_rejects_a_shift_not_aligned_to_clock_time() -> None:
+    module = _load_script()
+    # 7 doesn't divide 86400 evenly, so a whole-day shift wouldn't land back on the same
+    # second-of-day — this clock_time isn't one game_engine.py actually allows, but the
+    # validation is generic (keyed off the pickle's own clock_time, not a hardcoded list).
+    engine_state = _engine_state(clock_time=7)
+
+    with pytest.raises(ValueError, match="clock_time"):
+        module.shift_start_date(engine_state, 1)
+
+
+@pytest.mark.parametrize("clock_time", [60, 30, 20, 15, 12, 10, 6, 5, 4, 3, 2, 1])
+def test_shift_start_date_accepts_every_supported_clock_time(clock_time: int) -> None:
+    """Every clock_time game_engine.py's init_instance() allows divides 86400 evenly, so a
+    whole-day shift must always validate clean for all of them.
+    """
+    module = _load_script()
+    engine_state = _engine_state(clock_time=clock_time)
+
+    module.shift_start_date(engine_state, 3)  # must not raise
+
+
+def test_find_running_instance_pid_returns_none_without_a_proc_dir(tmp_path: Path) -> None:
+    module = _load_script()
+
+    pid = module.find_running_instance_pid(tmp_path, proc_root=tmp_path / "no-such-proc")
+
+    assert pid is None
+
+
+def _make_fake_proc(proc_root: Path, pid: int, cwd_target: Path, cmdline: bytes) -> None:
+    pid_dir = proc_root / str(pid)
+    pid_dir.mkdir(parents=True)
+    os.symlink(cwd_target, pid_dir / "cwd")
+    (pid_dir / "cmdline").write_bytes(cmdline)
+
+
+def test_find_running_instance_pid_finds_a_matching_main_py_process(tmp_path: Path) -> None:
+    module = _load_script()
+    working_dir = tmp_path / "var-www-energetica-zhaw"
+    working_dir.mkdir()
+    proc_root = tmp_path / "proc"
+    _make_fake_proc(proc_root, 4242, working_dir, b"/venv/bin/python\x00main.py\x00--env\x00prod\x00")
+
+    pid = module.find_running_instance_pid(working_dir, proc_root=proc_root)
+
+    assert pid == 4242
+
+
+def test_find_running_instance_pid_ignores_processes_with_a_different_cwd(tmp_path: Path) -> None:
+    module = _load_script()
+    working_dir = tmp_path / "target"
+    working_dir.mkdir()
+    other_dir = tmp_path / "unrelated"
+    other_dir.mkdir()
+    proc_root = tmp_path / "proc"
+    _make_fake_proc(proc_root, 111, other_dir, b"/venv/bin/python\x00main.py\x00")
+
+    pid = module.find_running_instance_pid(working_dir, proc_root=proc_root)
+
+    assert pid is None
+
+
+def test_find_running_instance_pid_ignores_non_main_py_processes_in_the_same_dir(tmp_path: Path) -> None:
+    module = _load_script()
+    working_dir = tmp_path / "target"
+    working_dir.mkdir()
+    proc_root = tmp_path / "proc"
+    _make_fake_proc(proc_root, 222, working_dir, b"/bin/bash\x00")
+
+    pid = module.find_running_instance_pid(working_dir, proc_root=proc_root)
+
+    assert pid is None
+
+
+def test_find_running_instance_pid_ignores_non_pid_entries(tmp_path: Path) -> None:
+    module = _load_script()
+    working_dir = tmp_path / "target"
+    working_dir.mkdir()
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    (proc_root / "self").mkdir()  # /proc has non-numeric entries too
+
+    pid = module.find_running_instance_pid(working_dir, proc_root=proc_root)
+
+    assert pid is None


### PR DESCRIPTION
Closes #1024.

Adds the script the issue's follow-up asked for (endorsed in the comment thread): shift the persisted `engine.start_date` in `instance/engine_data.pck` by a whole number of days, so a stopped-and-restarted instance doesn't rapid-fire every missed tick to catch up on real downtime (e.g. a holiday break). Editing the instance config's `start_date` doesn't work for this — it's only read by `init_instance()` on a brand-new instance, never by `engine.load()`, which is the path a restart of an already-running instance always takes.

**What it does**
- Validates the shift is nonzero and a whole multiple of the instance's `clock_time` — keeps the daily-quiz trigger's tick alignment intact (`% 86400 == 9*3600` in `tick_execution.py`).
- Refuses to run if it finds a live `main.py` process whose cwd matches the instance (best-effort `/proc` scan; `--force` to override).
- Backs up the pickle before writing (`<pickle>.bak-<timestamp>`), unless `--no-backup`.
- Supports `--dry-run` to check the math first.

**Testing**
- `tests/unit/test_shift_start_date.py` — 21 tests on the two pure-logic seams (`shift_start_date`, `find_running_instance_pid`), matching this repo's existing script-test convention (pickle I/O/CLI glue stays in `main()`, untested, per `test_migrate_drop_user.py`'s precedent).
- Full backend suite passes (362 tests).
- Manually smoke-tested end to end (dry-run, real run + backup, zero-days rejection, missing-pickle error) against a synthetic pickle.
- Ran through `/code-review`; the one finding (unused import in the test file) is fixed.

**Docs**
- `docs/backend/incident-recovery.md` gets a new "Pausing an instance without simulating downtime" section with the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an operator-facing script and runbook for moving a stopped instance's persisted simulation epoch across a real-world break.
- Validates whole-tick day shifts and offers dry-run and backup modes.
- Attempts to detect a live instance before modifying its engine pickle.
- Adds focused unit coverage for shift validation and process detection.

<h3>Confidence Score: 4/5</h3>

The live-pickle replacement should be made atomic before merging so an interrupted maintenance command cannot prevent the instance from restarting.

The script truncates the only pickle used by normal startup before the replacement serialization succeeds, and startup has no automatic fallback to the backup it creates.

**Files Needing Attention:** scripts/shift_start_date.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/shift_start_date.py | Adds the epoch-shifting CLI and safety checks, but writes the critical live pickle non-atomically. |
| tests/unit/test_shift_start_date.py | Covers shift validation and process detection thoroughly, while leaving the destructive write path untested. |
| docs/backend/incident-recovery.md | Documents the intended stop-shift-restart operational procedure and required service user. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Stop[Stop instance service] --> Guard[Check for matching live main.py]
  Guard --> Load[Load engine_data.pck]
  Load --> Shift[Shift persisted start_date]
  Shift --> Backup[Copy original to timestamped backup]
  Backup --> Write[Write modified live pickle]
  Write --> Start[Restart instance service]
  Write -. interruption or I/O failure .-> Partial[Partial live pickle]
  Partial --> Failure[Restart fails during pickle.load]
```

<sub>Reviews (1): Last reviewed commit: ["Add scripts/shift\_start\_date.py to pause..."](https://github.com/felixvonsamson/energetica/commit/245c244f0399ab4aea299867f77120be01492e2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59692612)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Game data and persistence](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/game-data-and-persistence.md)
- Knowledge Base — [Deployment and environment operations](https://app.greptile.com/energetica-org-2/-/custom-context/knowledge-base/felixvonsamson/energetica/-/docs/deployment-and-environment-operations.md)

<!-- /greptile_comment -->