### PR TITLE
fix(scripts): add repo root to sys.path in shift_start_date.py

### DIFF
--- a/scripts/shift_start_date.py
+++ b/scripts/shift_start_date.py
@@ -159,6 +159,13 @@ def main() -> int:
         )
         return 1
 
+    # This script lives in scripts/, not the repo root, so the interpreter's default sys.path
+    # (the script's own directory) never includes the repo root — `energetica` isn't installed
+    # into the venv as a package. Nothing here imports it directly, but the pickle's
+    # `db_model_instances` entry holds real `energetica.database.*` objects, so pickle.load()
+    # below needs the package importable to reconstruct them.
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
     print(f"Loading pickle from {args.pickle}")
     with args.pickle.open("rb") as f:
         engine_state = pickle.load(f)


### PR DESCRIPTION
## Problem

PR #1044 merged before this follow-up fix was pushed, so it landed on an orphan branch. Running `shift_start_date.py` as documented, from the instance's own working directory, fails:

```
ModuleNotFoundError: No module named 'energetica'
```

The pickle's `db_model_instances` entry holds real `energetica.database.*` objects, so `pickle.load()` needs the `energetica` package importable to reconstruct them — even though the script never imports it directly. `scripts/` isn't on `sys.path` by default (Python only adds the invoked script's own directory), so this fails wherever it's run from except the repo root itself.

## Fix

Add the repo root to `sys.path` before loading the pickle, matching the pattern already used in `whitelist-run.py`, `grant-facilitator.py`, and `generate_openapi_schema.py`.

Reproduced the failure (pickled dict containing an `energetica`-defined object, run from a different cwd) and confirmed the fix resolves it; existing unit tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the repository root to Python’s import path before loading an engine-state pickle, allowing pickle to reconstruct objects defined in the `energetica` package.
- Applies the same import-path pattern used by other repository scripts.
- Leaves the newly fixed deserialization path without automated regression coverage.

<h3>Confidence Score: 4/5</h3>

The change appears safe to merge, with a non-blocking gap in automated coverage for the import-path regression it fixes.

The path insertion correctly supports the documented invocation and follows existing repository conventions, but current tests do not exercise `main()` or prove that package-defined pickle objects deserialize successfully.

**Files Needing Attention:** scripts/shift_start_date.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/shift_start_date.py | Adds the repository root to `sys.path` before unpickling; the fix is consistent with related scripts but lacks a focused regression test. |

<sub>Reviews (1): Last reviewed commit: ["fix(scripts): add repo root to sys.path ..."](https://github.com/felixvonsamson/energetica/commit/844eb78156f4a8876ad9818027c8d71f4fd75459) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60780449)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->